### PR TITLE
feat(program-escrow): scope disputes by recipient and schedule

### DIFF
--- a/docs/program-escrow/IMPLEMENTATION_SUMMARY.md
+++ b/docs/program-escrow/IMPLEMENTATION_SUMMARY.md
@@ -159,6 +159,60 @@ payouts, single payouts, and release-schedule operations. Program escrow does
 not enforce a multisig threshold for payouts; multisig governance lives in other
 contracts and should not be inferred from program-escrow storage.
 
+## Scoped Dispute Resolution
+
+Program escrow now supports three dispute scopes:
+
+1. `Global` - preserves the previous `DataKey::Dispute` behavior and blocks all
+   payout and release paths until the dispute is resolved or cancelled.
+2. `Recipient(Address)` - stores a recipient-scoped `DisputeRecord` and blocks
+   direct payouts plus release schedules for that recipient only.
+3. `Schedule(u64)` - stores a schedule-scoped `DisputeRecord` and blocks only
+   the selected release schedule.
+
+### Storage Keys
+
+- `DataKey::Dispute` - global program halt, matching the historical
+  single-dispute semantics.
+- `DataKey::RecipientDispute(Address)` - one active/historical dispute record
+  per recipient.
+- `DataKey::ScheduleDispute(u64)` - one active/historical dispute record per
+  release schedule id.
+
+### Payout And Release Rules
+
+- `single_payout` rejects when a global dispute is open or when the recipient is
+  individually disputed.
+- `batch_payout` rejects the whole batch if any recipient in that batch is
+  disputed; unrelated batches remain payable.
+- `trigger_program_releases` still rejects all releases for a global dispute,
+  but skips only recipient- or schedule-scoped disputed targets and releases
+  other due schedules.
+- `release_program_schedule_manual` and `release_prog_schedule_automatic`
+  reject only when the target schedule is globally halted, schedule-disputed, or
+  belongs to a disputed recipient.
+
+### Events And Security Notes
+
+`DisputeOpenedEvent`, `DisputeResolvedEvent`, and `DisputeCancelledEvent` now
+include a `scope` field so indexers and auditors can distinguish global,
+recipient, and schedule dispute actions. Scoped disputes never bypass a global
+halt: every payout and release path checks `DataKey::Dispute` before evaluating
+more granular scopes.
+
+### Test Coverage
+
+`program-escrow/src/test_dispute_resolution.rs` includes coverage for:
+
+- recipient A disputed while recipient B single payout succeeds;
+- batch payout rejecting batches containing a disputed recipient while allowing
+  unrelated batches;
+- due release schedules skipping only the disputed recipient target;
+- schedule-scoped disputes skipping only the selected schedule even when another
+  schedule pays the same recipient;
+- historical global dispute behavior continuing to block all payouts and
+  releases.
+
 ## Two-Step Admin Handover
 
 ### Overview

--- a/program-escrow/src/lib.rs
+++ b/program-escrow/src/lib.rs
@@ -317,7 +317,9 @@ pub enum DataKey {
     RateLimitConfig,                 // RateLimitConfig struct
     FeeConfig,                       // FeeConfig struct
     ProgramRegistry,                 // Vec<String> of program IDs
-    Dispute,                         // DisputeRecord (program-level dispute)
+    Dispute,                         // DisputeRecord (global program-level dispute)
+    RecipientDispute(Address),       // recipient -> DisputeRecord
+    ScheduleDispute(u64),            // schedule_id -> DisputeRecord
 }
 
 #[contracttype]
@@ -443,6 +445,19 @@ pub enum DisputeStatus {
     Cancelled,
 }
 
