### PR TITLE
[codex] Implement program escrow recipient whitelist

### DIFF
--- a/docs/program-escrow/IMPLEMENTATION_SUMMARY.md
+++ b/docs/program-escrow/IMPLEMENTATION_SUMMARY.md
@@ -162,3 +162,39 @@ contracts and should not be inferred from program-escrow storage.
 ## Notes
 
 The implementation is complete and ready for review. The existing test suite has compilation errors unrelated to this feature, which should be addressed separately. The new analytics events are production-ready and follow best practices for observability and monitoring.
+
+## Recipient Whitelist Enforcement
+
+Program escrow now includes a real recipient whitelist instead of a no-op
+`set_whitelist` entrypoint.
+
+### Storage And Defaults
+
+- `DataKey::Whitelist(Address)` stores whether a recipient is allowed.
+- `DataKey::WhitelistEnforcementEnabled` stores the global enforcement flag.
+- Enforcement defaults to `false` for backwards compatibility, so existing
+  payout integrations keep working until an admin explicitly enables it.
+
+### Admin Entrypoints
+
+- `set_whitelist(address, whitelisted)` requires the configured contract admin
+  and adds or removes a recipient from whitelist storage.
+- `is_whitelisted(address)` returns the persisted whitelist state.
+- `set_whitelist_enforcement(enabled)` requires the configured contract admin
+  and toggles recipient enforcement.
+- `is_whitelist_enforcement_enabled()` returns the enforcement flag.
+
+### Payout Enforcement
+
+When enforcement is enabled, both `single_payout` and `batch_payout` reject any
+recipient that is not whitelisted before token transfer. Rejections clear the
+reentrancy guard before aborting.
+
+### Event Schema
+
+Whitelist changes emit `WListChg` with:
+
+- `version`
+- `address`
+- `whitelisted`
+- `admin`

--- a/program-escrow/src/lib.rs
+++ b/program-escrow/src/lib.rs
@@ -194,6 +194,7 @@ const PAUSE_STATE_CHANGED: Symbol = symbol_short!("PauseSt");
 const AGGREGATE_STATS: Symbol = symbol_short!("AggStats");
 const LARGE_PAYOUT: Symbol = symbol_short!("LrgPay");
 const SCHEDULE_TRIGGERED: Symbol = symbol_short!("SchedTrg");
+const WHITELIST_CHANGED: Symbol = symbol_short!("WListChg");
 
 // Storage keys
 const PROGRAM_DATA: Symbol = symbol_short!("ProgData");
@@ -292,6 +293,15 @@ pub struct ScheduleTriggeredEvent {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WhitelistChangedEvent {
+    pub version: u32,
+    pub address: Address,
+    pub whitelisted: bool,
+    pub admin: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProgramData {
     pub program_id: String,
     pub total_funds: i128,
@@ -318,6 +328,8 @@ pub enum DataKey {
     FeeConfig,                       // FeeConfig struct
     ProgramRegistry,                 // Vec<String> of program IDs
     Dispute,                         // DisputeRecord (program-level dispute)
+    Whitelist(Address),              // recipient address -> bool
+    WhitelistEnforcementEnabled,     // bool, default false
 }
 
 #[contracttype]
@@ -709,6 +721,25 @@ impl ProgramEscrowContract {
                 scheduled_count,
             },
         );
+    }
+
+    fn is_whitelisted_internal(env: &Env, address: &Address) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Whitelist(address.clone()))
+            .unwrap_or(false)
+    }
+
+    fn whitelist_enforcement_enabled(env: &Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::WhitelistEnforcementEnabled)
+            .unwrap_or(false)
+    }
+
+    fn recipient_allowed_by_whitelist(env: &Env, recipient: &Address) -> bool {
+        !Self::whitelist_enforcement_enabled(env)
+            || Self::is_whitelisted_internal(env, recipient)
     }
 
     /// Check if payout is large and emit event if threshold exceeded
@@ -1300,14 +1331,58 @@ impl ProgramEscrowContract {
             })
     }
 
-    pub fn set_whitelist(env: Env, _address: Address, _whitelisted: bool) {
-        // Only admin can set whitelist
+    /// Add or remove a recipient from the payout whitelist.
+    ///
+    /// Only the contract admin can mutate whitelist state. Enforcement remains
+    /// disabled until `set_whitelist_enforcement(true)` is called.
+    pub fn set_whitelist(env: Env, address: Address, whitelisted: bool) {
         let admin: Address = env
             .storage()
             .instance()
             .get(&DataKey::Admin)
             .unwrap_or_else(|| panic!("Not initialized"));
         admin.require_auth();
+        let key = DataKey::Whitelist(address.clone());
+        if whitelisted {
+            env.storage().instance().set(&key, &true);
+        } else {
+            env.storage().instance().remove(&key);
+        }
+        env.events().publish(
+            (WHITELIST_CHANGED,),
+            WhitelistChangedEvent {
+                version: EVENT_VERSION_V2,
+                address,
+                whitelisted,
+                admin,
+            },
+        );
+    }
+
+    /// Return whether `address` is currently present in the recipient whitelist.
+    pub fn is_whitelisted(env: Env, address: Address) -> bool {
+        Self::is_whitelisted_internal(&env, &address)
+    }
+
+    /// Enable or disable recipient whitelist enforcement for payouts.
+    ///
+    /// The default is disabled for backwards compatibility with existing
+    /// deployments and payout integrations.
+    pub fn set_whitelist_enforcement(env: Env, enabled: bool) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Not initialized"));
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::WhitelistEnforcementEnabled, &enabled);
+    }
+
+    /// Return whether recipient whitelist enforcement is currently enabled.
+    pub fn is_whitelist_enforcement_enabled(env: Env) -> bool {
+        Self::whitelist_enforcement_enabled(&env)
     }
 
     // ========================================================================
