### PR TITLE
fix(sdk): complete bounty escrow error map

### DIFF
--- a/sdk/ERROR_MAPPING.md
+++ b/sdk/ERROR_MAPPING.md
@@ -84,6 +84,9 @@ Source: `contracts/bounty_escrow/contracts/escrow/src/lib.rs`
 | 16 | `BOUNTY_INSUFFICIENT_FUNDS` | InsufficientFunds | Insufficient funds in the escrow for this operation |
 | 17 | `BOUNTY_REFUND_NOT_APPROVED` | RefundNotApproved | Refund has not been approved by an admin |
 | 18 | `BOUNTY_FUNDS_PAUSED` | FundsPaused | Bounty fund operations are currently paused |
+| 19 | `BOUNTY_AMOUNT_BELOW_MINIMUM` | AmountBelowMinimum | Bounty lock amount is below the configured policy minimum |
+| 20 | `BOUNTY_AMOUNT_ABOVE_MAXIMUM` | AmountAboveMaximum | Bounty lock amount is above the configured policy maximum |
+| 21 | `BOUNTY_CIRCUIT_BREAKER_OPEN` | CircuitBreakerOpen | Bounty escrow circuit breaker is open |
 
 ### Governance Contract
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -214,6 +214,11 @@ try {
 - `LENGTH_MISMATCH` - Recipients and amounts arrays must match
 - `OVERFLOW` - Payout amount overflow
 
+Bounty-escrow errors are also mapped by their on-chain numeric codes, including
+the intentional gap at code 15 and the policy/circuit errors at codes 19-21:
+`BOUNTY_AMOUNT_BELOW_MINIMUM`, `BOUNTY_AMOUNT_ABOVE_MAXIMUM`, and
+`BOUNTY_CIRCUIT_BREAKER_OPEN`. See `ERROR_MAPPING.md` for the full table.
+
 ## Testing
 
 Run the test suite:

--- a/sdk/src/__tests__/error-mapping.test.ts
+++ b/sdk/src/__tests__/error-mapping.test.ts
@@ -24,7 +24,7 @@ import {
 
 /** contracts/bounty_escrow/contracts/escrow/src/lib.rs — Error enum */
 const BOUNTY_ESCROW_DISCRIMINANTS: number[] = [
-  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, /* gap at 15 */ 16, 17, 18,
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, /* gap at 15 */ 16, 17, 18, 19, 20, 21,
 ];
 
 /** contracts/grainlify-core/src/governance.rs — Error enum */
@@ -71,7 +71,7 @@ describe('Error mapping completeness', () => {
 // =======================================================================
 describe('Numeric error code tables', () => {
   describe('Bounty-escrow', () => {
-    it('maps every contract discriminant (1-18, excluding 15)', () => {
+    it('maps every contract discriminant (1-21, excluding 15)', () => {
       for (const code of BOUNTY_ESCROW_DISCRIMINANTS) {
         expect(BOUNTY_ESCROW_ERROR_MAP[code]).toBeDefined();
       }
@@ -185,6 +185,9 @@ describe('parseContractError string matching', () => {
     ['InsufficientFunds',                              ContractErrorCode.BOUNTY_INSUFFICIENT_FUNDS],
     ['RefundNotApproved',                              ContractErrorCode.BOUNTY_REFUND_NOT_APPROVED],
     ['FundsPaused',                                    ContractErrorCode.BOUNTY_FUNDS_PAUSED],
+    ['Bounty amount below minimum',                    ContractErrorCode.BOUNTY_AMOUNT_BELOW_MINIMUM],
+    ['Bounty amount above maximum',                    ContractErrorCode.BOUNTY_AMOUNT_ABOVE_MAXIMUM],
+    ['BountyCircuitBreakerOpen',                       ContractErrorCode.BOUNTY_CIRCUIT_BREAKER_OPEN],
   ];
 
   it.each(bountyEscrowCases)(
@@ -267,6 +270,9 @@ describe('Cross-layer consistency', () => {
       [4,  'Bounty not found'],
       [13, 'Bounty amount is invalid'],
       [16, 'InsufficientFunds'],
+      [19, 'Bounty amount below minimum'],
+      [20, 'Bounty amount above maximum'],
+      [21, 'BountyCircuitBreakerOpen'],
     ];
 
     for (const [code, message] of numericToString) {
@@ -298,12 +304,12 @@ describe('Cross-layer consistency', () => {
 describe('Enum size regression guards', () => {
   it('ContractErrorCode has the expected number of values', () => {
     const count = Object.keys(ContractErrorCode).length;
-    // 10 program-escrow + 17 bounty-escrow + 14 governance + 3 circuit-breaker = 44
-    expect(count).toBe(44);
+    // 10 program-escrow + 20 bounty-escrow + 14 governance + 3 circuit-breaker = 47
+    expect(count).toBe(47);
   });
 
-  it('BOUNTY_ESCROW_ERROR_MAP has 17 entries', () => {
-    expect(Object.keys(BOUNTY_ESCROW_ERROR_MAP).length).toBe(17);
+  it('BOUNTY_ESCROW_ERROR_MAP has 20 entries', () => {
+    expect(Object.keys(BOUNTY_ESCROW_ERROR_MAP).length).toBe(20);
   });
 
   it('GOVERNANCE_ERROR_MAP has 14 entries', () => {

--- a/sdk/src/__tests__/smoke.test.ts
+++ b/sdk/src/__tests__/smoke.test.ts
@@ -54,7 +54,7 @@ describe('SDK Example Smoke Tests', () => {
         const result = await lockFundsExample(client, mockKeypair);
         expect(result).toBeDefined();
         //@ts-ignore - accessing private field
-        expect(client.invokeContract).toHaveBeenCalledWith('lock_program_funds', [10000000n], mockKeypair);
+        expect(client.invokeContract).toHaveBeenCalledWith('lock_program_funds', [mockKeypair.publicKey(), 10000000n], mockKeypair);
     });
 
     it('should run release-funds example successfully', async () => {

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -55,9 +55,9 @@ export class ValidationError extends SDKError {
  *   - Governance ..............................  GOV_*
  *   - Circuit-breaker / error-recovery .......  CIRCUIT_*
  *
- * AMOUNT_BELOW_MIN and AMOUNT_ABOVE_MAX map to the on-chain errors
- *   Error::AmountBelowMinimum = 8
- *   Error::AmountAboveMaximum = 9
+ * Program-level AMOUNT_BELOW_MIN / AMOUNT_ABOVE_MAX are kept for the
+ * program-escrow surface. Bounty-escrow uses its own BOUNTY_* variants for
+ * the contract discriminants at 19 and 20.
  */
 export enum ContractErrorCode {
   // ── Program-Escrow (original) ──────────────────────────────────────────
@@ -90,6 +90,9 @@ export enum ContractErrorCode {
   BOUNTY_INSUFFICIENT_FUNDS  = 'BOUNTY_INSUFFICIENT_FUNDS',    // 16
   BOUNTY_REFUND_NOT_APPROVED = 'BOUNTY_REFUND_NOT_APPROVED',   // 17
   BOUNTY_FUNDS_PAUSED        = 'BOUNTY_FUNDS_PAUSED',          // 18
+  BOUNTY_AMOUNT_BELOW_MINIMUM = 'BOUNTY_AMOUNT_BELOW_MINIMUM', // 19
+  BOUNTY_AMOUNT_ABOVE_MAXIMUM = 'BOUNTY_AMOUNT_ABOVE_MAXIMUM', // 20
+  BOUNTY_CIRCUIT_BREAKER_OPEN = 'BOUNTY_CIRCUIT_BREAKER_OPEN', // 21
 
   // ── Governance (contracts/grainlify-core/governance) ───────────────────
   GOV_NOT_INITIALIZED        = 'GOV_NOT_INITIALIZED',          // 1
@@ -148,6 +151,9 @@ const CONTRACT_ERROR_MESSAGES: Record<ContractErrorCode, string> = {
   [ContractErrorCode.BOUNTY_INSUFFICIENT_FUNDS]:  'Insufficient funds in the escrow for this operation',
   [ContractErrorCode.BOUNTY_REFUND_NOT_APPROVED]: 'Refund has not been approved by an admin',
   [ContractErrorCode.BOUNTY_FUNDS_PAUSED]:        'Bounty fund operations are currently paused',
+  [ContractErrorCode.BOUNTY_AMOUNT_BELOW_MINIMUM]: 'Bounty lock amount is below the configured policy minimum',
+  [ContractErrorCode.BOUNTY_AMOUNT_ABOVE_MAXIMUM]: 'Bounty lock amount is above the configured policy maximum',
+  [ContractErrorCode.BOUNTY_CIRCUIT_BREAKER_OPEN]: 'Bounty escrow circuit breaker is open',
 
   // Governance
   [ContractErrorCode.GOV_NOT_INITIALIZED]:        'Governance contract has not been initialized',
@@ -194,6 +200,9 @@ export const BOUNTY_ESCROW_ERROR_MAP: Record<number, ContractErrorCode> = {
   16: ContractErrorCode.BOUNTY_INSUFFICIENT_FUNDS,
   17: ContractErrorCode.BOUNTY_REFUND_NOT_APPROVED,
   18: ContractErrorCode.BOUNTY_FUNDS_PAUSED,
+  19: ContractErrorCode.BOUNTY_AMOUNT_BELOW_MINIMUM,
+  20: ContractErrorCode.BOUNTY_AMOUNT_ABOVE_MAXIMUM,
+  21: ContractErrorCode.BOUNTY_CIRCUIT_BREAKER_OPEN,
 };
 
 /** Governance #[contracterror] discriminants → SDK code */
@@ -274,6 +283,18 @@ export function parseContractErrorByCode(
  */
 export function parseContractError(error: any): ContractError {
   const errorMessage = error?.message || error?.toString() || 'Unknown contract error';
+
+  // ── Bounty-escrow specific policy/circuit patterns ─────────────────────
+  // These must run before the generic program-escrow min/max patterns below.
+  if (/BountyAmountBelowMinimum|bounty.*below.*min(imum)?/i.test(errorMessage)) {
+    return createContractError(ContractErrorCode.BOUNTY_AMOUNT_BELOW_MINIMUM);
+  }
+  if (/BountyAmountAboveMaximum|bounty.*(above|max|exceed).*max(imum)?/i.test(errorMessage)) {
+    return createContractError(ContractErrorCode.BOUNTY_AMOUNT_ABOVE_MAXIMUM);
+  }
+  if (/BountyCircuitBreakerOpen|bounty.*circuit breaker/i.test(errorMessage)) {
+    return createContractError(ContractErrorCode.BOUNTY_CIRCUIT_BREAKER_OPEN);
+  }
 
   // ── Program-escrow patterns ────────────────────────────────────────────
   if (errorMessage.includes('not initialized') || errorMessage.includes('Program not initialized')) {


### PR DESCRIPTION
## Summary
- Completes the SDK `BOUNTY_ESCROW_ERROR_MAP` for bounty escrow contract codes 19, 20, and 21.
- Adds bounty-specific `ContractErrorCode` values for `AmountBelowMinimum`, `AmountAboveMaximum`, and `CircuitBreakerOpen` so they do not collide with the program-escrow min/max codes.
- Updates error-mapping tests, SDK docs, and a stale smoke-test expectation for the current `lockProgramFunds` invocation shape.

## Issue
Addresses #55 by reconciling the SDK error map with the current on-chain `bounty_escrow` enum, including the intentional gap at code 15.

## Validation
- `npm test -- --runInBand` — 6 suites passed, 147 tests passed.
- `npm run build` — TypeScript compile passed.
- `git diff --check` — passed.

## Notes
This PR intentionally does not change the on-chain contract. The existing `BountyEscrowClient` is already present on `main`; this patch closes the remaining SDK error-code audit gap from #55.