+/// Scope for a dispute halt.
+///
+/// `Global` preserves the original program-wide dispute behavior. `Recipient`
+/// blocks direct payouts and releases for one recipient, while `Schedule`
+/// blocks only one release schedule.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DisputeScope {
+    Global,
+    Recipient(Address),
+    Schedule(u64),
+}
+
 /// Record stored on-chain for an active or historical dispute.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -462,6 +477,7 @@ pub struct DisputeRecord {
 pub struct DisputeOpenedEvent {
     pub version: u32,
     pub program_id: String,
+    pub scope: DisputeScope,
     pub opened_by: Address,
     pub reason: String,
     pub timestamp: u64,
@@ -472,6 +488,7 @@ pub struct DisputeOpenedEvent {
 pub struct DisputeResolvedEvent {
     pub version: u32,
     pub program_id: String,
+    pub scope: DisputeScope,
     pub resolved_by: Address,
     pub timestamp: u64,
 }
@@ -481,6 +498,7 @@ pub struct DisputeResolvedEvent {
 pub struct DisputeCancelledEvent {
     pub version: u32,
     pub program_id: String,
+    pub scope: DisputeScope,
     pub cancelled_by: Address,
     pub timestamp: u64,
 }
@@ -963,17 +981,136 @@ impl ProgramEscrowContract {
             .unwrap_or_else(|| panic!("Admin not set"))
     }
 
-    /// Internal guard — panics if a dispute is currently open.
-    fn check_not_disputed(env: &Env) {
-        if let Some(record) = env
+    /// Returns true when the given dispute key currently stores an open dispute.
+    fn is_dispute_open_for_key(env: &Env, key: &DataKey) -> bool {
+        if let Some(record) = env.storage().instance().get::<DataKey, DisputeRecord>(key) {
+            record.status == DisputeStatus::Open
+        } else {
+            false
+        }
+    }
+
+    /// Returns true when a due schedule should be skipped by scoped dispute handling.
+    fn is_schedule_scope_disputed(env: &Env, schedule_id: u64, recipient: &Address) -> bool {
+        Self::is_dispute_open_for_key(env, &DataKey::ScheduleDispute(schedule_id))
+            || Self::is_dispute_open_for_key(env, &DataKey::RecipientDispute(recipient.clone()))
+    }
+
+    fn program_id_for_event(env: &Env) -> String {
+        let program_data: ProgramData = env
             .storage()
             .instance()
-            .get::<DataKey, DisputeRecord>(&DataKey::Dispute)
-        {
-            if record.status == DisputeStatus::Open {
-                panic!("Dispute in progress");
-            }
+            .get(&PROGRAM_DATA)
+            .unwrap_or_else(|| panic!("Program not initialized"));
+        program_data.program_id
+    }
+
+    fn open_dispute_at(
+        env: &Env,
+        key: DataKey,
+        scope: DisputeScope,
+        reason: String,
+        duplicate_message: &str,
+    ) {
+        let admin = Self::requireadmin(env);
+        admin.require_auth();
+
+        if Self::is_dispute_open_for_key(env, &key) {
+            panic!("{}", duplicate_message);
         }
+
+        let program_id = Self::program_id_for_event(env);
+        let now = env.ledger().timestamp();
+        let record = DisputeRecord {
+            opened_by: admin.clone(),
+            opened_at: now,
+            reason: reason.clone(),
+            status: DisputeStatus::Open,
+            resolved_by: None,
+            resolved_at: None,
+        };
+
+        env.storage().instance().set(&key, &record);
+
+        env.events().publish(
+            (DISPUTE_OPENED,),
+            DisputeOpenedEvent {
+                version: EVENT_VERSION_V2,
+                program_id,
+                scope,
+                opened_by: admin,
+                reason,
+                timestamp: now,
+            },
+        );
+    }
+
+    fn resolve_dispute_at(env: &Env, key: DataKey, scope: DisputeScope, missing_message: &str) {
+        let admin = Self::requireadmin(env);
+        admin.require_auth();
+
+        let mut record: DisputeRecord = env
+            .storage()
+            .instance()
+            .get(&key)
+            .unwrap_or_else(|| panic!("{}", missing_message));
+
+        if record.status != DisputeStatus::Open {
+            panic!("No open dispute to resolve");
+        }
+
+        let program_id = Self::program_id_for_event(env);
+        let now = env.ledger().timestamp();
+        record.status = DisputeStatus::Resolved;
+        record.resolved_by = Some(admin.clone());
+        record.resolved_at = Some(now);
+
+        env.storage().instance().set(&key, &record);
+
+        env.events().publish(
+            (DISPUTE_RESOLVED,),
+            DisputeResolvedEvent {
+                version: EVENT_VERSION_V2,
+                program_id,
+                scope,
+                resolved_by: admin,
+                timestamp: now,
+            },
+        );
+    }
+
+    fn cancel_dispute_at(env: &Env, key: DataKey, scope: DisputeScope, missing_message: &str) {
+        let admin = Self::requireadmin(env);
+        admin.require_auth();
+
+        let mut record: DisputeRecord = env
+            .storage()
+            .instance()
+            .get(&key)
+            .unwrap_or_else(|| panic!("{}", missing_message));
+
+        if record.status != DisputeStatus::Open {
+            panic!("No open dispute to cancel");
+        }
+
+        let program_id = Self::program_id_for_event(env);
+        let now = env.ledger().timestamp();
+        record.status = DisputeStatus::Cancelled;
+        record.resolved_by = Some(admin.clone());
+        record.resolved_at = Some(now);
+
+        env.storage().instance().set(&key, &record);
+
+        env.events().publish(
+            (DISPUTE_CANCELLED,),
+            DisputeCancelledEvent {
+                version: EVENT_VERSION_V2,
+                program_id,
+                scope,
+                cancelled_by: admin,
+                timestamp: now,
+            },
+        );
     }
 
     /// Open a dispute on this program, blocking further payouts until resolved or cancelled.
@@ -985,47 +1122,40 @@ impl ProgramEscrowContract {
     /// * If admin not set
     /// * If a dispute is already open
     pub fn open_dispute(env: Env, reason: String) {
-        let admin = Self::requireadmin(&env);
-        admin.require_auth();
+        Self::open_dispute_at(
+            &env,
+            DataKey::Dispute,
+            DisputeScope::Global,
+            reason,
+            "Dispute already open",
+        );
+    }
 
-        // Reject if a dispute is already open
-        if let Some(existing) = env
-            .storage()
-            .instance()
-            .get::<DataKey, DisputeRecord>(&DataKey::Dispute)
-        {
-            if existing.status == DisputeStatus::Open {
-                panic!("Dispute already open");
-            }
-        }
+    /// Open a recipient-scoped dispute.
+    ///
+    /// Direct payouts and release schedules for this recipient are blocked,
+    /// while unrelated recipients remain payable unless a global dispute is open.
+    pub fn open_recipient_dispute(env: Env, recipient: Address, reason: String) {
+        Self::open_dispute_at(
+            &env,
+            DataKey::RecipientDispute(recipient.clone()),
+            DisputeScope::Recipient(recipient),
+            reason,
+            "Recipient dispute already open",
+        );
+    }
 
-        let program_data: ProgramData = env
-            .storage()
-            .instance()
-            .get(&PROGRAM_DATA)
-            .unwrap_or_else(|| panic!("Program not initialized"));
-
-        let now = env.ledger().timestamp();
-        let record = DisputeRecord {
-            opened_by: admin.clone(),
-            opened_at: now,
-            reason: reason.clone(),
-            status: DisputeStatus::Open,
-            resolved_by: None,
-            resolved_at: None,
-        };
-
-        env.storage().instance().set(&DataKey::Dispute, &record);
-
-        env.events().publish(
-            (DISPUTE_OPENED,),
-            DisputeOpenedEvent {
-                version: EVENT_VERSION_V2,
-                program_id: program_data.program_id.clone(),
-                opened_by: admin,
-                reason,
-                timestamp: now,
-            },
+    /// Open a schedule-scoped dispute.
+    ///
+    /// Only the selected release schedule is blocked unless a global or
+    /// recipient-scoped dispute also applies.
+    pub fn open_schedule_dispute(env: Env, schedule_id: u64, reason: String) {
+        Self::open_dispute_at(
+            &env,
+            DataKey::ScheduleDispute(schedule_id),
+            DisputeScope::Schedule(schedule_id),
+            reason,
+            "Schedule dispute already open",
         );
     }
 
@@ -1035,40 +1165,31 @@ impl ProgramEscrowContract {
     /// * If admin not set
     /// * If no dispute is currently open
     pub fn resolve_dispute(env: Env) {
-        let admin = Self::requireadmin(&env);
-        admin.require_auth();
+        Self::resolve_dispute_at(
+            &env,
+            DataKey::Dispute,
+            DisputeScope::Global,
+            "No dispute to resolve",
+        );
+    }
 
-        let mut record: DisputeRecord = env
-            .storage()
-            .instance()
-            .get(&DataKey::Dispute)
-            .unwrap_or_else(|| panic!("No dispute to resolve"));
+    /// Resolve an open recipient-scoped dispute.
+    pub fn resolve_recipient_dispute(env: Env, recipient: Address) {
+        Self::resolve_dispute_at(
+            &env,
+            DataKey::RecipientDispute(recipient.clone()),
+            DisputeScope::Recipient(recipient),
+            "No recipient dispute to resolve",
+        );
+    }
 
-        if record.status != DisputeStatus::Open {
-            panic!("No open dispute to resolve");
-        }
-
-        let program_data: ProgramData = env
-            .storage()
-            .instance()
-            .get(&PROGRAM_DATA)
-            .unwrap_or_else(|| panic!("Program not initialized"));
-
-        let now = env.ledger().timestamp();
-        record.status = DisputeStatus::Resolved;
-        record.resolved_by = Some(admin.clone());
-        record.resolved_at = Some(now);
-
-        env.storage().instance().set(&DataKey::Dispute, &record);
-
-        env.events().publish(
-            (DISPUTE_RESOLVED,),
-            DisputeResolvedEvent {
-                version: EVENT_VERSION_V2,
-                program_id: program_data.program_id.clone(),
-                resolved_by: admin,
-                timestamp: now,
-            },
+    /// Resolve an open schedule-scoped dispute.
+    pub fn resolve_schedule_dispute(env: Env, schedule_id: u64) {
+        Self::resolve_dispute_at(
+            &env,
+            DataKey::ScheduleDispute(schedule_id),
+            DisputeScope::Schedule(schedule_id),
+            "No schedule dispute to resolve",
         );
     }
 
@@ -1078,40 +1199,31 @@ impl ProgramEscrowContract {
     /// * If admin not set
     /// * If no dispute is currently open
     pub fn cancel_dispute(env: Env) {
-        let admin = Self::requireadmin(&env);
-        admin.require_auth();
+        Self::cancel_dispute_at(
+            &env,
+            DataKey::Dispute,
+            DisputeScope::Global,
+            "No dispute to cancel",
+        );
+    }
 
-        let mut record: DisputeRecord = env
-            .storage()
-            .instance()
-            .get(&DataKey::Dispute)
-            .unwrap_or_else(|| panic!("No dispute to cancel"));
+    /// Cancel an open recipient-scoped dispute.
+    pub fn cancel_recipient_dispute(env: Env, recipient: Address) {
+        Self::cancel_dispute_at(
+            &env,
+            DataKey::RecipientDispute(recipient.clone()),
+            DisputeScope::Recipient(recipient),
+            "No recipient dispute to cancel",
+        );
+    }
 
-        if record.status != DisputeStatus::Open {
-            panic!("No open dispute to cancel");
-        }
-
-        let program_data: ProgramData = env
-            .storage()
-            .instance()
-            .get(&PROGRAM_DATA)
-            .unwrap_or_else(|| panic!("Program not initialized"));
-
-        let now = env.ledger().timestamp();
-        record.status = DisputeStatus::Cancelled;
-        record.resolved_by = Some(admin.clone());
-        record.resolved_at = Some(now);
-
-        env.storage().instance().set(&DataKey::Dispute, &record);
-
-        env.events().publish(
-            (DISPUTE_CANCELLED,),
-            DisputeCancelledEvent {
-                version: EVENT_VERSION_V2,
-                program_id: program_data.program_id.clone(),
-                cancelled_by: admin,
-                timestamp: now,
-            },
+    /// Cancel an open schedule-scoped dispute.
+    pub fn cancel_schedule_dispute(env: Env, schedule_id: u64) {
+        Self::cancel_dispute_at(
+            &env,
+            DataKey::ScheduleDispute(schedule_id),
+            DisputeScope::Schedule(schedule_id),
+            "No schedule dispute to cancel",
         );
     }
 
@@ -1120,17 +1232,33 @@ impl ProgramEscrowContract {
         env.storage().instance().get(&DataKey::Dispute)
     }
 
+    /// Returns the current recipient-scoped dispute record, if any.
+    pub fn get_recipient_dispute(env: Env, recipient: Address) -> Option<DisputeRecord> {
+        env.storage()
+            .instance()
+            .get(&DataKey::RecipientDispute(recipient))
+    }
+
+    /// Returns the current schedule-scoped dispute record, if any.
+    pub fn get_schedule_dispute(env: Env, schedule_id: u64) -> Option<DisputeRecord> {
+        env.storage()
+            .instance()
+            .get(&DataKey::ScheduleDispute(schedule_id))
+    }
+
     /// Returns true if a dispute is currently open.
     pub fn is_disputed(env: Env) -> bool {
-        if let Some(record) = env
-            .storage()
-            .instance()
-            .get::<DataKey, DisputeRecord>(&DataKey::Dispute)
-        {
-            record.status == DisputeStatus::Open
-        } else {
-            false
-        }
+        Self::is_dispute_open_for_key(&env, &DataKey::Dispute)
+    }
+
+    /// Returns true if a recipient-scoped dispute is currently open.
+    pub fn is_recipient_disputed(env: Env, recipient: Address) -> bool {
+        Self::is_dispute_open_for_key(&env, &DataKey::RecipientDispute(recipient))
+    }
+
+    /// Returns true if a schedule-scoped dispute is currently open.
+    pub fn is_schedule_disputed(env: Env, schedule_id: u64) -> bool {
+        Self::is_dispute_open_for_key(&env, &DataKey::ScheduleDispute(schedule_id))
     }
 
     // --- Circuit Breaker & Rate Limit ---
@@ -1394,8 +1522,8 @@ impl ProgramEscrowContract {
             panic!("Funds Paused");
         }
 
-        // Dispute guard: block payouts while a dispute is open
-        if Self::is_disputed(env.clone()) {
+        // Global dispute guard: block all payouts while a global dispute is open.
+        if Self::is_dispute_open_for_key(&env, &DataKey::Dispute) {
             reentrancy_guard::clear_entered(&env);
             panic!("Dispute in progress");
         }
@@ -1429,6 +1557,13 @@ impl ProgramEscrowContract {
         if recipient_count > MAX_BATCH_SIZE {
             reentrancy_guard::clear_entered(&env);
             panic!("Batch size exceeds maximum allowed");
+        }
+
+        for recipient in recipients.iter() {
+            if Self::is_dispute_open_for_key(&env, &DataKey::RecipientDispute(recipient)) {
+                reentrancy_guard::clear_entered(&env);
+                panic!("Dispute in progress");
+            }
         }
 
         // Calculate total payout amount
@@ -1571,8 +1706,11 @@ impl ProgramEscrowContract {
             panic!("Funds Paused");
         }
 
-        // Dispute guard: block payouts while a dispute is open
-        if Self::is_disputed(env.clone()) {
+        // Dispute guard: global disputes block all payouts; recipient disputes
+        // block only this payout target.
+        if Self::is_dispute_open_for_key(&env, &DataKey::Dispute)
+            || Self::is_dispute_open_for_key(&env, &DataKey::RecipientDispute(recipient.clone()))
+        {
             reentrancy_guard::clear_entered(&env);
             panic!("Dispute in progress");
         }
@@ -1755,8 +1893,8 @@ impl ProgramEscrowContract {
             panic!("Circuit breaker open: schedule releases temporarily disabled");
         }
 
-        // Dispute guard: block schedule releases while a dispute is open
-        if Self::is_disputed(env.clone()) {
+        // Global dispute guard: block all schedule releases while a global dispute is open.
+        if Self::is_dispute_open_for_key(&env, &DataKey::Dispute) {
             reentrancy_guard::clear_entered(&env);
             panic!("Dispute in progress");
         }
@@ -1796,6 +1934,10 @@ impl ProgramEscrowContract {
 
             let mut schedule = schedules.get(i).unwrap();
             if schedule.released || now < schedule.release_timestamp {
+                continue;
+            }
+
+            if Self::is_schedule_scope_disputed(&env, schedule.schedule_id, &schedule.recipient) {
                 continue;
             }
 
@@ -2304,6 +2446,12 @@ impl ProgramEscrowContract {
                     reentrancy_guard::clear_entered(&env);
                     panic!("Already released");
                 }
+                if Self::is_dispute_open_for_key(&env, &DataKey::Dispute)
+                    || Self::is_schedule_scope_disputed(&env, s.schedule_id, &s.recipient)
+                {
+                    reentrancy_guard::clear_entered(&env);
+                    panic!("Dispute in progress");
+                }
 
                 // Transfer funds
                 let token_client = token::Client::new(&env, &program_data.token_address);
@@ -2395,6 +2543,12 @@ impl ProgramEscrowContract {
                 if now < s.release_timestamp {
                     reentrancy_guard::clear_entered(&env);
                     panic!("Not yet due");
+                }
+                if Self::is_dispute_open_for_key(&env, &DataKey::Dispute)
+                    || Self::is_schedule_scope_disputed(&env, s.schedule_id, &s.recipient)
+                {
+                    reentrancy_guard::clear_entered(&env);
+                    panic!("Dispute in progress");
                 }
 
                 // Transfer funds

--- a/program-escrow/src/test_dispute_resolution.rs
+++ b/program-escrow/src/test_dispute_resolution.rs
@@ -387,3 +387,133 @@ fn test_dispute_reason_stored_correctly() {
     assert_eq!(record.reason, expected_reason);
     assert_eq!(record.status, DisputeStatus::Open);
 }
+
+// ─── Scoped disputes: recipient-specific payout guards ──────────────────────
+
+/// A recipient-scoped dispute must block only that recipient's single payout.
+#[test]
+fn test_recipient_dispute_blocks_only_target_single_payout() {
+    let env = Env::default();
+    let (client, _admin, _cid) = setup(&env, 100_000);
+
+    let disputed = Address::generate(&env);
+    let unrelated = Address::generate(&env);
+    let reason = String::from_str(&env, "Recipient KYC evidence mismatch");
+
+    client.open_recipient_dispute(&disputed, &reason);
+
+    assert!(client.is_recipient_disputed(&disputed));
+    assert!(!client.is_recipient_disputed(&unrelated));
+    assert!(!client.is_disputed());
+
+    let blocked = client.try_single_payout(&disputed, &10_000);
+    assert!(blocked.is_err());
+
+    let data = client.single_payout(&unrelated, &25_000);
+    assert_eq!(data.remaining_balance, 75_000);
+    assert_eq!(data.payout_history.len(), 1);
+    assert_eq!(data.payout_history.get(0).unwrap().recipient, unrelated);
+}
+
+/// Batch payouts reject batches containing a disputed recipient, but unrelated
+/// batches remain payable.
+#[test]
+fn test_recipient_dispute_blocks_only_target_batch_payout() {
+    let env = Env::default();
+    let (client, _admin, _cid) = setup(&env, 200_000);
+
+    let disputed = Address::generate(&env);
+    let allowed_a = Address::generate(&env);
+    let allowed_b = Address::generate(&env);
+    let reason = String::from_str(&env, "Recipient payout challenged");
+
+    client.open_recipient_dispute(&disputed, &reason);
+
+    let blocked_recipients = soroban_sdk::vec![&env, allowed_a.clone(), disputed.clone()];
+    let blocked_amounts = soroban_sdk::vec![&env, 10_000i128, 10_000i128];
+    let blocked = client.try_batch_payout(&blocked_recipients, &blocked_amounts);
+    assert!(blocked.is_err());
+
+    let allowed_recipients = soroban_sdk::vec![&env, allowed_a, allowed_b];
+    let allowed_amounts = soroban_sdk::vec![&env, 30_000i128, 40_000i128];
+    let data = client.batch_payout(&allowed_recipients, &allowed_amounts);
+
+    assert_eq!(data.remaining_balance, 130_000);
+    assert_eq!(data.payout_history.len(), 2);
+}
+
+/// Triggering due schedules should skip only schedules for a disputed recipient
+/// and release unrelated due schedules.
+#[test]
+fn test_recipient_dispute_skips_only_target_schedule_release() {
+    let env = Env::default();
+    env.ledger().set_timestamp(0);
+    let (client, _admin, _cid) = setup(&env, 150_000);
+
+    let disputed = Address::generate(&env);
+    let unrelated = Address::generate(&env);
+    let disputed_schedule = client.create_program_release_schedule(&50_000, &100, &disputed);
+    let unrelated_schedule = client.create_program_release_schedule(&60_000, &100, &unrelated);
+
+    let reason = String::from_str(&env, "Release evidence challenged");
+    client.open_recipient_dispute(&disputed, &reason);
+
+    env.ledger().set_timestamp(150);
+    let released_count = client.trigger_program_releases();
+    assert_eq!(released_count, 1);
+
+    let schedules = client.get_program_release_schedules();
+    let first = schedules.get(0).unwrap();
+    let second = schedules.get(1).unwrap();
+
+    assert_eq!(first.schedule_id, disputed_schedule.schedule_id);
+    assert!(!first.released);
+    assert_eq!(second.schedule_id, unrelated_schedule.schedule_id);
+    assert!(second.released);
+
+    let blocked = client.try_release_prog_schedule_automatic(&disputed_schedule.schedule_id);
+    assert!(blocked.is_err());
+
+    let data = client.get_program_info();
+    assert_eq!(data.remaining_balance, 90_000);
+    assert_eq!(data.payout_history.len(), 1);
+}
+
+/// A schedule-scoped dispute must block only the selected schedule, while other
+/// due schedules for the same recipient can still release.
+#[test]
+fn test_schedule_dispute_skips_only_target_schedule_release() {
+    let env = Env::default();
+    env.ledger().set_timestamp(0);
+    let (client, _admin, _cid) = setup(&env, 150_000);
+
+    let recipient = Address::generate(&env);
+    let disputed_schedule = client.create_program_release_schedule(&50_000, &100, &recipient);
+    let allowed_schedule = client.create_program_release_schedule(&60_000, &100, &recipient);
+
+    let reason = String::from_str(&env, "Schedule milestone challenged");
+    client.open_schedule_dispute(&disputed_schedule.schedule_id, &reason);
+
+    assert!(client.is_schedule_disputed(&disputed_schedule.schedule_id));
+    assert!(!client.is_schedule_disputed(&allowed_schedule.schedule_id));
+
+    env.ledger().set_timestamp(150);
+    let released_count = client.trigger_program_releases();
+    assert_eq!(released_count, 1);
+
+    let schedules = client.get_program_release_schedules();
+    let first = schedules.get(0).unwrap();
+    let second = schedules.get(1).unwrap();
+
+    assert_eq!(first.schedule_id, disputed_schedule.schedule_id);
+    assert!(!first.released);
+    assert_eq!(second.schedule_id, allowed_schedule.schedule_id);
+    assert!(second.released);
+
+    let blocked = client.try_release_prog_schedule_automatic(&disputed_schedule.schedule_id);
+    assert!(blocked.is_err());
+
+    let data = client.get_program_info();
+    assert_eq!(data.remaining_balance, 90_000);
+    assert_eq!(data.payout_history.len(), 1);
+}


### PR DESCRIPTION
Closes #92

## Summary
- preserve the existing `DataKey::Dispute` key as the global dispute halt
- add recipient-scoped and schedule-scoped dispute storage plus public lifecycle/query APIs
- update single payout, batch payout, manual release, and automatic release flows so scoped disputes block only their target while global disputes still block all payouts/releases
- document the scoped dispute storage model, payout/release behavior, and security notes

## Process
I applied on the issue first and waited for assignment before implementing this change.

## Validation
- `cargo test test_recipient_dispute --lib`
- `cargo test test_schedule_dispute --lib`
- `cargo test test_dispute_resolution --lib`
- `cargo test` (309 passed, 1 ignored)
- `cargo build`
- `git diff --check HEAD~1..HEAD`

`cargo fmt --check` still reports pre-existing formatting drift in the package, so I left broad formatting churn out of this PR.