### PR TITLE
test(bounty_escrow): add query pagination property tests

### DIFF
--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -2463,13 +2463,12 @@ impl BountyEscrowContract {
                         stats.count_released += 1;
                     }
                     EscrowStatus::Refunded => {
-                        let final_refunded_amount = if refunded_amount > 0 {
-                            refunded_amount
+                        if refunded_amount > 0 {
+                            stats.total_released += released_amount;
+                            stats.total_refunded += refunded_amount;
                         } else {
-                            escrow.amount.saturating_sub(released_amount)
-                        };
-                        stats.total_released += escrow.amount.saturating_sub(final_refunded_amount);
-                        stats.total_refunded += final_refunded_amount;
+                            stats.total_refunded += settled_amount;
+                        }
                         stats.count_refunded += 1;
                     }
                 }

--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -2444,9 +2444,18 @@ impl BountyEscrowContract {
                 .persistent()
                 .get::<DataKey, Escrow>(&DataKey::Escrow(bounty_id))
             {
+                let mut refunded_amount = 0_i128;
+                for refund in escrow.refund_history.iter() {
+                    refunded_amount = refunded_amount.saturating_add(refund.amount);
+                }
+                let settled_amount = escrow.amount.saturating_sub(escrow.remaining_amount);
+                let released_amount = settled_amount.saturating_sub(refunded_amount);
+
                 match escrow.status {
                     EscrowStatus::Locked | EscrowStatus::PartiallyRefunded => {
                         stats.total_locked += escrow.remaining_amount;
+                        stats.total_released += released_amount;
+                        stats.total_refunded += refunded_amount;
                         stats.count_locked += 1;
                     }
                     EscrowStatus::Released => {
@@ -2454,9 +2463,13 @@ impl BountyEscrowContract {
                         stats.count_released += 1;
                     }
                     EscrowStatus::Refunded => {
-                        // For refunded, we count the original amount in total_refunded
-                        // The actual refund amounts are tracked in refund_history
-                        stats.total_refunded += escrow.amount;
+                        let final_refunded_amount = if refunded_amount > 0 {
+                            refunded_amount
+                        } else {
+                            escrow.amount.saturating_sub(released_amount)
+                        };
+                        stats.total_released += escrow.amount.saturating_sub(final_refunded_amount);
+                        stats.total_refunded += final_refunded_amount;
                         stats.count_refunded += 1;
                     }
                 }

--- a/bounty_escrow/contracts/escrow/src/proptest_invariants.rs
+++ b/bounty_escrow/contracts/escrow/src/proptest_invariants.rs
@@ -2,14 +2,17 @@
 
 extern crate std;
 
-use crate::{BountyEscrowContract, BountyEscrowContractClient, EscrowStatus, RefundMode};
+use crate::{
+    BountyEscrowContract, BountyEscrowContractClient, EscrowQueryFilter, EscrowStatus,
+    EscrowWithId, RefundMode,
+};
 use proptest::prelude::*;
 use proptest::test_runner::{Config as ProptestConfig, TestCaseError, TestRng, TestRunner};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
-    token, Address, Env,
+    token, Address, Env, Vec as SorobanVec,
 };
-use std::format;
+use std::{collections::BTreeSet, format};
 
 const CASES: u32 = 16;
 const MAX_SHRINK_ITERS: u32 = 64;
@@ -20,6 +23,14 @@ const MAX_FEE_RATE: i128 = 5_000;
 struct LifecycleOp {
     kind: u8,
     selector: usize,
+    amount: i128,
+    deadline_delta: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PaginationEscrowSpec {
+    depositor_slot: u8,
+    transition: u8,
     amount: i128,
     deadline_delta: u64,
 }
@@ -39,6 +50,15 @@ struct ModelEscrow {
     remaining: i128,
     deadline: u64,
     status: ModelStatus,
+}
+
+#[derive(Clone, Debug)]
+struct PaginationModelEscrow {
+    id: u64,
+    amount: i128,
+    deadline: u64,
+    status: EscrowStatus,
+    depositor_slot: u8,
 }
 
 struct ModelTotals {
@@ -109,6 +129,20 @@ fn op_strategy() -> impl Strategy<Value = LifecycleOp> {
     )
 }
 
+fn pagination_spec_strategy() -> impl Strategy<Value = std::vec::Vec<PaginationEscrowSpec>> {
+    proptest::collection::vec(
+        (0_u8..=1, 0_u8..=3, 2_i128..=50_000, 1_u64..=600).prop_map(
+            |(depositor_slot, transition, amount, deadline_delta)| PaginationEscrowSpec {
+                depositor_slot,
+                transition,
+                amount,
+                deadline_delta,
+            },
+        ),
+        4..=14,
+    )
+}
+
 fn proptest_config() -> ProptestConfig {
     ProptestConfig {
         cases: CASES,
@@ -160,9 +194,6 @@ fn assert_invariants(
     let mut count_locked = 0_u32;
     let mut count_released = 0_u32;
     let mut count_refunded = 0_u32;
-    let mut stats_locked = 0_i128;
-    let mut stats_released = 0_i128;
-    let mut stats_refunded = 0_i128;
 
     for expected in model {
         let escrow = setup.escrow.get_escrow_info(&expected.id);
@@ -175,20 +206,16 @@ fn assert_invariants(
         match escrow.status {
             EscrowStatus::Locked => {
                 count_locked += 1;
-                stats_locked += escrow.amount;
                 active_contract_balance += escrow.remaining_amount;
             }
             EscrowStatus::Released => {
                 count_released += 1;
-                stats_released += escrow.amount;
             }
             EscrowStatus::Refunded => {
                 count_refunded += 1;
-                stats_refunded += escrow.amount;
             }
             EscrowStatus::PartiallyRefunded => {
-                count_refunded += 1;
-                stats_refunded += escrow.amount;
+                count_locked += 1;
                 active_contract_balance += escrow.remaining_amount;
             }
         }
@@ -198,9 +225,9 @@ fn assert_invariants(
     prop_assert_eq!(aggregate.count_locked, count_locked);
     prop_assert_eq!(aggregate.count_released, count_released);
     prop_assert_eq!(aggregate.count_refunded, count_refunded);
-    prop_assert_eq!(aggregate.total_locked, stats_locked);
-    prop_assert_eq!(aggregate.total_released, stats_released);
-    prop_assert_eq!(aggregate.total_refunded, stats_refunded);
+    prop_assert_eq!(aggregate.total_locked, active_contract_balance);
+    prop_assert_eq!(aggregate.total_released, totals.released);
+    prop_assert_eq!(aggregate.total_refunded, totals.refunded);
 
     let contract_balance = setup.escrow.get_balance();
     prop_assert_eq!(contract_balance, active_contract_balance);
@@ -214,6 +241,370 @@ fn assert_invariants(
         setup.token.balance(&setup.depositor),
         totals.minted - totals.locked + totals.refunded
     );
+
+    Ok(())
+}
+
+fn escrow_with_id_ids(page: SorobanVec<EscrowWithId>) -> std::vec::Vec<u64> {
+    let mut ids = std::vec::Vec::with_capacity(page.len() as usize);
+    for i in 0..page.len() {
+        ids.push(page.get(i).unwrap().bounty_id);
+    }
+    ids
+}
+
+fn u64_vec_ids(page: SorobanVec<u64>) -> std::vec::Vec<u64> {
+    let mut ids = std::vec::Vec::with_capacity(page.len() as usize);
+    for i in 0..page.len() {
+        ids.push(page.get(i).unwrap());
+    }
+    ids
+}
+
+fn assert_no_duplicate_ids(ids: &[u64]) -> Result<(), TestCaseError> {
+    let mut seen = BTreeSet::new();
+    for id in ids {
+        prop_assert!(seen.insert(*id), "duplicate id {id}");
+    }
+    Ok(())
+}
+
+/// Proves a paginated query is stable, non-overlapping, and complete.
+///
+/// The expected IDs are the ground truth derived from the generated model. The
+/// first query with `limit > total` also validates the contract's unpaginated
+/// scan against that model before walking fixed-size pages.
+fn assert_paginated_ids<F>(expected_ids: &[u64], mut query: F) -> Result<(), TestCaseError>
+where
+    F: FnMut(u32, u32) -> std::vec::Vec<u64>,
+{
+    let total = expected_ids.len() as u32;
+    let over_limit = total.saturating_add(5).max(1);
+
+    prop_assert!(
+        query(0, 0).is_empty(),
+        "limit 0 must always return an empty page"
+    );
+    prop_assert!(
+        query(total, 1).is_empty(),
+        "offset equal to total must return an empty page"
+    );
+    prop_assert!(
+        query(total.saturating_add(5), 3).is_empty(),
+        "offset greater than total must return an empty page"
+    );
+
+    let full_scan = query(0, over_limit);
+    prop_assert_eq!(full_scan.as_slice(), expected_ids);
+    assert_no_duplicate_ids(&full_scan)?;
+
+    for limit in [1_u32, 2, 3, 5, over_limit] {
+        let mut offset = 0_u32;
+        let mut stitched = std::vec::Vec::new();
+
+        loop {
+            let page = query(offset, limit);
+            let repeated_page = query(offset, limit);
+            prop_assert_eq!(
+                page.as_slice(),
+                repeated_page.as_slice(),
+                "same page must be stable across repeated reads"
+            );
+            prop_assert!(
+                page.len() <= limit as usize,
+                "page length must not exceed limit"
+            );
+            assert_no_duplicate_ids(&page)?;
+
+            for id in &page {
+                prop_assert!(
+                    !stitched.contains(id),
+                    "id {id} appeared in more than one page"
+                );
+            }
+
+            if page.is_empty() {
+                break;
+            }
+
+            stitched.extend(page);
+            offset = offset.saturating_add(limit);
+
+            if offset > total.saturating_add(limit) {
+                break;
+            }
+        }
+
+        prop_assert_eq!(stitched, expected_ids);
+    }
+
+    Ok(())
+}
+
+fn model_ids_by_status(
+    model: &[PaginationModelEscrow],
+    status: &EscrowStatus,
+) -> std::vec::Vec<u64> {
+    model
+        .iter()
+        .filter_map(|escrow| (escrow.status == *status).then_some(escrow.id))
+        .collect()
+}
+
+fn model_ids_by_amount(
+    model: &[PaginationModelEscrow],
+    min_amount: i128,
+    max_amount: i128,
+) -> std::vec::Vec<u64> {
+    model
+        .iter()
+        .filter_map(|escrow| {
+            (escrow.amount >= min_amount && escrow.amount <= max_amount).then_some(escrow.id)
+        })
+        .collect()
+}
+
+fn model_ids_by_deadline(
+    model: &[PaginationModelEscrow],
+    min_deadline: u64,
+    max_deadline: u64,
+) -> std::vec::Vec<u64> {
+    model
+        .iter()
+        .filter_map(|escrow| {
+            (escrow.deadline >= min_deadline && escrow.deadline <= max_deadline)
+                .then_some(escrow.id)
+        })
+        .collect()
+}
+
+fn model_ids_by_depositor_slot(
+    model: &[PaginationModelEscrow],
+    depositor_slot: u8,
+) -> std::vec::Vec<u64> {
+    model
+        .iter()
+        .filter_map(|escrow| (escrow.depositor_slot == depositor_slot).then_some(escrow.id))
+        .collect()
+}
+
+fn model_ids_by_composite_filter(
+    model: &[PaginationModelEscrow],
+    depositor_slot: u8,
+    status: &EscrowStatus,
+    min_amount: i128,
+    max_deadline: u64,
+) -> std::vec::Vec<u64> {
+    model
+        .iter()
+        .filter_map(|escrow| {
+            (escrow.depositor_slot == depositor_slot
+                && escrow.status == *status
+                && escrow.amount >= min_amount
+                && escrow.deadline <= max_deadline)
+                .then_some(escrow.id)
+        })
+        .collect()
+}
+
+fn model_expiring_ids(model: &[PaginationModelEscrow], max_deadline: u64) -> std::vec::Vec<u64> {
+    model
+        .iter()
+        .filter_map(|escrow| {
+            ((escrow.status == EscrowStatus::Locked
+                || escrow.status == EscrowStatus::PartiallyRefunded)
+                && escrow.deadline <= max_deadline)
+                .then_some(escrow.id)
+        })
+        .collect()
+}
+
+fn generated_pagination_model(
+    setup: &TestSetup<'_>,
+    specs: &[PaginationEscrowSpec],
+) -> (Address, std::vec::Vec<PaginationModelEscrow>) {
+    let alternate_depositor = Address::generate(&setup.env);
+    let mut model = std::vec::Vec::with_capacity(specs.len());
+    let mut release_ids = std::vec::Vec::new();
+    let mut partial_refunds = std::vec::Vec::new();
+    let mut deadline_refund_ids = std::vec::Vec::new();
+
+    for (idx, spec) in specs.iter().enumerate() {
+        let id = 20_000_u64 + idx as u64;
+        let depositor = if spec.depositor_slot == 0 {
+            setup.depositor.clone()
+        } else {
+            alternate_depositor.clone()
+        };
+
+        setup.token_admin.mint(&depositor, &spec.amount);
+        setup
+            .env
+            .ledger()
+            .set_timestamp(setup.env.ledger().timestamp().saturating_add(61));
+        let deadline = setup
+            .env
+            .ledger()
+            .timestamp()
+            .saturating_add(spec.deadline_delta)
+            .saturating_add(1);
+
+        setup
+            .escrow
+            .lock_funds(&depositor, &id, &spec.amount, &deadline);
+
+        let status = match spec.transition {
+            1 => {
+                release_ids.push(id);
+                EscrowStatus::Released
+            }
+            2 => {
+                deadline_refund_ids.push(id);
+                EscrowStatus::Refunded
+            }
+            3 => {
+                partial_refunds.push((id, spec.amount / 2, depositor.clone()));
+                EscrowStatus::PartiallyRefunded
+            }
+            _ => EscrowStatus::Locked,
+        };
+
+        model.push(PaginationModelEscrow {
+            id,
+            amount: spec.amount,
+            deadline,
+            status,
+            depositor_slot: spec.depositor_slot,
+        });
+    }
+
+    for id in release_ids {
+        setup.escrow.release_funds(&id, &setup.contributor);
+    }
+
+    for (id, refund_amount, depositor) in partial_refunds {
+        setup
+            .escrow
+            .approve_refund(&id, &refund_amount, &depositor, &RefundMode::Partial);
+        setup.escrow.refund(&id);
+    }
+
+    let refund_timestamp = model
+        .iter()
+        .map(|escrow| escrow.deadline)
+        .max()
+        .unwrap_or_else(|| setup.env.ledger().timestamp())
+        .saturating_add(1);
+    setup.env.ledger().set_timestamp(refund_timestamp);
+
+    for id in deadline_refund_ids {
+        setup.escrow.refund(&id);
+    }
+
+    (alternate_depositor, model)
+}
+
+fn assert_query_pagination_properties(
+    specs: std::vec::Vec<PaginationEscrowSpec>,
+) -> Result<(), TestCaseError> {
+    let setup = TestSetup::new();
+    let (alternate_depositor, model) = generated_pagination_model(&setup, &specs);
+    let max_model_amount = model.iter().map(|escrow| escrow.amount).max().unwrap_or(0);
+    let min_model_deadline = model
+        .iter()
+        .map(|escrow| escrow.deadline)
+        .min()
+        .unwrap_or(0);
+    let max_model_deadline = model
+        .iter()
+        .map(|escrow| escrow.deadline)
+        .max()
+        .unwrap_or(0);
+    let mid_deadline = min_model_deadline
+        .saturating_add(max_model_deadline.saturating_sub(min_model_deadline) / 2);
+    let min_amount = 2_i128;
+    let max_amount = (max_model_amount / 2).max(min_amount);
+
+    let locked = EscrowStatus::Locked;
+    let released = EscrowStatus::Released;
+    let partially_refunded = EscrowStatus::PartiallyRefunded;
+
+    let expected_locked = model_ids_by_status(&model, &locked);
+    assert_paginated_ids(&expected_locked, |offset, limit| {
+        escrow_with_id_ids(
+            setup
+                .escrow
+                .query_escrows_by_status(&locked, &offset, &limit),
+        )
+    })?;
+
+    let expected_released_ids = model_ids_by_status(&model, &released);
+    assert_paginated_ids(&expected_released_ids, |offset, limit| {
+        u64_vec_ids(
+            setup
+                .escrow
+                .get_escrow_ids_by_status(&released, &offset, &limit),
+        )
+    })?;
+
+    let expected_by_amount = model_ids_by_amount(&model, min_amount, max_amount);
+    assert_paginated_ids(&expected_by_amount, |offset, limit| {
+        escrow_with_id_ids(setup.escrow.query_escrows_by_amount(
+            &min_amount,
+            &max_amount,
+            &offset,
+            &limit,
+        ))
+    })?;
+
+    let expected_by_deadline = model_ids_by_deadline(&model, min_model_deadline, mid_deadline);
+    assert_paginated_ids(&expected_by_deadline, |offset, limit| {
+        escrow_with_id_ids(setup.escrow.query_escrows_by_deadline(
+            &min_model_deadline,
+            &mid_deadline,
+            &offset,
+            &limit,
+        ))
+    })?;
+
+    let expected_by_depositor = model_ids_by_depositor_slot(&model, 1);
+    assert_paginated_ids(&expected_by_depositor, |offset, limit| {
+        escrow_with_id_ids(setup.escrow.query_escrows_by_depositor(
+            &alternate_depositor,
+            &offset,
+            &limit,
+        ))
+    })?;
+
+    let composite_filter = EscrowQueryFilter {
+        has_status_filter: true,
+        status: partially_refunded.clone(),
+        has_depositor_filter: true,
+        depositor: setup.depositor.clone(),
+        min_amount,
+        max_amount: i128::MAX,
+        min_deadline: 0,
+        max_deadline: mid_deadline,
+    };
+    let expected_composite =
+        model_ids_by_composite_filter(&model, 0, &partially_refunded, min_amount, mid_deadline);
+    assert_paginated_ids(&expected_composite, |offset, limit| {
+        escrow_with_id_ids(
+            setup
+                .escrow
+                .query_escrows(&composite_filter, &offset, &limit),
+        )
+    })?;
+
+    let expiring_cutoff = mid_deadline.max(min_model_deadline);
+    let expected_expiring = model_expiring_ids(&model, expiring_cutoff);
+    assert_paginated_ids(&expected_expiring, |offset, limit| {
+        u64_vec_ids(
+            setup
+                .escrow
+                .query_expiring_bounties(&expiring_cutoff, &offset, &limit),
+        )
+    })?;
 
     Ok(())
 }
@@ -467,4 +858,16 @@ fn proptest_fee_basis_points_do_not_overflow_or_exceed_principal() {
             Ok(())
         })
         .expect("basis-point fee properties should hold");
+}
+
+#[test]
+fn proptest_query_pagination_invariants_cover_edge_limits_and_offsets() {
+    let mut runner = deterministic_runner();
+
+    runner
+        .run(
+            &pagination_spec_strategy(),
+            assert_query_pagination_properties,
+        )
+        .expect("query pagination properties should hold");
 }

--- a/bounty_escrow/contracts/escrow/src/test_analytics_monitoring.rs
+++ b/bounty_escrow/contracts/escrow/src/test_analytics_monitoring.rs
@@ -19,10 +19,13 @@
 /// * `get_refund_history`    – history vector is populated by approved-refund path
 /// * Monitoring event emission – lock/release/refund each emit ≥ 1 event
 /// * Error flows             – failed attempts do not corrupt metrics
-use crate::{BountyEscrowContract, BountyEscrowContractClient, EscrowStatus, RefundMode, LockFundsItem, ReleaseFundsItem};
+use crate::{
+    BountyEscrowContract, BountyEscrowContractClient, DataKey, Escrow, EscrowStatus,
+    LockFundsItem, RefundMode, ReleaseFundsItem,
+};
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
-    token, Address, Env,
+    token, vec, Address, Env,
 };
 
 // ---------------------------------------------------------------------------
@@ -1275,6 +1278,42 @@ fn test_counters_match_full_scan_after_partial_refund() {
         counter_stats, full_scan_stats,
         "O(1) counters must match O(N) full scan after partial refund"
     );
+}
+
+#[test]
+fn test_full_scan_legacy_refund_without_history_counts_as_refunded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let (token, token_admin) = create_token_contract(&env, &admin);
+    let escrow = create_escrow_contract(&env);
+    escrow.init(&admin, &token.address);
+    token_admin.mint(&depositor, &1_000_000);
+
+    let deadline = env.ledger().timestamp() + 500;
+    escrow.lock_funds(&depositor, &305, &1_000, &deadline);
+
+    env.as_contract(&escrow.address, || {
+        env.storage().persistent().set(
+            &DataKey::Escrow(305),
+            &Escrow {
+                depositor,
+                amount: 1_000,
+                remaining_amount: 0,
+                status: EscrowStatus::Refunded,
+                deadline,
+                refund_history: vec![&env],
+            },
+        );
+    });
+
+    let full_scan_stats = escrow.get_aggregate_stats_full_scan();
+
+    assert_eq!(full_scan_stats.total_locked, 0);
+    assert_eq!(full_scan_stats.total_released, 0);
+    assert_eq!(full_scan_stats.total_refunded, 1_000);
+    assert_eq!(full_scan_stats.count_refunded, 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add generated proptest coverage for bounty escrow pagination invariants across status, amount, deadline, depositor-index, composite, ID-only, and expiring-bounty query paths.
- Assert stable repeated reads, non-overlapping pages, complete page unions, `limit == 0`, `offset >= total`, and `limit > total` edge cases.
- Fix full-scan aggregate accounting for partial releases/refunds so the existing O(1) counter reconciliation tests and lifecycle proptest model match the contract semantics.

Closes #85

## Security notes

- The new pagination checks exercise read-only query surfaces and do not relax authorization or mutate contract state outside test setup.
- The aggregate full-scan change is confined to the read-only reconciliation view and reconstructs partial settlement totals from `remaining_amount` plus `refund_history`.

## Verification

```text
cd bounty_escrow/contracts/escrow
cargo test

329 passed; 0 failed
```