### PR TITLE
feat(bounty_escrow): add emergency global pause

### DIFF
--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -451,6 +451,7 @@ pub struct EscrowWithId {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PauseFlags {
+    pub global_paused: bool,
     pub lock_paused: bool,
     pub release_paused: bool,
     pub refund_paused: bool,
@@ -636,9 +637,9 @@ impl BountyEscrowContract {
     }
 
     // ==================== INCREMENTAL AGGREGATE COUNTERS ====================
-    
+
     /// Get the current aggregate counters, initializing to zero if not present.
-    /// 
+    ///
     /// These counters are maintained incrementally on every state transition
     /// (lock, release, refund, partial_release) to provide O(1) aggregate queries.
     fn get_counters(env: &Env) -> AggregateStats {
@@ -668,7 +669,7 @@ impl BountyEscrowContract {
     }
 
     /// Increment counters when a new bounty is locked.
-    /// 
+    ///
     /// This is called from `lock_funds` and `batch_lock_funds`.
     /// Adds the amount to total_locked and increments count_locked.
     fn increment_locked(env: &Env, amount: i128) {
@@ -679,7 +680,7 @@ impl BountyEscrowContract {
     }
 
     /// Transition a bounty from Locked to Released.
-    /// 
+    ///
     /// Called from `release_funds`, `batch_release_funds`, and `claim`.
     /// Decrements locked counters and increments released counters.
     fn transition_locked_to_released(env: &Env, amount: i128) {
@@ -692,7 +693,7 @@ impl BountyEscrowContract {
     }
 
     /// Transition a bounty from Locked to Refunded.
-    /// 
+    ///
     /// Called from `refund` and `sweep_expired_refunds` when the full amount is refunded.
     /// Decrements locked counters and increments refunded counters.
     fn transition_locked_to_refunded(env: &Env, amount: i128) {
@@ -705,7 +706,7 @@ impl BountyEscrowContract {
     }
 
     /// Transition a bounty from Locked to PartiallyRefunded.
-    /// 
+    ///
     /// Called from `refund` when a partial refund is performed.
     /// The bounty remains in the locked bucket but total_locked is reduced by the refunded amount.
     /// Total_refunded tracks the cumulative refunded amount.
@@ -718,7 +719,7 @@ impl BountyEscrowContract {
     }
 
     /// Transition a bounty from PartiallyRefunded to Refunded.
-    /// 
+    ///
     /// Called from `refund` when the final refund completes a partially refunded bounty.
     /// Decrements locked count and increments refunded count.
     fn transition_partially_refunded_to_refunded(env: &Env, final_refund_amount: i128) {
@@ -731,7 +732,7 @@ impl BountyEscrowContract {
     }
 
     /// Handle partial release from a Locked bounty.
-    /// 
+    ///
     /// Called from `partial_release`. Reduces total_locked by the released amount
     /// and adds to total_released. If the bounty transitions to Released status
     /// after this partial release (remaining_amount == 0), the caller must also
@@ -744,7 +745,7 @@ impl BountyEscrowContract {
     }
 
     /// Finalize a partial release that transitions the bounty to Released.
-    /// 
+    ///
     /// Called from `partial_release` when remaining_amount reaches zero.
     /// Decrements locked count and increments released count.
     fn finalize_partial_release_to_released(env: &Env) {
@@ -922,12 +923,44 @@ impl BountyEscrowContract {
         Ok(())
     }
 
+    /// Set or clear the admin-only emergency pause kill switch.
+    ///
+    /// When enabled, every value-moving escrow entrypoint is halted with
+    /// `Error::FundsPaused` while read/query functions remain available.
+    pub fn set_emergency_pause(env: Env, paused: bool) -> Result<(), Error> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::NotInitialized);
+        }
+
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+
+        // Check governance requirements before changing incident controls.
+        Self::check_governance_requirements(&env)?;
+
+        let mut flags = Self::get_pause_flags(&env);
+        flags.global_paused = paused;
+
+        events::emit_pause_state_changed(
+            &env,
+            PauseStateChanged {
+                operation: symbol_short!("global"),
+                paused,
+                admin: admin.clone(),
+            },
+        );
+
+        env.storage().instance().set(&DataKey::PauseFlags, &flags);
+        Ok(())
+    }
+
     /// Get current pause flags
     pub fn get_pause_flags(env: &Env) -> PauseFlags {
         env.storage()
             .instance()
             .get(&DataKey::PauseFlags)
             .unwrap_or(PauseFlags {
+                global_paused: false,
                 lock_paused: false,
                 release_paused: false,
                 refund_paused: false,
@@ -937,6 +970,9 @@ impl BountyEscrowContract {
     /// Check if an operation is paused
     fn check_paused(env: &Env, operation: Symbol) -> bool {
         let flags = Self::get_pause_flags(env);
+        if flags.global_paused {
+            return true;
+        }
         if operation == symbol_short!("lock") {
             return flags.lock_paused;
         } else if operation == symbol_short!("release") {
@@ -1015,6 +1051,7 @@ impl BountyEscrowContract {
                 fee_enabled: false,
             };
             let pause_flags = PauseFlags {
+                global_paused: false,
                 lock_paused: false,
                 release_paused: false,
                 refund_paused: false,
@@ -1683,6 +1720,10 @@ impl BountyEscrowContract {
         contributor: Address,
         payout_amount: i128,
     ) -> Result<(), Error> {
+        if Self::check_paused(&env, symbol_short!("release")) {
+            return Err(Error::FundsPaused);
+        }
+
         if !env.storage().instance().has(&DataKey::Admin) {
             return Err(Error::NotInitialized);
         }
@@ -2404,23 +2445,23 @@ impl BountyEscrowContract {
     }
 
     /// Get aggregate statistics from O(1) incremental counters.
-    /// 
+    ///
     /// This function reads maintained counters that are updated on every state transition
     /// (lock, release, refund, partial_release). Provides constant-time aggregate queries.
-    /// 
-    /// For verification purposes, use `get_aggregate_stats_full_scan` to perform a 
+    ///
+    /// For verification purposes, use `get_aggregate_stats_full_scan` to perform a
     /// ground-truth comparison.
     pub fn get_aggregate_stats(env: Env) -> AggregateStats {
         Self::get_counters(&env)
     }
 
     /// Get aggregate statistics via full O(N) scan for reconciliation and testing.
-    /// 
+    ///
     /// This function performs a complete scan of all escrows to calculate aggregate
     /// statistics from scratch. Use this to verify the incremental counters are accurate
     /// or when counters need to be rebuilt.
-    /// 
-    /// **Performance:** O(N) where N is the number of bounties. Not suitable for 
+    ///
+    /// **Performance:** O(N) where N is the number of bounties. Not suitable for
     /// production queries at scale.
     pub fn get_aggregate_stats_full_scan(env: Env) -> AggregateStats {
         let index: Vec<u64> = env
@@ -3044,7 +3085,7 @@ impl BountyEscrowContract {
     /// - Total released amount
     /// - Total refunded amount
     /// - Average bounty size
-    /// 
+    ///
     /// This function uses O(1) incremental counters for efficiency.
     pub fn get_contract_analytics(env: Env) -> ContractAnalytics {
         let stats = Self::get_counters(&env);
@@ -3093,7 +3134,7 @@ impl BountyEscrowContract {
     /// # Returns
     /// Number of bounties in the specified status
     /// Count bounties by status using O(1) incremental counters.
-    /// 
+    ///
     /// For Locked status, this includes both Locked and PartiallyRefunded bounties.
     /// For other statuses, only exact matches are counted.
     pub fn count_bounties_by_status(env: Env, status: EscrowStatus) -> u32 {
@@ -3111,7 +3152,7 @@ impl BountyEscrowContract {
     }
 
     /// Count bounties by status via full O(N) scan for exact status matching.
-    /// 
+    ///
     /// Use this when you need to distinguish between Locked and PartiallyRefunded,
     /// or for verification purposes.
     pub fn count_by_status_full_scan(env: Env, status: EscrowStatus) -> u32 {
@@ -3138,7 +3179,7 @@ impl BountyEscrowContract {
     }
 
     /// Get total volume of funds by status using O(1) incremental counters.
-    /// 
+    ///
     /// Returns the sum of all funds in bounties with the specified status.
     pub fn get_volume_by_status(env: Env, status: EscrowStatus) -> i128 {
         let stats = Self::get_counters(&env);
@@ -3155,7 +3196,7 @@ impl BountyEscrowContract {
     }
 
     /// Get total volume of funds by status via full O(N) scan.
-    /// 
+    ///
     /// Use this for exact status matching or verification.
     pub fn volume_by_status_full_scan(env: Env, status: EscrowStatus) -> i128 {
         let index: Vec<u64> = env

--- a/bounty_escrow/contracts/escrow/src/test_granular_pause.rs
+++ b/bounty_escrow/contracts/escrow/src/test_granular_pause.rs
@@ -97,9 +97,149 @@ fn test_default_all_flags_false() {
     let (client, _, _, _) = setup(&env, 0);
 
     let flags = client.get_pause_flags();
+    assert!(!flags.global_paused);
     assert!(!flags.lock_paused);
     assert!(!flags.release_paused);
     assert!(!flags.refund_paused);
+}
+
+// ---------------------------------------------------------------------------
+// § 1b  Emergency global pause — every value-moving entrypoint blocked
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_emergency_pause_blocks_lock_and_batch_lock() {
+    let env = Env::default();
+    let (client, _, depositor, _) = setup(&env, 1_000);
+
+    client.set_emergency_pause(&true);
+
+    let deadline = env.ledger().timestamp() + 1_000;
+    assert_eq!(
+        client.try_lock_funds(&depositor, &1, &100, &deadline),
+        Err(Ok(Error::FundsPaused))
+    );
+
+    let items = soroban_sdk::vec![
+        &env,
+        LockFundsItem {
+            bounty_id: 2,
+            depositor: depositor.clone(),
+            amount: 100,
+            deadline,
+        }
+    ];
+    assert_eq!(
+        client.try_batch_lock_funds(&items),
+        Err(Ok(Error::FundsPaused))
+    );
+}
+
+#[test]
+fn test_emergency_pause_blocks_release_claim_partial_and_batch_release() {
+    let env = Env::default();
+    let (client, _, depositor, _) = setup(&env, 2_000);
+    let contributor = Address::generate(&env);
+
+    lock_bounty(&client, &env, &depositor, 1, 200);
+    lock_bounty(&client, &env, &depositor, 2, 300);
+    lock_bounty(&client, &env, &depositor, 3, 400);
+    client.set_claim_window(&500);
+    client.authorize_claim(&3, &contributor);
+
+    client.set_emergency_pause(&true);
+
+    assert_eq!(
+        client.try_release_funds(&1, &contributor),
+        Err(Ok(Error::FundsPaused))
+    );
+    assert_eq!(
+        client.try_partial_release(&1, &contributor, &50),
+        Err(Ok(Error::FundsPaused))
+    );
+
+    let batch = soroban_sdk::vec![
+        &env,
+        ReleaseFundsItem {
+            bounty_id: 2,
+            contributor: contributor.clone(),
+        }
+    ];
+    assert_eq!(
+        client.try_batch_release_funds(&batch),
+        Err(Ok(Error::FundsPaused))
+    );
+    assert_eq!(client.try_claim(&3), Err(Ok(Error::FundsPaused)));
+}
+
+#[test]
+fn test_emergency_pause_blocks_refund_and_sweep_but_keeps_queries_live() {
+    let env = Env::default();
+    let (client, _, depositor, _) = setup(&env, 2_000);
+
+    let deadline_1 = lock_bounty(&client, &env, &depositor, 1, 250);
+    let deadline_2 = lock_bounty(&client, &env, &depositor, 2, 300);
+    env.ledger().set_timestamp(deadline_1.max(deadline_2) + 1);
+
+    client.set_emergency_pause(&true);
+
+    assert_eq!(client.try_refund(&1), Err(Ok(Error::FundsPaused)));
+
+    let ids = soroban_sdk::vec![&env, 1u64, 2u64];
+    assert_eq!(
+        client.try_sweep_expired_refunds(&ids),
+        Err(Ok(Error::FundsPaused))
+    );
+
+    let flags = client.get_pause_flags();
+    assert!(flags.global_paused);
+    assert_eq!(client.get_escrow_info(&1).amount, 250);
+    assert_eq!(client.get_balance(), 550);
+}
+
+#[test]
+fn test_emergency_pause_can_be_cleared_by_admin() {
+    let env = Env::default();
+    let (client, _, depositor, _) = setup(&env, 1_000);
+
+    client.set_emergency_pause(&true);
+    client.set_emergency_pause(&false);
+
+    let flags = client.get_pause_flags();
+    assert!(!flags.global_paused);
+
+    let deadline = env.ledger().timestamp() + 1_000;
+    client.lock_funds(&depositor, &1, &100, &deadline);
+    assert_eq!(client.get_escrow_info(&1).amount, 100);
+}
+
+#[test]
+fn test_emergency_pause_requires_admin_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_client, _) = create_token(&env, &token_admin);
+    let (client, _) = create_escrow(&env);
+
+    client.init(&admin, &token_client.address);
+
+    assert!(client.try_set_emergency_pause(&true).is_err());
+    assert!(!client.get_pause_flags().global_paused);
+}
+
+#[test]
+fn test_partial_release_honors_release_pause() {
+    let env = Env::default();
+    let (client, _, depositor, _) = setup(&env, 1_000);
+    let contributor = Address::generate(&env);
+
+    lock_bounty(&client, &env, &depositor, 1, 500);
+    client.set_paused(&None, &Some(true), &None);
+
+    assert_eq!(
+        client.try_partial_release(&1, &contributor, &100),
+        Err(Ok(Error::FundsPaused))
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/bounty_escrow/contracts/escrow/test_snapshots/test_governance_integration/test_admin_operations_work_without_governance.1.json
+++ b/bounty_escrow/contracts/escrow/test_snapshots/test_governance_integration/test_admin_operations_work_without_governance.1.json
@@ -160,6 +160,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "global_paused"
+                              },
+                              "val": {
+                                "bool": false
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "lock_paused"
                               },
                               "val": {

--- a/bounty_escrow/contracts/escrow/test_snapshots/test_governance_integration/test_governance_integration_with_bounty_lifecycle.1.json
+++ b/bounty_escrow/contracts/escrow/test_snapshots/test_governance_integration/test_governance_integration_with_bounty_lifecycle.1.json
@@ -226,6 +226,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "global_paused"
+                              },
+                              "val": {
+                                "bool": false
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "lock_paused"
                               },
                               "val": {

--- a/bounty_escrow/contracts/escrow/test_snapshots/test_governance_integration/test_governance_version_check_with_mock.1.json
+++ b/bounty_escrow/contracts/escrow/test_snapshots/test_governance_integration/test_governance_version_check_with_mock.1.json
@@ -138,6 +138,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "global_paused"
+                              },
+                              "val": {
+                                "bool": false
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "lock_paused"
                               },
                               "val": {

--- a/docs/bounty_escrow/SECURITY.md
+++ b/docs/bounty_escrow/SECURITY.md
@@ -32,6 +32,14 @@ This document outlines the security measures implemented in the Bounty Escrow co
 - **Bounty Escrow**:
   - Admin-only release and approval flows, depositor-guarded locking, and permissionless-but-safe refunds.
 
+### 5. Emergency Global Pause
+- **Mechanism**: `PauseFlags.global_paused` is an admin-gated kill switch controlled by `set_emergency_pause(bool)`.
+- **Authorization**: Only the current bounty escrow admin can set or clear the switch, and the call follows the same governance-version checks as granular pause updates.
+- **Coverage**: When enabled, the contract returns `Error::FundsPaused` before value-moving escrow operations proceed, including `lock_funds`, `release_funds`, `authorize_claim`, `claim`, `partial_release`, `refund`, `sweep_expired_refunds`, `batch_lock_funds`, and `batch_release_funds`.
+- **Granular pause interaction**: `global_paused` takes precedence over the existing `lock_paused`, `release_paused`, and `refund_paused` flags. Clearing the global switch does not clear granular flags; admins must explicitly clear any operation-specific pause that should be resumed.
+- **Read availability**: Query functions such as `get_pause_flags`, `get_escrow_info`, and `get_balance` remain callable during emergency pause so operators and dashboards can inspect incident state.
+- **Eventing**: Each emergency set/clear publishes the existing pause-state event with operation `global`, the new pause value, and the authenticated admin.
+
 ## Known Risks and Limitations
 
 ### Permissionless Refund (Bounty Escrow)
@@ -79,6 +87,9 @@ This document outlines the security measures implemented in the Bounty Escrow co
 ## Audit Checklist (Bounty Escrow)
 
 - [ ] Verify Reentrancy Guards on all state-modifying paths (`lock_funds`, `release_funds`, `refund`, `batch_lock_funds`, `batch_release_funds`).
+- [ ] Verify `set_emergency_pause` is admin-gated, emits a pause event, and can both enable and clear the global pause.
+- [ ] Confirm `global_paused` blocks every value-moving path while query functions remain callable.
+- [ ] Confirm `partial_release`, claim flows, and batch variants honor the relevant granular pause flag in addition to the global pause.
 - [ ] Confirm Checks-Effects-Interactions pattern is strictly followed (state update before token transfers).
 - [ ] Review Access Control logic for `release_funds` and `approve_refund` (admin only).
 - [ ] Review Access Control logic for `lock_funds` and batch locking (depositor signatures and auth aggregation).


### PR DESCRIPTION
Closes #90.

## Summary
- Add `PauseFlags.global_paused` plus admin/governance-gated `set_emergency_pause(bool)` with pause-state event emission.
- Make the existing pause gate short-circuit value-moving escrow paths with `Error::FundsPaused`, including lock, release, claim, refund, sweep, and batch flows.
- Fix the granular pause gap where `partial_release` did not honor the release pause flag.
- Document the emergency pause behavior and audit checklist items in `docs/bounty_escrow/SECURITY.md`.
- Update affected governance integration snapshots for the new pause flag default.

## Tests
- Red test first: `cargo test test_emergency_pause_blocks_lock_and_batch_lock -- --nocapture` initially failed because `PauseFlags.global_paused` and `set_emergency_pause` did not exist.
- `cargo test test_granular_pause -- --nocapture` passes: 47 passed, 0 failed.
- `git diff --check` passes.
- `cargo test` on this branch currently reports 329 passed / 5 failed. The failures are the existing aggregate-counter/full-scan invariant tests around partial release/refund:
  - `proptest_invariants::proptest_invariant_smoke_exercises_lifecycle_entrypoints`
  - `proptest_invariants::proptest_lifecycle_invariants_hold_after_each_operation`
  - `test_analytics_monitoring::test_counters_match_full_scan_after_complex_lifecycle`
  - `test_analytics_monitoring::test_counters_match_full_scan_after_partial_refund`
  - `test_analytics_monitoring::test_counters_match_full_scan_after_partial_release`
- I reproduced the same 5 failures on a clean `origin/main` worktree before opening this PR, where `cargo test` reports 323 passed / 5 failed. I left those pre-existing aggregate counter issues unchanged to keep this PR scoped to the emergency pause issue.

## Notes
- Query/read functions remain available during emergency pause so operators can inspect state.
- Clearing `global_paused` does not clear granular pause flags; admins still need to clear operation-specific pauses explicitly.
