### PR TITLE
test(program-escrow): add balance reconciliation invariant

### DIFF
--- a/program-escrow/src/test_balance_invariant.rs
+++ b/program-escrow/src/test_balance_invariant.rs
@@ -2,12 +2,14 @@
 
 /// # Token-Balance Invariant Test Suite — Program Escrow
 ///
-/// Proves that `remaining_balance` (stored in `ProgramData`) never diverges
-/// from the real SAC token balance held by the contract across every payout
-/// and release lifecycle path:
+/// Proves that `remaining_balance` (stored in `ProgramData`) plus the schedule
+/// ledger never diverges from the real SAC token balance held by the contract
+/// across every payout and release lifecycle path:
 ///
 /// ```text
-/// token_client.balance(&contract_id)  ==  program_data.remaining_balance
+/// token_client.balance(&contract_id)
+///   == spendable_balance + pending_scheduled_amounts
+///   == program_data.remaining_balance
 /// ```
 ///
 /// ## Covered paths
@@ -19,7 +21,6 @@
 /// 5. `release_prog_schedule_automatic` — automatic single schedule release
 /// 6. Insufficient-balance rejection — invariant is untouched on panic
 /// 7. Top-up + mixed payouts — `lock_program_funds` top-up followed by mixed paths
-
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
@@ -39,7 +40,11 @@ fn make_client(env: &Env) -> (ProgramEscrowContractClient<'static>, Address) {
 fn make_token(
     env: &Env,
     admin: &Address,
-) -> (token::Client<'static>, token::StellarAssetClient<'static>, Address) {
+) -> (
+    token::Client<'static>,
+    token::StellarAssetClient<'static>,
+    Address,
+) {
     let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
     let token_id = token_contract.address();
     (
@@ -49,8 +54,23 @@ fn make_token(
     )
 }
 
-/// Core invariant check: SAC balance held by the contract must equal
-/// `remaining_balance` tracked inside `ProgramData`.
+/// Sum all unreleased scheduled amounts from the on-chain schedule ledger.
+fn pending_scheduled_total(client: &ProgramEscrowContractClient) -> i128 {
+    let schedules = client.get_program_release_schedules();
+    let mut total = 0_i128;
+    for i in 0..schedules.len() {
+        let schedule = schedules.get(i).unwrap();
+        if !schedule.released {
+            total += schedule.amount;
+        }
+    }
+    total
+}
+
+/// Core invariant check: SAC balance held by the contract must equal all
+/// accounted funds after every operation. `remaining_balance` is the contract's
+/// total accounted balance; splitting it into spendable and unreleased scheduled
+/// buckets makes schedule over-reservation fail loudly at the first operation.
 fn assert_balance_invariant(
     client: &ProgramEscrowContractClient,
     token_client: &token::Client,
@@ -59,13 +79,20 @@ fn assert_balance_invariant(
 ) {
     let sac = token_client.balance(contract_id);
     let remaining = client.get_remaining_balance();
-    assert_eq!(
-        sac,
-        remaining,
-        "[{}] INVARIANT VIOLATED — SAC balance ({}) ≠ remaining_balance ({})",
+    let pending_scheduled = pending_scheduled_total(client);
+    assert!(
+        remaining >= pending_scheduled,
+        "[{}] INVARIANT VIOLATED — pending schedules ({}) exceed remaining_balance ({})",
         label,
-        sac,
+        pending_scheduled,
         remaining,
+    );
+    let spendable = remaining - pending_scheduled;
+    let accounted = spendable + pending_scheduled;
+    assert_eq!(
+        sac, accounted,
+        "[{}] INVARIANT VIOLATED — SAC balance ({}) ≠ spendable ({}) + pending_scheduled ({})",
+        label, sac, spendable, pending_scheduled,
     );
 }
 
@@ -90,11 +117,19 @@ fn setup(
 
     token_sac.mint(&admin, &amount);
     client.init_program(&program_id, &admin, &token_id);
+    client.setadmin(&admin);
     if amount > 0 {
         client.lock_program_funds(&admin, &amount);
     }
 
-    (client, contract_id, admin, token_client, token_sac, token_id)
+    (
+        client,
+        contract_id,
+        admin,
+        token_client,
+        token_sac,
+        token_id,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -105,8 +140,7 @@ fn setup(
 fn test_invariant_sequential_single_payouts() {
     let env = Env::default();
     let total: i128 = 9_000;
-    let (client, contract_id, _admin, token_client, _token_sac, _token_id) =
-        setup(&env, total);
+    let (client, contract_id, _admin, token_client, _token_sac, _token_id) = setup(&env, total);
 
     assert_balance_invariant(&client, &token_client, &contract_id, "initial");
 
@@ -123,7 +157,12 @@ fn test_invariant_sequential_single_payouts() {
     assert_eq!(client.get_remaining_balance(), 3_500);
 
     client.single_payout(&w3, &3_500);
-    assert_balance_invariant(&client, &token_client, &contract_id, "after payout 3 (drain)");
+    assert_balance_invariant(
+        &client,
+        &token_client,
+        &contract_id,
+        "after payout 3 (drain)",
+    );
     assert_eq!(client.get_remaining_balance(), 0);
     assert_eq!(token_client.balance(&contract_id), 0);
 }
@@ -136,8 +175,7 @@ fn test_invariant_sequential_single_payouts() {
 fn test_invariant_batch_payout() {
     let env = Env::default();
     let total: i128 = 12_000;
-    let (client, contract_id, _admin, token_client, _token_sac, _token_id) =
-        setup(&env, total);
+    let (client, contract_id, _admin, token_client, _token_sac, _token_id) = setup(&env, total);
 
     assert_balance_invariant(&client, &token_client, &contract_id, "initial");
 
@@ -162,8 +200,7 @@ fn test_invariant_batch_payout() {
 fn test_invariant_trigger_program_releases() {
     let env = Env::default();
     let total: i128 = 6_000;
-    let (client, contract_id, admin, token_client, _token_sac, _token_id) =
-        setup(&env, total);
+    let (client, contract_id, _admin, token_client, _token_sac, _token_id) = setup(&env, total);
 
     assert_balance_invariant(&client, &token_client, &contract_id, "initial");
 
@@ -204,8 +241,7 @@ fn test_invariant_trigger_program_releases() {
 fn test_invariant_release_program_schedule_manual() {
     let env = Env::default();
     let total: i128 = 8_000;
-    let (client, contract_id, _admin, token_client, _token_sac, _token_id) =
-        setup(&env, total);
+    let (client, contract_id, _admin, token_client, _token_sac, _token_id) = setup(&env, total);
 
     assert_balance_invariant(&client, &token_client, &contract_id, "initial");
 
@@ -216,7 +252,12 @@ fn test_invariant_release_program_schedule_manual() {
     let sched1 = client.create_program_release_schedule(&3_000, &0, &w1);
     let sched2 = client.create_program_release_schedule(&5_000, &0, &w2);
 
-    assert_balance_invariant(&client, &token_client, &contract_id, "after creating schedules");
+    assert_balance_invariant(
+        &client,
+        &token_client,
+        &contract_id,
+        "after creating schedules",
+    );
 
     // Release first schedule manually
     client.release_program_schedule_manual(&sched1.schedule_id);
@@ -248,8 +289,7 @@ fn test_invariant_release_program_schedule_manual() {
 fn test_invariant_release_prog_schedule_automatic() {
     let env = Env::default();
     let total: i128 = 5_000;
-    let (client, contract_id, _admin, token_client, _token_sac, _token_id) =
-        setup(&env, total);
+    let (client, contract_id, _admin, token_client, _token_sac, _token_id) = setup(&env, total);
 
     assert_balance_invariant(&client, &token_client, &contract_id, "initial");
 
@@ -258,7 +298,12 @@ fn test_invariant_release_prog_schedule_automatic() {
     // Create a schedule with release_timestamp = 100
     let sched = client.create_program_release_schedule(&5_000, &100, &winner);
 
-    assert_balance_invariant(&client, &token_client, &contract_id, "after creating schedule");
+    assert_balance_invariant(
+        &client,
+        &token_client,
+        &contract_id,
+        "after creating schedule",
+    );
 
     // Advance ledger timestamp past release point
     env.ledger().set_timestamp(200);
@@ -282,8 +327,7 @@ fn test_invariant_release_prog_schedule_automatic() {
 fn test_invariant_overpayout_rejected() {
     let env = Env::default();
     let total: i128 = 1_000;
-    let (client, contract_id, _admin, token_client, _token_sac, _token_id) =
-        setup(&env, total);
+    let (client, contract_id, _admin, token_client, _token_sac, _token_id) = setup(&env, total);
 
     assert_balance_invariant(&client, &token_client, &contract_id, "initial");
 
@@ -312,8 +356,7 @@ fn test_invariant_topup_then_mixed_payouts() {
     let env = Env::default();
     let initial: i128 = 5_000;
     let topup: i128 = 3_000;
-    let (client, contract_id, admin, token_client, token_sac, _token_id) =
-        setup(&env, initial);
+    let (client, contract_id, admin, token_client, token_sac, _token_id) = setup(&env, initial);
 
     assert_balance_invariant(&client, &token_client, &contract_id, "after initial lock");
 
@@ -347,5 +390,114 @@ fn test_invariant_topup_then_mixed_payouts() {
         "after manual schedule release",
     );
     assert_eq!(client.get_remaining_balance(), 0);
+    assert_eq!(token_client.balance(&contract_id), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Test 8 — deterministic mixed sequence with schedules, disputes, and logging
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_reconciliation_invariant_after_each_mixed_operation() {
+    let env = Env::default();
+    let total: i128 = 20_000;
+    let (client, contract_id, _admin, token_client, _token_sac, _token_id) = setup(&env, total);
+
+    let w1 = Address::generate(&env);
+    let w2 = Address::generate(&env);
+    let w3 = Address::generate(&env);
+    let w4 = Address::generate(&env);
+
+    assert_balance_invariant(&client, &token_client, &contract_id, "sequence=start");
+
+    client.single_payout(&w1, &1_000);
+    assert_balance_invariant(
+        &client,
+        &token_client,
+        &contract_id,
+        "sequence=single_payout(1000)",
+    );
+
+    // Partial batch spend: leaves both spendable funds and later scheduled funds
+    // in the same contract balance.
+    let batch_recipients = vec![&env, w2.clone(), w3.clone()];
+    let batch_amounts = vec![&env, 1_500_i128, 2_500_i128];
+    client.batch_payout(&batch_recipients, &batch_amounts);
+    assert_balance_invariant(
+        &client,
+        &token_client,
+        &contract_id,
+        "sequence=batch_payout(1500,2500)",
+    );
+
+    let sched1 = client.create_program_release_schedule(&3_000, &50, &w1);
+    let _sched2 = client.create_program_release_schedule(&4_000, &100, &w4);
+    assert_balance_invariant(
+        &client,
+        &token_client,
+        &contract_id,
+        "sequence=create_schedules(3000@50,4000@100)",
+    );
+
+    // Automatic release before due time must fail without changing accounting.
+    env.ledger().set_timestamp(49);
+    let early = client.try_release_prog_schedule_automatic(&sched1.schedule_id);
+    assert!(early.is_err(), "expected before-due release to fail");
+    assert_balance_invariant(
+        &client,
+        &token_client,
+        &contract_id,
+        "sequence=failed_automatic_release_before_due(schedule=1)",
+    );
+
+    // Due exactly at the scheduled timestamp.
+    env.ledger().set_timestamp(50);
+    client.release_prog_schedule_automatic(&sched1.schedule_id);
+    assert_balance_invariant(
+        &client,
+        &token_client,
+        &contract_id,
+        "sequence=automatic_release_due_exactly(schedule=1)",
+    );
+
+    // Open dispute blocks payout/release paths and must preserve the invariant.
+    client.open_dispute(&String::from_str(
+        &env,
+        "pause payouts while reviewing award",
+    ));
+    let disputed_payout = client.try_single_payout(&w2, &500);
+    assert!(disputed_payout.is_err(), "expected disputed payout to fail");
+    let disputed_release = client.try_trigger_program_releases();
+    assert!(
+        disputed_release.is_err(),
+        "expected disputed schedule trigger to fail"
+    );
+    assert_balance_invariant(
+        &client,
+        &token_client,
+        &contract_id,
+        "sequence=dispute_blocked_payout_and_release",
+    );
+
+    client.resolve_dispute();
+    env.ledger().set_timestamp(100);
+    let released = client.trigger_program_releases();
+    assert_eq!(released, 1);
+    assert_balance_invariant(
+        &client,
+        &token_client,
+        &contract_id,
+        "sequence=resolve_dispute_then_trigger_due(schedule=2)",
+    );
+
+    client.single_payout(&w3, &8_000);
+    assert_balance_invariant(
+        &client,
+        &token_client,
+        &contract_id,
+        "sequence=final_single_payout(8000)",
+    );
+    assert_eq!(client.get_remaining_balance(), 0);
+    assert_eq!(pending_scheduled_total(&client), 0);
     assert_eq!(token_client.balance(&contract_id), 0);
 }


### PR DESCRIPTION
## Summary
- extends `program-escrow/src/test_balance_invariant.rs` with schedule-ledger reconciliation helpers
- asserts the real SAC contract balance after each operation and decomposes `remaining_balance` into spendable + pending scheduled amounts
- adds an end-to-end mixed operation sequence covering single payout, partial batch payout, scheduled releases before/at/after due time, dispute-blocked payout/release paths, and final drain
- initializes admin in the shared fixture so dispute-gated flows can be exercised in this suite

## Security notes
- The invariant now fails with an operation label at the first accounting divergence.
- Current contract semantics keep pending scheduled funds inside `remaining_balance`; the test makes that explicit by checking `remaining_balance >= pending_scheduled` and `SAC balance == spendable + pending_scheduled == remaining_balance`.

## Validation
- `rustfmt src/test_balance_invariant.rs`
- `cd program-escrow && cargo test test_balance_invariant -- --nocapture` — 8 passed
- `cd program-escrow && cargo test` — 305 passed; 0 failed; 1 ignored
- `git diff --check`

Closes #102
