### PR TITLE
Add expiry sweep refunds for bounty escrow

### DIFF
--- a/EVENT_SCHEMA.md
+++ b/EVENT_SCHEMA.md
@@ -347,6 +347,49 @@ pub struct FundsRefunded {
 
 ---
 
+### 5.4a `BountyExpired`
+
+**Emitted by:** `emit_bounty_expired()`
+**Topics:** `(symbol_short!("expired"), event.bounty_id)`
+**Struct:** `BountyExpired`
+**Lifecycle phase:** Bounty deadline expiry / sweep refund
+
+```rust
+#[contracttype]
+pub struct BountyExpired {
+    pub version:   u32,
+    pub bounty_id: u64,
+    pub amount:    i128,
+    pub depositor: Address,
+    pub deadline:  u64,
+    pub timestamp: u64,
+}
+```
+
+#### v2 Payload Example
+
+```json
+{
+  "version":   2,
+  "bounty_id": 42,
+  "amount":    1000000000,
+  "depositor": "GABC…",
+  "deadline":  1740199000,
+  "timestamp": 1740200000
+}
+```
+
+| Field       | Rust type | v1 required | v2 required | Description |
+|-------------|-----------|-------------|-------------|-------------|
+| `version`   | `u32`     | No          | **Yes**     | Always `2` |
+| `bounty_id` | `u64`     | **Yes**     | **Yes**     | Bounty identifier; also in topic[1] |
+| `amount`    | `i128`    | **Yes**     | **Yes**     | Remaining amount swept back to the depositor |
+| `depositor` | `Address` | **Yes**     | **Yes**     | Original depositor receiving the expiry refund |
+| `deadline`  | `u64`     | **Yes**     | **Yes**     | Bounty deadline that made the refund sweep eligible |
+| `timestamp` | `u64`     | **Yes**     | **Yes**     | Ledger timestamp at sweep/refund |
+
+---
+
 ### 5.5 `FeeCollected`
 
 **Emitted by:** `emit_fee_collected()`

--- a/EVENT_VERSIONING.md
+++ b/EVENT_VERSIONING.md
@@ -17,4 +17,4 @@ For event consumers in this repository:
 - Backward compatibility: SDK parsing tests cover legacy/unversioned payloads.
 - Forward compatibility: SDK parsing tests cover newer version tags with additive fields.
 - Contract emission correctness: contract tests assert emitted payloads include `version: 2` tags on current emitters.
-
+- Expiry lifecycle additions such as `BountyExpired` are additive v2 payloads and must keep `bounty_id`, `amount`, `depositor`, `deadline`, and `timestamp` stable for indexers.

--- a/bounty_escrow/contracts/escrow/src/events.rs
+++ b/bounty_escrow/contracts/escrow/src/events.rs
@@ -62,6 +62,22 @@ pub fn emit_funds_refunded(env: &Env, event: FundsRefunded) {
 }
 
 #[contracttype]
+#[derive(Clone, Debug)]
+pub struct BountyExpired {
+    pub version: u32,
+    pub bounty_id: u64,
+    pub amount: i128,
+    pub depositor: Address,
+    pub deadline: u64,
+    pub timestamp: u64,
+}
+
+pub fn emit_bounty_expired(env: &Env, event: BountyExpired) {
+    let topics = (symbol_short!("expired"), event.bounty_id);
+    env.events().publish(topics, event.clone());
+}
+
+#[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum FeeOperationType {
     Lock,

--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -8,10 +8,10 @@ mod error_recovery;
 mod test_rbac;
 
 use events::{
-    emit_batch_funds_locked, emit_batch_funds_released, emit_bounty_initialized, emit_funds_locked,
-    emit_funds_refunded, emit_funds_released, BatchFundsLocked, BatchFundsReleased,
-    BountyEscrowInitialized, ClaimCancelled, ClaimCreated, ClaimExecuted, FundsLocked,
-    FundsRefunded, FundsReleased, EVENT_VERSION_V2,
+    emit_batch_funds_locked, emit_batch_funds_released, emit_bounty_expired,
+    emit_bounty_initialized, emit_funds_locked, emit_funds_refunded, emit_funds_released,
+    BatchFundsLocked, BatchFundsReleased, BountyEscrowInitialized, BountyExpired, ClaimCancelled,
+    ClaimCreated, ClaimExecuted, FundsLocked, FundsRefunded, FundsReleased, EVENT_VERSION_V2,
 };
 use analytics::{
     emit_analytics_snapshot, emit_bounty_activity, emit_bounty_state_transitioned,
@@ -1717,6 +1717,171 @@ impl BountyEscrowContract {
         Ok(())
     }
 
+    /// Sweep a bounded batch of expired bounties and refund remaining balances.
+    ///
+    /// This path is intentionally stricter than `refund`: it only processes
+    /// bounties whose deadline has passed and always refunds the original
+    /// depositor. Administrative refund approvals are ignored for recipient
+    /// selection because the sweep is an expiry lifecycle helper.
+    pub fn sweep_expired_refunds(env: Env, bounty_ids: Vec<u64>) -> Result<u32, Error> {
+        if Self::check_paused(&env, symbol_short!("refund")) {
+            return Err(Error::FundsPaused);
+        }
+
+        if let Err(_) = check_and_allow(&env) {
+            return Err(Error::CircuitBreakerOpen);
+        }
+
+        let batch_size = bounty_ids.len() as u32;
+        if batch_size == 0 || batch_size > MAX_BATCH_SIZE {
+            return Err(Error::InvalidBatchSize);
+        }
+
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::NotInitialized);
+        }
+
+        let now = env.ledger().timestamp();
+        for bounty_id in bounty_ids.iter() {
+            if !env.storage().persistent().has(&DataKey::Escrow(bounty_id)) {
+                return Err(Error::BountyNotFound);
+            }
+
+            let escrow: Escrow = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Escrow(bounty_id))
+                .unwrap();
+
+            if escrow.status != EscrowStatus::Locked
+                && escrow.status != EscrowStatus::PartiallyRefunded
+            {
+                return Err(Error::FundsNotLocked);
+            }
+
+            if escrow.remaining_amount <= 0 {
+                return Err(Error::InvalidAmount);
+            }
+
+            if now < escrow.deadline {
+                return Err(Error::DeadlineNotPassed);
+            }
+
+            if env
+                .storage()
+                .persistent()
+                .has(&DataKey::PendingClaim(bounty_id))
+            {
+                return Err(Error::RefundNotApproved);
+            }
+
+            let mut duplicates = 0u32;
+            for other_id in bounty_ids.iter() {
+                if other_id == bounty_id {
+                    duplicates += 1;
+                }
+            }
+            if duplicates > 1 {
+                return Err(Error::DuplicateBountyId);
+            }
+        }
+
+        if env.storage().instance().has(&DataKey::ReentrancyGuard) {
+            panic!("Reentrancy detected");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyGuard, &true);
+
+        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let client = token::Client::new(&env, &token_addr);
+        let contract_address = env.current_contract_address();
+        let mut swept = 0u32;
+
+        for bounty_id in bounty_ids.iter() {
+            let mut escrow: Escrow = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Escrow(bounty_id))
+                .unwrap();
+            let refund_amount = escrow.remaining_amount;
+            let refund_to = escrow.depositor.clone();
+            let previous_state = if escrow.status == EscrowStatus::PartiallyRefunded {
+                symbol_short!("partial_r")
+            } else {
+                symbol_short!("locked")
+            };
+
+            client.transfer(&contract_address, &refund_to, &refund_amount);
+
+            escrow.remaining_amount = 0;
+            escrow.status = EscrowStatus::Refunded;
+            escrow.refund_history.push_back(RefundRecord {
+                amount: refund_amount,
+                recipient: refund_to.clone(),
+                timestamp: now,
+                mode: RefundMode::Full,
+            });
+            env.storage()
+                .persistent()
+                .set(&DataKey::Escrow(bounty_id), &escrow);
+            env.storage()
+                .persistent()
+                .remove(&DataKey::RefundApproval(bounty_id));
+
+            update_analytics_on_refund(&env, bounty_id, refund_amount, now);
+            emit_bounty_state_transitioned(
+                &env,
+                BountyStateTransitioned {
+                    version: analytics::ANALYTICS_VERSION_V1,
+                    bounty_id,
+                    previous_state,
+                    new_state: symbol_short!("refunded"),
+                    amount: refund_amount,
+                    actor: refund_to.clone(),
+                    timestamp: now,
+                },
+            );
+            emit_bounty_activity(
+                &env,
+                BountyActivityEvent {
+                    version: analytics::ANALYTICS_VERSION_V1,
+                    bounty_id,
+                    activity_type: symbol_short!("refunded"),
+                    amount: refund_amount,
+                    timestamp: now,
+                },
+            );
+            emit_bounty_expired(
+                &env,
+                BountyExpired {
+                    version: EVENT_VERSION_V2,
+                    bounty_id,
+                    amount: refund_amount,
+                    depositor: refund_to.clone(),
+                    deadline: escrow.deadline,
+                    timestamp: now,
+                },
+            );
+            emit_funds_refunded(
+                &env,
+                FundsRefunded {
+                    version: EVENT_VERSION_V2,
+                    bounty_id,
+                    amount: refund_amount,
+                    refund_to,
+                    timestamp: now,
+                },
+            );
+
+            swept += 1;
+        }
+
+        env.storage().instance().remove(&DataKey::ReentrancyGuard);
+
+        Ok(swept)
+    }
+
     /// view function to get escrow info
     pub fn get_escrow_info(env: Env, bounty_id: u64) -> Result<Escrow, Error> {
         if !env.storage().persistent().has(&DataKey::Escrow(bounty_id)) {
@@ -2946,14 +3111,12 @@ impl BountyEscrowContract {
     // ==================== END CIRCUIT BREAKER ADMIN CONTROLS ====================
 }
 
-
 #[cfg(test)]
 mod test;
 #[cfg(test)]
 mod test_analytics_monitoring;
 #[cfg(test)]
 mod test_auto_refund_permissions;
-#[cfg(test)]
 mod test_bounty_escrow;
 #[cfg(test)]
 mod test_dispute_resolution;

--- a/bounty_escrow/contracts/escrow/src/test_expiration_and_dispute.rs
+++ b/bounty_escrow/contracts/escrow/src/test_expiration_and_dispute.rs
@@ -1,9 +1,11 @@
 #![cfg(test)]
 
-use crate::{BountyEscrowContract, BountyEscrowContractClient, EscrowStatus};
+use crate::{
+    BountyEscrowContract, BountyEscrowContractClient, Error as ContractError, EscrowStatus,
+};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
-    token, Address, Env,
+    token, vec, Address, Env,
 };
 
 fn create_token_contract<'a>(
@@ -404,4 +406,110 @@ fn test_claim_cancellation_restores_refund_eligibility() {
     setup.escrow.refund(&bounty_id);
 
     assert_eq!(setup.token.balance(&setup.depositor), 10_000_000);
+}
+
+#[test]
+fn test_sweep_expired_refunds_refunds_batch_to_depositors() {
+    let setup = TestSetup::new();
+    let now = setup.env.ledger().timestamp();
+    let first_deadline = now + 100;
+    let second_deadline = now + 200;
+
+    setup
+        .escrow
+        .lock_funds(&setup.depositor, &101, &1000, &first_deadline);
+    setup
+        .escrow
+        .lock_funds(&setup.depositor, &102, &2500, &second_deadline);
+
+    setup.env.ledger().set_timestamp(second_deadline + 1);
+
+    let swept = setup
+        .escrow
+        .sweep_expired_refunds(&vec![&setup.env, 101, 102]);
+
+    assert_eq!(swept, 2);
+    assert_eq!(
+        setup.escrow.get_escrow_info(&101).status,
+        EscrowStatus::Refunded
+    );
+    assert_eq!(
+        setup.escrow.get_escrow_info(&102).status,
+        EscrowStatus::Refunded
+    );
+    assert_eq!(setup.token.balance(&setup.depositor), 10_000_000);
+    assert_eq!(setup.token.balance(&setup.escrow.address), 0);
+}
+
+#[test]
+fn test_sweep_expired_refunds_rejects_active_bounty_before_transfer() {
+    let setup = TestSetup::new();
+    let now = setup.env.ledger().timestamp();
+
+    setup
+        .escrow
+        .lock_funds(&setup.depositor, &201, &1000, &(now + 100));
+    setup
+        .escrow
+        .lock_funds(&setup.depositor, &202, &2000, &(now + 1000));
+
+    setup.env.ledger().set_timestamp(now + 200);
+
+    let result = setup
+        .escrow
+        .try_sweep_expired_refunds(&vec![&setup.env, 201, 202]);
+
+    assert_eq!(result, Err(Ok(ContractError::DeadlineNotPassed)));
+    assert_eq!(
+        setup.escrow.get_escrow_info(&201).status,
+        EscrowStatus::Locked
+    );
+    assert_eq!(
+        setup.escrow.get_escrow_info(&202).status,
+        EscrowStatus::Locked
+    );
+    assert_eq!(setup.token.balance(&setup.escrow.address), 3000);
+}
+
+#[test]
+fn test_sweep_expired_refunds_rejects_duplicate_bounty_ids() {
+    let setup = TestSetup::new();
+    let deadline = setup.env.ledger().timestamp() + 100;
+
+    setup
+        .escrow
+        .lock_funds(&setup.depositor, &301, &1000, &deadline);
+    setup.env.ledger().set_timestamp(deadline + 1);
+
+    let result = setup
+        .escrow
+        .try_sweep_expired_refunds(&vec![&setup.env, 301, 301]);
+
+    assert_eq!(result, Err(Ok(ContractError::DuplicateBountyId)));
+    assert_eq!(
+        setup.escrow.get_escrow_info(&301).status,
+        EscrowStatus::Locked
+    );
+}
+
+#[test]
+fn test_sweep_expired_refunds_honors_refund_pause() {
+    let setup = TestSetup::new();
+    let deadline = setup.env.ledger().timestamp() + 100;
+
+    setup
+        .escrow
+        .lock_funds(&setup.depositor, &401, &1000, &deadline);
+    setup.env.ledger().set_timestamp(deadline + 1);
+    setup.escrow.set_paused(&None, &None, &Some(true));
+
+    let result = setup
+        .escrow
+        .try_sweep_expired_refunds(&vec![&setup.env, 401]);
+
+    assert_eq!(result, Err(Ok(ContractError::FundsPaused)));
+    assert_eq!(
+        setup.escrow.get_escrow_info(&401).status,
+        EscrowStatus::Locked
+    );
 }


### PR DESCRIPTION
## Summary
- Add a v2 `BountyExpired` event and document its schema for expiry lifecycle indexing.
- Add `sweep_expired_refunds(env, bounty_ids)` for bounded batch refunds of expired locked or partially refunded bounties.
- Keep the sweep gated by refund pause, circuit breaker, duplicate-id checks, pending-claim checks, and a reentrancy guard.
- Emit per-bounty `BountyExpired` and existing `FundsRefunded` events, and cover success and rejection paths in expiration/dispute tests.

Closes #59.

## Validation
- `git diff --check`
- `git ls-files | grep -E '\.(d|wasm)$' && exit 1 || true`
- `cargo test -p bounty-escrow test_expiration_and_dispute` — 13 passed
- `cargo test -p bounty-escrow` — 298 passed
