### PR TITLE
fix(bounty_escrow): gate value transfers by governance version

### DIFF
--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -1303,19 +1303,14 @@ impl BountyEscrowContract {
         }
         let _start = env.ledger().timestamp();
 
-        // Ensure contract is initialized
-        if env.storage().instance().has(&DataKey::ReentrancyGuard) {
-            panic!("Reentrancy detected");
-        }
-        env.storage()
-            .instance()
-            .set(&DataKey::ReentrancyGuard, &true);
         if !env.storage().instance().has(&DataKey::Admin) {
             return Err(Error::NotInitialized);
         }
 
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
+
+        Self::check_governance_requirements(&env)?;
 
         if !env.storage().persistent().has(&DataKey::Escrow(bounty_id)) {
             return Err(Error::BountyNotFound);
@@ -1331,6 +1326,13 @@ impl BountyEscrowContract {
         if escrow.status != EscrowStatus::Locked {
             return Err(Error::FundsNotLocked);
         }
+
+        if env.storage().instance().has(&DataKey::ReentrancyGuard) {
+            panic!("Reentrancy detected");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyGuard, &true);
 
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let client = token::Client::new(&env, &token_addr);
@@ -1695,6 +1697,8 @@ impl BountyEscrowContract {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
 
+        Self::check_governance_requirements(&env)?;
+
         // Dispute protection: block partial releases while a dispute (pending claim) is open.
         if env
             .storage()
@@ -1827,6 +1831,8 @@ impl BountyEscrowContract {
         if let Err(_) = check_and_allow(&env) {
             return Err(Error::CircuitBreakerOpen);
         }
+
+        Self::check_governance_requirements(&env)?;
 
         let mut escrow = Self::load_refundable_escrow(&env, bounty_id)?;
 
@@ -1991,6 +1997,8 @@ impl BountyEscrowContract {
         if let Err(_) = check_and_allow(&env) {
             return Err(Error::CircuitBreakerOpen);
         }
+
+        Self::check_governance_requirements(&env)?;
 
         let batch_size = bounty_ids.len() as u32;
         if batch_size == 0 || batch_size > MAX_BATCH_SIZE {
@@ -2444,19 +2452,36 @@ impl BountyEscrowContract {
                 .persistent()
                 .get::<DataKey, Escrow>(&DataKey::Escrow(bounty_id))
             {
+                let mut refunded_total = 0_i128;
+                for j in 0..escrow.refund_history.len() {
+                    let refund = escrow.refund_history.get(j).unwrap();
+                    refunded_total = refunded_total.saturating_add(refund.amount);
+                }
+                if escrow.status == EscrowStatus::Refunded
+                    && refunded_total == 0
+                    && escrow.remaining_amount == 0
+                {
+                    refunded_total = escrow.amount;
+                }
+                let released_total = escrow
+                    .amount
+                    .saturating_sub(escrow.remaining_amount)
+                    .saturating_sub(refunded_total);
+
                 match escrow.status {
                     EscrowStatus::Locked | EscrowStatus::PartiallyRefunded => {
                         stats.total_locked += escrow.remaining_amount;
+                        stats.total_released += released_total;
+                        stats.total_refunded += refunded_total;
                         stats.count_locked += 1;
                     }
                     EscrowStatus::Released => {
-                        stats.total_released += escrow.amount;
+                        stats.total_released += released_total;
                         stats.count_released += 1;
                     }
                     EscrowStatus::Refunded => {
-                        // For refunded, we count the original amount in total_refunded
-                        // The actual refund amounts are tracked in refund_history
-                        stats.total_refunded += escrow.amount;
+                        stats.total_released += released_total;
+                        stats.total_refunded += refunded_total;
                         stats.count_refunded += 1;
                     }
                 }
@@ -2910,6 +2935,8 @@ impl BountyEscrowContract {
 
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
+
+        Self::check_governance_requirements(&env)?;
 
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let client = token::Client::new(&env, &token_addr);

--- a/bounty_escrow/contracts/escrow/src/proptest_invariants.rs
+++ b/bounty_escrow/contracts/escrow/src/proptest_invariants.rs
@@ -160,9 +160,6 @@ fn assert_invariants(
     let mut count_locked = 0_u32;
     let mut count_released = 0_u32;
     let mut count_refunded = 0_u32;
-    let mut stats_locked = 0_i128;
-    let mut stats_released = 0_i128;
-    let mut stats_refunded = 0_i128;
 
     for expected in model {
         let escrow = setup.escrow.get_escrow_info(&expected.id);
@@ -173,23 +170,15 @@ fn assert_invariants(
         prop_assert_eq!(actual_status, expected_status(expected.status));
 
         match escrow.status {
-            EscrowStatus::Locked => {
+            EscrowStatus::Locked | EscrowStatus::PartiallyRefunded => {
                 count_locked += 1;
-                stats_locked += escrow.amount;
                 active_contract_balance += escrow.remaining_amount;
             }
             EscrowStatus::Released => {
                 count_released += 1;
-                stats_released += escrow.amount;
             }
             EscrowStatus::Refunded => {
                 count_refunded += 1;
-                stats_refunded += escrow.amount;
-            }
-            EscrowStatus::PartiallyRefunded => {
-                count_refunded += 1;
-                stats_refunded += escrow.amount;
-                active_contract_balance += escrow.remaining_amount;
             }
         }
     }
@@ -198,9 +187,9 @@ fn assert_invariants(
     prop_assert_eq!(aggregate.count_locked, count_locked);
     prop_assert_eq!(aggregate.count_released, count_released);
     prop_assert_eq!(aggregate.count_refunded, count_refunded);
-    prop_assert_eq!(aggregate.total_locked, stats_locked);
-    prop_assert_eq!(aggregate.total_released, stats_released);
-    prop_assert_eq!(aggregate.total_refunded, stats_refunded);
+    prop_assert_eq!(aggregate.total_locked, active_contract_balance);
+    prop_assert_eq!(aggregate.total_released, totals.released);
+    prop_assert_eq!(aggregate.total_refunded, totals.refunded);
 
     let contract_balance = setup.escrow.get_balance();
     prop_assert_eq!(contract_balance, active_contract_balance);

--- a/bounty_escrow/contracts/escrow/src/test_governance_integration.rs
+++ b/bounty_escrow/contracts/escrow/src/test_governance_integration.rs
@@ -2,7 +2,10 @@
 
 use crate::{governance_integration, BountyEscrowContract, BountyEscrowContractClient, Error};
 use grainlify_core::{GrainlifyContract, GrainlifyContractClient};
-use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, vec, Address, BytesN, Env,
+};
 
 // Mock governance contract for testing
 mod mock_governance {
@@ -25,6 +28,32 @@ mod mock_governance {
             wasm_hash == BytesN::from_array(&env, &[7u8; 32])
         }
     }
+}
+
+fn setup_low_version_governed_escrow(
+) -> (Env, BountyEscrowContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let contributor = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin);
+    let token_addr = token_id.address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_addr);
+
+    client.init(&admin, &token_addr);
+    token_admin_client.mint(&depositor, &100_000);
+
+    let gov_contract_id = env.register_contract(None, mock_governance::MockGovernanceContract);
+    client.set_governance_contract(&gov_contract_id);
+    client.set_min_governance_version(&3);
+
+    (env, client, depositor, contributor)
 }
 
 #[test]
@@ -208,6 +237,53 @@ fn test_governance_version_too_low_blocks_fee_config_with_typed_error() {
 
     let result = client.try_update_fee_config(&Some(100), &None, &None, &None);
     assert_eq!(result, Err(Ok(Error::GovernanceVersionTooLow)));
+}
+
+#[test]
+fn test_governance_version_too_low_blocks_value_transfer_operations() {
+    let (env, client, depositor, contributor) = setup_low_version_governed_escrow();
+    env.ledger().set_timestamp(1_000);
+
+    let active_deadline = 10_000;
+    for bounty_id in 1..=5 {
+        client.lock_funds(&depositor, &bounty_id, &1_000, &active_deadline);
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp().saturating_add(61));
+    }
+
+    assert_eq!(
+        client.try_release_funds(&1, &contributor),
+        Err(Ok(Error::GovernanceVersionTooLow))
+    );
+    assert_eq!(
+        client.try_partial_release(&2, &contributor, &500),
+        Err(Ok(Error::GovernanceVersionTooLow))
+    );
+
+    env.ledger().set_timestamp(active_deadline + 1);
+
+    assert_eq!(
+        client.try_refund(&3),
+        Err(Ok(Error::GovernanceVersionTooLow))
+    );
+
+    let sweep_ids = vec![&env, 4_u64];
+    assert_eq!(
+        client.try_sweep_expired_refunds(&sweep_ids),
+        Err(Ok(Error::GovernanceVersionTooLow))
+    );
+
+    let release_items = vec![
+        &env,
+        crate::ReleaseFundsItem {
+            bounty_id: 5,
+            contributor,
+        },
+    ];
+    assert_eq!(
+        client.try_batch_release_funds(&release_items),
+        Err(Ok(Error::GovernanceVersionTooLow))
+    );
 }
 
 #[test]

--- a/docs/GOVERNANCE_INTEGRATION.md
+++ b/docs/GOVERNANCE_INTEGRATION.md
@@ -100,6 +100,11 @@ The following admin operations now check governance requirements:
 - `set_paused()` - Pause/unpause operations
 - `update_fee_config()` - Fee configuration
 - `update_multisig_config()` - Multisig configuration
+- `release_funds()` - Direct admin-authorized value transfer to a contributor
+- `partial_release()` - Partial admin-authorized value transfer to a contributor
+- `refund()` - Refund transfer path
+- `sweep_expired_refunds()` - Batch expired-refund transfer path
+- `batch_release_funds()` - Batch admin-authorized value transfer to contributors
 
 ### Governance Check Flow
 


### PR DESCRIPTION
## Summary
- gate `release_funds`, `partial_release`, `refund`, `sweep_expired_refunds`, and `batch_release_funds` with the existing governance version requirement when governance is configured
- keep no-governance behavior unchanged and avoid leaving the reentrancy guard set on early `release_funds` validation errors
- add regression coverage for value-transfer operations blocked by `GovernanceVersionTooLow`
- update governance docs and align aggregate full-scan/proptest accounting for partial release/refund flows so the package test suite passes

Closes #79

## Validation
- `cargo test -p bounty-escrow test_governance_integration`
- `cargo test -p bounty-escrow test_analytics_monitoring::test_counters_match_full_scan_after_partial_release`
- `cargo test -p bounty-escrow test_analytics_monitoring::test_counters_match_full_scan_after_partial_refund`
- `cargo test -p bounty-escrow proptest_invariants::proptest_invariant_smoke_exercises_lifecycle_entrypoints`
- `cargo test -p bounty-escrow` (329 passed)
- `git diff --check`

## Notes
- The governance check is still a no-op unless a governance contract is configured, preserving current deployments without governance wiring.
- The full package test run emits existing warnings, but no test failures remain.