@@ -1446,6 +1521,13 @@ impl ProgramEscrowContract {
 
         // Validate sufficient balance — record failure before abort so the
         // circuit breaker can accumulate this as a known-bad condition.
+        for recipient in recipients.iter() {
+            if !Self::recipient_allowed_by_whitelist(&env, &recipient) {
+                reentrancy_guard::clear_entered(&env);
+                panic!("Recipient not whitelisted");
+            }
+        }
+
         if total_payout > program_data.remaining_balance {
             error_recovery::record_failure(
                 &env,
@@ -1588,6 +1670,11 @@ impl ProgramEscrowContract {
                 });
 
         program_data.authorized_payout_key.require_auth();
+
+        if !Self::recipient_allowed_by_whitelist(&env, &recipient) {
+            reentrancy_guard::clear_entered(&env);
+            panic!("Recipient not whitelisted");
+        }
 
         // Validate amount
         if amount <= 0 {

--- a/program-escrow/src/test_lifecycle.rs
+++ b/program-escrow/src/test_lifecycle.rs
@@ -285,6 +285,80 @@ fn test_active_batch_payout_allowed() {
     assert_eq!(token_client.balance(&r2), 20_000);
 }
 
+#[test]
+fn test_whitelist_set_unset_persists_state() {
+    let env = Env::default();
+    let (client, admin, _cid, _token_client) = setup_active_program(&env, 100_000);
+    client.initialize_contract(&admin);
+    let recipient = Address::generate(&env);
+
+    assert!(!client.is_whitelisted(&recipient));
+
+    client.set_whitelist(&recipient, &true);
+    assert!(client.is_whitelisted(&recipient));
+
+    client.set_whitelist(&recipient, &false);
+    assert!(!client.is_whitelisted(&recipient));
+}
+
+#[test]
+fn test_whitelist_enforcement_defaults_off_for_backward_compatibility() {
+    let env = Env::default();
+    let (client, _admin, _cid, token_client) = setup_active_program(&env, 100_000);
+    let recipient = Address::generate(&env);
+
+    assert!(!client.is_whitelist_enforcement_enabled());
+
+    let data = client.single_payout(&recipient, &10_000);
+    assert_eq!(data.remaining_balance, 90_000);
+    assert_eq!(token_client.balance(&recipient), 10_000);
+}
+
+#[test]
+#[should_panic(expected = "Recipient not whitelisted")]
+fn test_single_payout_rejects_unlisted_recipient_when_whitelist_enforced() {
+    let env = Env::default();
+    let (client, admin, _cid, _token_client) = setup_active_program(&env, 100_000);
+    client.initialize_contract(&admin);
+    client.set_whitelist_enforcement(&true);
+    let recipient = Address::generate(&env);
+
+    client.single_payout(&recipient, &10_000);
+}
+
+#[test]
+fn test_whitelisted_recipient_can_receive_single_payout_when_enforced() {
+    let env = Env::default();
+    let (client, admin, _cid, token_client) = setup_active_program(&env, 100_000);
+    client.initialize_contract(&admin);
+    let recipient = Address::generate(&env);
+
+    client.set_whitelist_enforcement(&true);
+    client.set_whitelist(&recipient, &true);
+
+    let data = client.single_payout(&recipient, &10_000);
+    assert_eq!(data.remaining_balance, 90_000);
+    assert_eq!(token_client.balance(&recipient), 10_000);
+}
+
+#[test]
+#[should_panic(expected = "Recipient not whitelisted")]
+fn test_batch_payout_rejects_any_unlisted_recipient_when_whitelist_enforced() {
+    let env = Env::default();
+    let (client, admin, _cid, _token_client) = setup_active_program(&env, 100_000);
+    client.initialize_contract(&admin);
+    let allowed = Address::generate(&env);
+    let blocked = Address::generate(&env);
+
+    client.set_whitelist_enforcement(&true);
+    client.set_whitelist(&allowed, &true);
+
+    client.batch_payout(
+        &vec![&env, allowed, blocked],
+        &vec![&env, 10_000i128, 10_000i128],
+    );
+}
+
 /// Multiple lock calls accumulate funds (top-up stays in Active state).
 #[test]
 fn test_active_top_up_lock_increases_balance() {


### PR DESCRIPTION
Closes #80.

Summary:
- Replaced the no-op `set_whitelist` entrypoint with admin-authenticated recipient whitelist storage.
- Added `is_whitelisted`, `set_whitelist_enforcement`, and `is_whitelist_enforcement_enabled` contract entrypoints.
- Kept enforcement disabled by default for backward compatibility, then gates `single_payout` and `batch_payout` recipients only when explicitly enabled.
- Emits a versioned `WListChg` event whenever whitelist state changes.
- Documented the recipient whitelist behavior in `docs/program-escrow/IMPLEMENTATION_SUMMARY.md`.

Validation:
- Added lifecycle tests for set/unset persistence, default-off compatibility, single-payout enforcement, whitelisted single payout, and batch rejection when any recipient is unlisted.
- Ran `git diff --check` successfully.
- `cargo` and `rustfmt` are unavailable in this environment, so Rust tests/formatting could not be executed locally.

Security notes:
- Only the configured contract admin can mutate whitelist state or toggle enforcement.
- Batch payouts pre-check all recipients before entering the token-transfer loop.
- Reentrancy guard is cleared before whitelist rejection panics.