### PR TITLE
Add v2 version fields to bounty escrow events

### DIFF
--- a/bounty_escrow/contracts/escrow/src/events.rs
+++ b/bounty_escrow/contracts/escrow/src/events.rs
@@ -89,6 +89,7 @@ pub enum FeeOperationType {
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct FeeCollected {
+    pub version: u32,
     pub operation_type: FeeOperationType,
     pub amount: i128,
     pub fee_rate: i128,
@@ -104,6 +105,7 @@ pub fn emit_fee_collected(env: &Env, event: FeeCollected) {
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct BatchFundsLocked {
+    pub version: u32,
     pub count: u32,
     pub total_amount: i128,
     pub timestamp: u64,
@@ -117,6 +119,7 @@ pub fn emit_batch_funds_locked(env: &Env, event: BatchFundsLocked) {
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct FeeConfigUpdated {
+    pub version: u32,
     pub lock_fee_rate: i128,
     pub release_fee_rate: i128,
     pub fee_recipient: Address,
@@ -132,6 +135,7 @@ pub fn emit_fee_config_updated(env: &Env, event: FeeConfigUpdated) {
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct BatchFundsReleased {
+    pub version: u32,
     pub count: u32,
     pub total_amount: i128,
     pub timestamp: u64,
@@ -145,6 +149,7 @@ pub fn emit_batch_funds_released(env: &Env, event: BatchFundsReleased) {
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct ApprovalAdded {
+    pub version: u32,
     pub bounty_id: u64,
     pub contributor: Address,
     pub approver: Address,
@@ -159,6 +164,7 @@ pub fn emit_approval_added(env: &Env, event: ApprovalAdded) {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ClaimCreated {
+    pub version: u32,
     pub bounty_id: u64, // use program_id+schedule_id equivalent in program-escrow
     pub recipient: Address,
     pub amount: i128,
@@ -168,6 +174,7 @@ pub struct ClaimCreated {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ClaimExecuted {
+    pub version: u32,
     pub bounty_id: u64,
     pub recipient: Address,
     pub amount: i128,
@@ -177,6 +184,7 @@ pub struct ClaimExecuted {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ClaimCancelled {
+    pub version: u32,
     pub bounty_id: u64,
     pub recipient: Address,
     pub amount: i128,

--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -730,6 +730,7 @@ impl BountyEscrowContract {
         events::emit_fee_config_updated(
             &env,
             events::FeeConfigUpdated {
+                version: EVENT_VERSION_V2,
                 lock_fee_rate: fee_config.lock_fee_rate,
                 release_fee_rate: fee_config.release_fee_rate,
                 fee_recipient: fee_config.fee_recipient.clone(),
@@ -1006,6 +1007,7 @@ impl BountyEscrowContract {
         events::emit_approval_added(
             &env,
             events::ApprovalAdded {
+                version: EVENT_VERSION_V2,
                 bounty_id,
                 contributor: contributor.clone(),
                 approver,
@@ -1348,6 +1350,7 @@ impl BountyEscrowContract {
         env.events().publish(
             (symbol_short!("claim"), symbol_short!("created")),
             ClaimCreated {
+                version: EVENT_VERSION_V2,
                 bounty_id,
                 recipient,
                 amount: escrow.amount,
@@ -1418,6 +1421,7 @@ impl BountyEscrowContract {
         env.events().publish(
             (symbol_short!("claim"), symbol_short!("done")),
             ClaimExecuted {
+                version: EVENT_VERSION_V2,
                 bounty_id,
                 recipient: claim.recipient.clone(),
                 amount: claim.amount,
@@ -1466,6 +1470,7 @@ impl BountyEscrowContract {
         env.events().publish(
             (symbol_short!("claim"), symbol_short!("cancel")),
             ClaimCancelled {
+                version: EVENT_VERSION_V2,
                 bounty_id,
                 recipient: claim.recipient,
                 amount: claim.amount,
@@ -2660,6 +2665,7 @@ impl BountyEscrowContract {
         emit_batch_funds_locked(
             &env,
             BatchFundsLocked {
+                version: EVENT_VERSION_V2,
                 count: locked_count,
                 total_amount: items.iter().map(|i| i.amount).sum(),
                 timestamp,
@@ -2804,6 +2810,7 @@ impl BountyEscrowContract {
         emit_batch_funds_released(
             &env,
             BatchFundsReleased {
+                version: EVENT_VERSION_V2,
                 count: released_count,
                 total_amount,
                 timestamp,

--- a/bounty_escrow/contracts/escrow/src/test_bounty_escrow.rs
+++ b/bounty_escrow/contracts/escrow/src/test_bounty_escrow.rs
@@ -1,9 +1,15 @@
 #![cfg(test)]
-use crate::{BountyEscrowContract, BountyEscrowContractClient, Error as ContractError};
-use soroban_sdk::testutils::Events;
+use crate::{
+    events::{
+        ApprovalAdded, BatchFundsLocked, BatchFundsReleased, ClaimCancelled, ClaimCreated,
+        ClaimExecuted, FeeCollected, FeeConfigUpdated, FeeOperationType, EVENT_VERSION_V2,
+    },
+    BountyEscrowContract, BountyEscrowContractClient, Error as ContractError, LockFundsItem,
+    ReleaseFundsItem,
+};
 use soroban_sdk::{
-    testutils::{Address as _, Ledger},
-    token, Address, Env, Map, Symbol, TryFromVal, Val,
+    testutils::{Address as _, Events, Ledger},
+    token, vec, Address, Env, Map, Symbol, TryFromVal, Val,
 };
 
 fn create_test_env() -> (Env, BountyEscrowContractClient<'static>, Address) {
@@ -35,20 +41,25 @@ fn assert_event_data_has_v2_tag(env: &Env, data: &Val) {
     assert_eq!(version, 2);
 }
 
-fn assert_current_call_has_versioned_contract_event(env: &Env, contract_id: &Address) {
+fn assert_new_contract_event_has_v2_tag(
+    env: &Env,
+    contract_id: &Address,
+    before_event_count: u32,
+    required_field: &str,
+) {
     let events = env.events().all();
     let mut found = false;
-    for (contract, _topics, data) in events.iter() {
+    for i in before_event_count..events.len() {
+        let (contract, _topics, data) = events.get(i).expect("event should exist");
         if contract != *contract_id {
             continue;
         }
-        // Only require that at least one event for this call carries
-        // the V2 version tag; other event families (e.g. analytics)
-        // may legitimately use different versioning schemes.
         if let Ok(data_map) = Map::<Symbol, Val>::try_from_val(env, &data) {
             if let Some(version_val) = data_map.get(Symbol::new(env, "version")) {
                 if let Ok(version) = u32::try_from_val(env, &version_val) {
-                    if version == 2 {
+                    if version == EVENT_VERSION_V2
+                        && data_map.get(Symbol::new(env, required_field)).is_some()
+                    {
                         found = true;
                         break;
                     }
@@ -57,6 +68,28 @@ fn assert_current_call_has_versioned_contract_event(env: &Env, contract_id: &Add
         }
     }
     assert!(found);
+}
+
+fn assert_unemitted_bounty_event_types_are_v2(env: &Env, address: &Address) {
+    let fee = FeeCollected {
+        version: EVENT_VERSION_V2,
+        operation_type: FeeOperationType::Lock,
+        amount: 1,
+        fee_rate: 10,
+        recipient: address.clone(),
+        timestamp: 1,
+    };
+    let fee_config = FeeConfigUpdated {
+        version: EVENT_VERSION_V2,
+        lock_fee_rate: 10,
+        release_fee_rate: 10,
+        fee_recipient: address.clone(),
+        fee_enabled: true,
+        timestamp: 1,
+    };
+
+    assert_eq!(fee.version, EVENT_VERSION_V2);
+    assert_eq!(fee_config.version, EVENT_VERSION_V2);
 }
 
 #[test]
@@ -89,18 +122,138 @@ fn test_events_emit_v2_version_tags_for_all_bounty_emitters() {
     let admin = Address::generate(&env);
     let depositor = Address::generate(&env);
     let contributor = Address::generate(&env);
+    let second_contributor = Address::generate(&env);
+    let signer = Address::generate(&env);
     let token_admin = Address::generate(&env);
     let (token, _token_client, token_admin_client) = create_token_contract(&env, &token_admin);
+    let now = env.ledger().timestamp();
 
+    assert_unemitted_bounty_event_types_are_v2(&env, &admin);
+
+    let before = env.events().all().len();
     client.init(&admin, &token);
-    assert_current_call_has_versioned_contract_event(&env, &contract_id);
+    assert_new_contract_event_has_v2_tag(&env, &contract_id, before, "admin");
 
-    token_admin_client.mint(&depositor, &10_000);
-    client.lock_funds(&depositor, &1, &10_000, &(env.ledger().timestamp() + 10));
-    assert_current_call_has_versioned_contract_event(&env, &contract_id);
+    let before = env.events().all().len();
+    client.update_fee_config(&Some(0), &Some(0), &Some(admin.clone()), &Some(false));
+    assert_new_contract_event_has_v2_tag(&env, &contract_id, before, "lock_fee_rate");
 
+    token_admin_client.mint(&depositor, &100_000);
+    let before = env.events().all().len();
+    client.lock_funds(&depositor, &1, &10_000, &(now + 10));
+    assert_new_contract_event_has_v2_tag(&env, &contract_id, before, "depositor");
+
+    let before = env.events().all().len();
     client.release_funds(&1, &contributor);
-    assert_current_call_has_versioned_contract_event(&env, &contract_id);
+    assert_new_contract_event_has_v2_tag(&env, &contract_id, before, "recipient");
+
+    let batch_items = vec![
+        &env,
+        LockFundsItem {
+            bounty_id: 2,
+            depositor: depositor.clone(),
+            amount: 20_000,
+            deadline: now + 20,
+        },
+        LockFundsItem {
+            bounty_id: 3,
+            depositor: depositor.clone(),
+            amount: 30_000,
+            deadline: now + 20,
+        },
+    ];
+    let before = env.events().all().len();
+    client.batch_lock_funds(&batch_items);
+    assert_new_contract_event_has_v2_tag(&env, &contract_id, before, "count");
+
+    let release_items = vec![
+        &env,
+        ReleaseFundsItem {
+            bounty_id: 2,
+            contributor: contributor.clone(),
+        },
+        ReleaseFundsItem {
+            bounty_id: 3,
+            contributor: second_contributor,
+        },
+    ];
+    let before = env.events().all().len();
+    client.batch_release_funds(&release_items);
+    assert_new_contract_event_has_v2_tag(&env, &contract_id, before, "total_amount");
+
+    client.update_multisig_config(&1_000, &vec![&env, signer.clone()], &1);
+    let before = env.events().all().len();
+    client.approve_large_release(&4, &contributor, &signer);
+    assert_new_contract_event_has_v2_tag(&env, &contract_id, before, "approver");
+
+    token_admin_client.mint(&depositor, &40_000);
+    client.lock_funds(&depositor, &5, &40_000, &(now + 30));
+    client.set_claim_window(&10);
+
+    let before = env.events().all().len();
+    client.authorize_claim(&5, &contributor);
+    assert_new_contract_event_has_v2_tag(&env, &contract_id, before, "expires_at");
+
+    let before = env.events().all().len();
+    client.claim(&5);
+    assert_new_contract_event_has_v2_tag(&env, &contract_id, before, "claimed_at");
+
+    token_admin_client.mint(&depositor, &50_000);
+    client.lock_funds(&depositor, &6, &50_000, &(now + 40));
+    client.authorize_claim(&6, &contributor);
+
+    let before = env.events().all().len();
+    client.cancel_pending_claim(&6);
+    assert_new_contract_event_has_v2_tag(&env, &contract_id, before, "cancelled_at");
+
+    let batch_locked = BatchFundsLocked {
+        version: EVENT_VERSION_V2,
+        count: 1,
+        total_amount: 1,
+        timestamp: now,
+    };
+    let batch_released = BatchFundsReleased {
+        version: EVENT_VERSION_V2,
+        count: 1,
+        total_amount: 1,
+        timestamp: now,
+    };
+    let approval = ApprovalAdded {
+        version: EVENT_VERSION_V2,
+        bounty_id: 1,
+        contributor: contributor.clone(),
+        approver: signer,
+        timestamp: now,
+    };
+    let claim_created = ClaimCreated {
+        version: EVENT_VERSION_V2,
+        bounty_id: 1,
+        recipient: contributor.clone(),
+        amount: 1,
+        expires_at: now,
+    };
+    let claim_executed = ClaimExecuted {
+        version: EVENT_VERSION_V2,
+        bounty_id: 1,
+        recipient: contributor.clone(),
+        amount: 1,
+        claimed_at: now,
+    };
+    let claim_cancelled = ClaimCancelled {
+        version: EVENT_VERSION_V2,
+        bounty_id: 1,
+        recipient: contributor,
+        amount: 1,
+        cancelled_at: now,
+        cancelled_by: admin,
+        reason: Symbol::new(&env, "manual"),
+    };
+    assert_eq!(batch_locked.version, EVENT_VERSION_V2);
+    assert_eq!(batch_released.version, EVENT_VERSION_V2);
+    assert_eq!(approval.version, EVENT_VERSION_V2);
+    assert_eq!(claim_created.version, EVENT_VERSION_V2);
+    assert_eq!(claim_executed.version, EVENT_VERSION_V2);
+    assert_eq!(claim_cancelled.version, EVENT_VERSION_V2);
 }
 
 #[test]

--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -397,12 +397,12 @@ pub struct BountyExpired {
 **Struct:** `FeeCollected`
 **Lifecycle phase:** Any operation that deducts a fee (lock or release)
 
-> **Version note:** `FeeCollected` does **not** carry a `version` field. It is a v1-style
-> payload. Parsers must not require `version` for this event.
+> **Version note:** `FeeCollected` now carries `version: 2` as the first payload field.
 
 ```rust
 #[contracttype]
 pub struct FeeCollected {
+    pub version:        u32,
     pub operation_type: FeeOperationType,  // enum: Lock | Release
     pub amount:         i128,
     pub fee_rate:       i128,
@@ -418,6 +418,7 @@ pub enum FeeOperationType { Lock, Release }
 
 ```json
 {
+  "version":        2,
   "operation_type": "Lock",
   "amount":         10000000,
   "fee_rate":       100,
@@ -428,6 +429,7 @@ pub enum FeeOperationType { Lock, Release }
 
 | Field            | Rust type          | Required | Description |
 |------------------|--------------------|----------|-------------|
+| `version`        | `u32`              | **Yes**  | Always `2` |
 | `operation_type` | `FeeOperationType` | **Yes**  | `Lock` or `Release` — which operation triggered the fee |
 | `amount`         | `i128`             | **Yes**  | Fee amount collected (token stroops) |
 | `fee_rate`       | `i128`             | **Yes**  | Fee rate in basis points at time of collection |
@@ -443,11 +445,12 @@ pub enum FeeOperationType { Lock, Release }
 **Struct:** `BatchFundsLocked`
 **Lifecycle phase:** Batch bounty creation
 
-> **Version note:** No `version` field — v1-style payload.
+> **Version note:** This event now carries `version: 2` as the first payload field.
 
 ```rust
 #[contracttype]
 pub struct BatchFundsLocked {
+    pub version:      u32,
     pub count:        u32,
     pub total_amount: i128,
     pub timestamp:    u64,
@@ -458,6 +461,7 @@ pub struct BatchFundsLocked {
 
 ```json
 {
+  "version":      2,
   "count":        5,
   "total_amount": 5000000000,
   "timestamp":    1740000200
@@ -466,6 +470,7 @@ pub struct BatchFundsLocked {
 
 | Field          | Rust type | Required | Description |
 |----------------|-----------|----------|-------------|
+| `version`      | `u32`     | **Yes**  | Always `2` |
 | `count`        | `u32`     | **Yes**  | Number of bounties locked in the batch |
 | `total_amount` | `i128`    | **Yes**  | Aggregate amount locked across all bounties |
 | `timestamp`    | `u64`     | **Yes**  | Ledger timestamp |
@@ -479,11 +484,12 @@ pub struct BatchFundsLocked {
 **Struct:** `BatchFundsReleased`
 **Lifecycle phase:** Batch bounty payout
 
-> **Version note:** No `version` field — v1-style payload.
+> **Version note:** This event now carries `version: 2` as the first payload field.
 
 ```rust
 #[contracttype]
 pub struct BatchFundsReleased {
+    pub version:      u32,
     pub count:        u32,
     pub total_amount: i128,
     pub timestamp:    u64,
@@ -494,6 +500,7 @@ pub struct BatchFundsReleased {
 
 ```json
 {
+  "version":      2,
   "count":        5,
   "total_amount": 4900000000,
   "timestamp":    1740100200
@@ -502,6 +509,7 @@ pub struct BatchFundsReleased {
 
 | Field          | Rust type | Required | Description |
 |----------------|-----------|----------|-------------|
+| `version`      | `u32`     | **Yes**  | Always `2` |
 | `count`        | `u32`     | **Yes**  | Number of bounties released in the batch |
 | `total_amount` | `i128`    | **Yes**  | Aggregate net amount released |
 | `timestamp`    | `u64`     | **Yes**  | Ledger timestamp |
@@ -515,11 +523,12 @@ pub struct BatchFundsReleased {
 **Struct:** `ApprovalAdded`
 **Lifecycle phase:** Work submission / approval flow
 
-> **Version note:** No `version` field — v1-style payload.
+> **Version note:** This event now carries `version: 2` as the first payload field.
 
 ```rust
 #[contracttype]
 pub struct ApprovalAdded {
+    pub version:     u32,
     pub bounty_id:   u64,
     pub contributor: Address,
     pub approver:    Address,
@@ -531,6 +540,7 @@ pub struct ApprovalAdded {
 
 ```json
 {
+  "version":     2,
   "bounty_id":   42,
   "contributor": "GCON…",
   "approver":    "GAPR…",
@@ -540,6 +550,7 @@ pub struct ApprovalAdded {
 
 | Field         | Rust type | Required | Description |
 |---------------|-----------|----------|-------------|
+| `version`     | `u32`     | **Yes**  | Always `2` |
 | `bounty_id`   | `u64`     | **Yes**  | Bounty identifier; also in topic[1] |
 | `contributor` | `Address` | **Yes**  | Address of the work submitter |
 | `approver`    | `Address` | **Yes**  | Address of the approver |
@@ -554,11 +565,12 @@ pub struct ApprovalAdded {
 **Struct:** `FeeConfigUpdated`
 **Lifecycle phase:** Admin fee configuration change
 
-> **Version note:** No `version` field — v1-style payload.
+> **Version note:** This event now carries `version: 2` as the first payload field.
 
 ```rust
 #[contracttype]
 pub struct FeeConfigUpdated {
+    pub version:          u32,
     pub lock_fee_rate:    i128,
     pub release_fee_rate: i128,
     pub fee_recipient:    Address,
@@ -571,6 +583,7 @@ pub struct FeeConfigUpdated {
 
 ```json
 {
+  "version":          2,
   "lock_fee_rate":    50,
   "release_fee_rate": 100,
   "fee_recipient":    "GFEE…",
@@ -581,6 +594,7 @@ pub struct FeeConfigUpdated {
 
 | Field              | Rust type | Required | Description |
 |--------------------|-----------|----------|-------------|
+| `version`          | `u32`     | **Yes**  | Always `2` |
 | `lock_fee_rate`    | `i128`    | **Yes**  | New lock-operation fee in basis points |
 | `release_fee_rate` | `i128`    | **Yes**  | New release-operation fee in basis points |
 | `fee_recipient`    | `Address` | **Yes**  | Address that will receive fees going forward |
@@ -589,7 +603,133 @@ pub struct FeeConfigUpdated {
 
 ---
 
-### 5.10 `PauseStateChanged` (bounty)
+### 5.10 `ClaimCreated`
+
+**Emitted by:** `authorize_claim()`
+**Topics:** `(symbol_short!("claim"), symbol_short!("created"))`
+**Struct:** `ClaimCreated`
+**Lifecycle phase:** Claim authorization / dispute window opening
+
+```rust
+#[contracttype]
+pub struct ClaimCreated {
+    pub version:    u32,
+    pub bounty_id:  u64,
+    pub recipient:  Address,
+    pub amount:     i128,
+    pub expires_at: u64,
+}
+```
+
+#### Payload Example
+
+```json
+{
+  "version":    2,
+  "bounty_id":  42,
+  "recipient":  "GCON...",
+  "amount":     10000000,
+  "expires_at": 1740050500
+}
+```
+
+| Field        | Rust type | Required | Description |
+|--------------|-----------|----------|-------------|
+| `version`    | `u32`     | **Yes**  | Always `2` |
+| `bounty_id`  | `u64`     | **Yes**  | Bounty identifier |
+| `recipient`  | `Address` | **Yes**  | Address authorized to claim |
+| `amount`     | `i128`    | **Yes**  | Claim amount |
+| `expires_at` | `u64`     | **Yes**  | Claim expiry timestamp |
+
+---
+
+### 5.11 `ClaimExecuted`
+
+**Emitted by:** `claim()`
+**Topics:** `(symbol_short!("claim"), symbol_short!("done"))`
+**Struct:** `ClaimExecuted`
+**Lifecycle phase:** Claim payout
+
+```rust
+#[contracttype]
+pub struct ClaimExecuted {
+    pub version:    u32,
+    pub bounty_id:  u64,
+    pub recipient:  Address,
+    pub amount:     i128,
+    pub claimed_at: u64,
+}
+```
+
+#### Payload Example
+
+```json
+{
+  "version":    2,
+  "bounty_id":  42,
+  "recipient":  "GCON...",
+  "amount":     10000000,
+  "claimed_at": 1740050300
+}
+```
+
+| Field       | Rust type | Required | Description |
+|-------------|-----------|----------|-------------|
+| `version`   | `u32`     | **Yes**  | Always `2` |
+| `bounty_id` | `u64`     | **Yes**  | Bounty identifier |
+| `recipient` | `Address` | **Yes**  | Address that claimed funds |
+| `amount`    | `i128`    | **Yes**  | Claimed amount |
+| `claimed_at`| `u64`     | **Yes**  | Ledger timestamp when claimed |
+
+---
+
+### 5.12 `ClaimCancelled`
+
+**Emitted by:** `cancel_pending_claim()`
+**Topics:** `(symbol_short!("claim"), symbol_short!("cancel"))`
+**Struct:** `ClaimCancelled`
+**Lifecycle phase:** Claim cancellation
+
+```rust
+#[contracttype]
+pub struct ClaimCancelled {
+    pub version:      u32,
+    pub bounty_id:    u64,
+    pub recipient:    Address,
+    pub amount:       i128,
+    pub cancelled_at: u64,
+    pub cancelled_by: Address,
+    pub reason:       Symbol,
+}
+```
+
+#### Payload Example
+
+```json
+{
+  "version":      2,
+  "bounty_id":    42,
+  "recipient":    "GCON...",
+  "amount":       10000000,
+  "cancelled_at": 1740050600,
+  "cancelled_by": "GADM...",
+  "reason":       "manual"
+}
+```
+
+| Field          | Rust type | Required | Description |
+|----------------|-----------|----------|-------------|
+| `version`      | `u32`     | **Yes**  | Always `2` |
+| `bounty_id`    | `u64`     | **Yes**  | Bounty identifier |
+| `recipient`    | `Address` | **Yes**  | Address whose claim was cancelled |
+| `amount`       | `i128`    | **Yes**  | Cancelled claim amount |
+| `cancelled_at` | `u64`     | **Yes**  | Ledger timestamp when cancelled |
+| `cancelled_by` | `Address` | **Yes**  | Admin that cancelled the claim |
+| `reason`       | `Symbol`  | **Yes**  | `manual` or `expired` |
+
+---
+
+### 5.13 `PauseStateChanged` (bounty)
 
 **Emitted by:** `emit_pause_state_changed()` — delegates to `crate::PauseStateChanged`
 **Topics:** `(symbol_short!("pause"), event.operation.clone())`
@@ -981,6 +1121,9 @@ Complete lookup table of every `env.events().publish(topics, …)` call in this 
 | `bounty_escrow`  | `(symbol_short!("b_rel"),)`                             | `"b_rel"`                 | `BatchFundsReleased`      |
 | `bounty_escrow`  | `(symbol_short!("approval"), bounty_id)`                | `"approval"` + u64        | `ApprovalAdded`           |
 | `bounty_escrow`  | `(symbol_short!("fee_cfg"),)`                           | `"fee_cfg"`               | `FeeConfigUpdated`        |
+| `bounty_escrow`  | `(symbol_short!("claim"), symbol_short!("created"))`  | `"claim"` + `"created"` | `ClaimCreated`           |
+| `bounty_escrow`  | `(symbol_short!("claim"), symbol_short!("done"))`     | `"claim"` + `"done"`    | `ClaimExecuted`          |
+| `bounty_escrow`  | `(symbol_short!("claim"), symbol_short!("cancel"))`   | `"claim"` + `"cancel"`  | `ClaimCancelled`         |
 | `bounty_escrow`  | `(symbol_short!("pause"), event.operation.clone())`     | `"pause"` + op symbol     | `PauseStateChanged`       |
 | `program_escrow` | `(PROGRAM_INITIALIZED,)` = `("PrgInit",)`               | `"PrgInit"`               | `ProgramInitializedEvent` |
 | `program_escrow` | `(FUNDS_LOCKED,)` = `("FndsLock",)`                     | `"FndsLock"`              | `FundsLockedEvent`        |
@@ -1019,6 +1162,11 @@ All fields appearing across all three contracts:
 | `total_amount`          | `i128`             | `I128`      | bounty, program |
 | `contributor`           | `Address`          | `Address`   | bounty |
 | `approver`              | `Address`          | `Address`   | bounty |
+| `expires_at`            | `u64`              | `U64`       | bounty |
+| `claimed_at`            | `u64`              | `U64`       | bounty |
+| `cancelled_at`          | `u64`              | `U64`       | bounty |
+| `cancelled_by`          | `Address`          | `Address`   | bounty |
+| `reason`                | `Symbol`           | `Symbol`    | bounty |
 | `operation`             | `Symbol`           | `Symbol`    | bounty, program |
 | `paused`                | `bool`             | `Bool`      | bounty, program |
 | `program_id`            | `String`           | `String`    | program |
@@ -1042,12 +1190,7 @@ All fields appearing across all three contracts:
 
 ## 10. v1 → v2 Migration Guide
 
-Five events in `bounty_escrow` are **permanently v1** (no `version` field was ever added):
-`FeeCollected`, `BatchFundsLocked`, `BatchFundsReleased`, `ApprovalAdded`, `FeeConfigUpdated`.
-Parsers must never require `version` on these events.
-
-For events that do carry `version` (`BountyEscrowInitialized`, `FundsLocked`, `FundsReleased`,
-`FundsRefunded`, `BountyExpired` in bounty_escrow; all events in `program_escrow`):
+All `bounty_escrow` value, batch, fee, approval, claim, and lifecycle events now carry `version: 2` as the first payload field. Legacy on-chain payloads that predate this schema may still omit `version`, so consumers should keep the absent-version fallback for historical data.
 
 1. **Detect version.** Read `version` from payload. If absent → treat as `1`.
 2. **`amount` is always safe.** Both v1 and v2 include `amount` on value-transfer events.


### PR DESCRIPTION
Title: Add v2 version fields to bounty escrow events

Summary:
- Added `version: u32` as the first payload field for the previously unversioned bounty escrow event structs: fee, batch lock/release, approval, and claim lifecycle events.
- Populated those event payloads with `EVENT_VERSION_V2` at every emit site.
- Expanded event schema docs and topic/field references for the newly versioned events.
- Strengthened the bounty event version test to assert newly emitted v2 payloads for init, fee config, lock/release, batch, approval, claim created/executed/cancelled flows.

Validation:
- `git diff --check`
- Could not run `cd bounty_escrow/contracts/escrow && cargo test` locally because this machine does not currently have `cargo`/Rust installed.

Notes:
- Addresses #77.
- This was prepared for the GrantFox/Maybe Rewarded campaign. If accepted, PayPal payment can be sent to the contributor email associated with my GitHub account, or I can provide a PayPal email privately on request.