### PR TITLE
fix(bounty_escrow): gate value transfers by governance

### DIFF
--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -1319,6 +1319,8 @@ impl BountyEscrowContract {
 
     /// Release funds to the contributor.
     /// Only the admin (backend) can authorize this.
+    /// If governance is configured, the linked governance version must meet
+    /// the configured minimum before this value transfer can proceed.
     pub fn release_funds(env: Env, bounty_id: u64, contributor: Address) -> Result<(), Error> {
         if Self::check_paused(&env, symbol_short!("release")) {
             return Err(Error::FundsPaused);
@@ -1328,6 +1330,8 @@ impl BountyEscrowContract {
         if let Err(_) = check_and_allow(&env) {
             return Err(Error::CircuitBreakerOpen);
         }
+
+        Self::check_governance_requirements(&env)?;
 
         // Dispute protection: if a pending claim exists for this bounty,
         // the dispute must be resolved (claim or cancel) before any direct release.
@@ -1714,6 +1718,8 @@ impl BountyEscrowContract {
     /// - `remaining_amount` is decremented by `payout_amount` after each call.
     /// - When `remaining_amount` reaches 0 the escrow status is set to Released.
     /// - The bounty stays Locked while any funds remain unreleased.
+    /// - If governance is configured, its version must satisfy the configured
+    ///   minimum before any partial payout is transferred.
     pub fn partial_release(
         env: Env,
         bounty_id: u64,
@@ -1732,6 +1738,8 @@ impl BountyEscrowContract {
         if let Err(_) = check_and_allow(&env) {
             return Err(Error::CircuitBreakerOpen);
         }
+
+        Self::check_governance_requirements(&env)?;
 
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
@@ -1859,6 +1867,8 @@ impl BountyEscrowContract {
 
     /// Refund funds to the original depositor if the deadline has passed.
     /// Refunds the full remaining_amount (accounts for any prior partial releases).
+    /// If governance is configured, the linked governance version must meet
+    /// the configured minimum before funds can be refunded.
     pub fn refund(env: Env, bounty_id: u64) -> Result<(), Error> {
         if Self::check_paused(&env, symbol_short!("refund")) {
             return Err(Error::FundsPaused);
@@ -1868,6 +1878,8 @@ impl BountyEscrowContract {
         if let Err(_) = check_and_allow(&env) {
             return Err(Error::CircuitBreakerOpen);
         }
+
+        Self::check_governance_requirements(&env)?;
 
         let mut escrow = Self::load_refundable_escrow(&env, bounty_id)?;
 
@@ -2024,6 +2036,8 @@ impl BountyEscrowContract {
     /// every bounty must exist, have no pending claim, be locked or partially
     /// refunded, and have `deadline <= now`. The batch is validated before any
     /// transfer, so one invalid entry rejects the whole sweep.
+    /// If governance is configured, the linked governance version must meet
+    /// the configured minimum before any expired bounty is swept.
     pub fn sweep_expired_refunds(env: Env, bounty_ids: Vec<u64>) -> Result<u32, Error> {
         if Self::check_paused(&env, symbol_short!("refund")) {
             return Err(Error::FundsPaused);
@@ -2032,6 +2046,8 @@ impl BountyEscrowContract {
         if let Err(_) = check_and_allow(&env) {
             return Err(Error::CircuitBreakerOpen);
         }
+
+        Self::check_governance_requirements(&env)?;
 
         let batch_size = bounty_ids.len() as u32;
         if batch_size == 0 || batch_size > MAX_BATCH_SIZE {
@@ -2927,6 +2943,8 @@ impl BountyEscrowContract {
     ///
     /// # Note
     /// This operation is atomic - if any item fails, the entire transaction reverts.
+    /// If governance is configured, the linked governance version must meet
+    /// the configured minimum before any item is released.
     pub fn batch_release_funds(env: Env, items: Vec<ReleaseFundsItem>) -> Result<u32, Error> {
         if Self::check_paused(&env, symbol_short!("release")) {
             return Err(Error::FundsPaused);
@@ -2936,6 +2954,9 @@ impl BountyEscrowContract {
         if let Err(_) = check_and_allow(&env) {
             return Err(Error::CircuitBreakerOpen);
         }
+
+        Self::check_governance_requirements(&env)?;
+
         // Validate batch size
         let batch_size = items.len() as u32;
         if batch_size == 0 {

--- a/bounty_escrow/contracts/escrow/src/test_governance_integration.rs
+++ b/bounty_escrow/contracts/escrow/src/test_governance_integration.rs
@@ -1,8 +1,14 @@
 #![cfg(test)]
 
-use crate::{governance_integration, BountyEscrowContract, BountyEscrowContractClient, Error};
+use crate::{
+    governance_integration, BountyEscrowContract, BountyEscrowContractClient, Error, EscrowStatus,
+    ReleaseFundsItem,
+};
 use grainlify_core::{GrainlifyContract, GrainlifyContractClient};
-use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, vec, Address, BytesN, Env,
+};
 
 // Mock governance contract for testing
 mod mock_governance {
@@ -25,6 +31,185 @@ mod mock_governance {
             wasm_hash == BytesN::from_array(&env, &[7u8; 32])
         }
     }
+}
+
+fn create_token_contract<'a>(
+    env: &Env,
+    admin: &Address,
+) -> (token::Client<'a>, token::StellarAssetClient<'a>) {
+    let contract_address = env.register_stellar_asset_contract(admin.clone());
+    (
+        token::Client::new(env, &contract_address),
+        token::StellarAssetClient::new(env, &contract_address),
+    )
+}
+
+struct ValueTransferSetup<'a> {
+    env: Env,
+    depositor: Address,
+    contributor: Address,
+    escrow: BountyEscrowContractClient<'a>,
+}
+
+impl<'a> ValueTransferSetup<'a> {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let depositor = Address::generate(&env);
+        let contributor = Address::generate(&env);
+        let (_token, token_admin) = create_token_contract(&env, &admin);
+
+        let contract_id = env.register_contract(None, BountyEscrowContract);
+        let escrow = BountyEscrowContractClient::new(&env, &contract_id);
+        escrow.init(&admin, &_token.address);
+        token_admin.mint(&depositor, &1_000_000);
+
+        Self {
+            env,
+            depositor,
+            contributor,
+            escrow,
+        }
+    }
+
+    fn configure_mock_governance(&self, min_version: u32) {
+        let gov_contract_id = self
+            .env
+            .register_contract(None, mock_governance::MockGovernanceContract);
+        self.escrow.set_governance_contract(&gov_contract_id);
+        self.escrow.set_min_governance_version(&min_version);
+    }
+
+    fn lock_bounty(&self, bounty_id: u64, amount: i128, deadline: u64) {
+        self.escrow
+            .lock_funds(&self.depositor, &bounty_id, &amount, &deadline);
+    }
+}
+
+#[test]
+fn test_governance_version_too_low_blocks_value_transfers() {
+    let setup = ValueTransferSetup::new();
+    setup.configure_mock_governance(3);
+
+    let now = setup.env.ledger().timestamp();
+    let active_deadline = now + 100;
+    let expired_deadline = now + 10;
+
+    setup.lock_bounty(1, 100, active_deadline);
+    setup.lock_bounty(2, 100, active_deadline);
+    setup.lock_bounty(3, 100, expired_deadline);
+    setup.lock_bounty(4, 100, expired_deadline);
+    setup.lock_bounty(5, 100, active_deadline);
+    setup.lock_bounty(6, 100, active_deadline);
+
+    assert_eq!(
+        setup.escrow.try_release_funds(&1, &setup.contributor),
+        Err(Ok(Error::GovernanceVersionTooLow))
+    );
+    assert_eq!(
+        setup
+            .escrow
+            .try_partial_release(&2, &setup.contributor, &25),
+        Err(Ok(Error::GovernanceVersionTooLow))
+    );
+
+    setup.env.ledger().set_timestamp(expired_deadline + 1);
+    assert_eq!(
+        setup.escrow.try_refund(&3),
+        Err(Ok(Error::GovernanceVersionTooLow))
+    );
+
+    let expired_ids = vec![&setup.env, 4_u64];
+    assert_eq!(
+        setup.escrow.try_sweep_expired_refunds(&expired_ids),
+        Err(Ok(Error::GovernanceVersionTooLow))
+    );
+
+    let release_items = vec![
+        &setup.env,
+        ReleaseFundsItem {
+            bounty_id: 5,
+            contributor: setup.contributor.clone(),
+        },
+        ReleaseFundsItem {
+            bounty_id: 6,
+            contributor: setup.contributor.clone(),
+        },
+    ];
+    assert_eq!(
+        setup.escrow.try_batch_release_funds(&release_items),
+        Err(Ok(Error::GovernanceVersionTooLow))
+    );
+
+    for bounty_id in 1_u64..=6 {
+        let escrow = setup.escrow.get_escrow_info(&bounty_id);
+        assert_eq!(escrow.status, EscrowStatus::Locked);
+        assert_eq!(escrow.remaining_amount, 100);
+    }
+}
+
+#[test]
+fn test_governance_version_met_allows_value_transfers() {
+    let setup = ValueTransferSetup::new();
+    setup.configure_mock_governance(2);
+
+    let now = setup.env.ledger().timestamp();
+    let active_deadline = now + 100;
+    let expired_deadline = now + 10;
+
+    setup.lock_bounty(11, 100, active_deadline);
+    setup.lock_bounty(12, 100, active_deadline);
+    setup.lock_bounty(13, 100, expired_deadline);
+    setup.lock_bounty(14, 100, expired_deadline);
+    setup.lock_bounty(15, 100, active_deadline);
+    setup.lock_bounty(16, 100, active_deadline);
+
+    setup.escrow.release_funds(&11, &setup.contributor);
+    setup.escrow.partial_release(&12, &setup.contributor, &25);
+
+    setup.env.ledger().set_timestamp(expired_deadline + 1);
+    setup.escrow.refund(&13);
+    let expired_ids = vec![&setup.env, 14_u64];
+    assert_eq!(setup.escrow.sweep_expired_refunds(&expired_ids), 1);
+
+    let release_items = vec![
+        &setup.env,
+        ReleaseFundsItem {
+            bounty_id: 15,
+            contributor: setup.contributor.clone(),
+        },
+        ReleaseFundsItem {
+            bounty_id: 16,
+            contributor: setup.contributor.clone(),
+        },
+    ];
+    assert_eq!(setup.escrow.batch_release_funds(&release_items), 2);
+
+    assert_eq!(
+        setup.escrow.get_escrow_info(&11).status,
+        EscrowStatus::Released
+    );
+    let partial = setup.escrow.get_escrow_info(&12);
+    assert_eq!(partial.status, EscrowStatus::Locked);
+    assert_eq!(partial.remaining_amount, 75);
+    assert_eq!(
+        setup.escrow.get_escrow_info(&13).status,
+        EscrowStatus::Refunded
+    );
+    assert_eq!(
+        setup.escrow.get_escrow_info(&14).status,
+        EscrowStatus::Refunded
+    );
+    assert_eq!(
+        setup.escrow.get_escrow_info(&15).status,
+        EscrowStatus::Released
+    );
+    assert_eq!(
+        setup.escrow.get_escrow_info(&16).status,
+        EscrowStatus::Released
+    );
 }
 
 #[test]

--- a/docs/GOVERNANCE_INTEGRATION.md
+++ b/docs/GOVERNANCE_INTEGRATION.md
@@ -100,6 +100,11 @@ The following admin operations now check governance requirements:
 - `set_paused()` - Pause/unpause operations
 - `update_fee_config()` - Fee configuration
 - `update_multisig_config()` - Multisig configuration
+- `release_funds()` - Admin-authorized full value transfer to a contributor
+- `partial_release()` - Admin-authorized partial value transfer to a contributor
+- `batch_release_funds()` - Batch admin-authorized contributor payouts
+- `refund()` - Post-deadline or approved refund transfer
+- `sweep_expired_refunds()` - Batch post-deadline refund sweep
 
 ### Governance Check Flow
 
@@ -263,6 +268,7 @@ The integration includes comprehensive tests:
    - Upgrade scenarios
    - Matching-hash approval, wrong-hash rejection, and missing-governance rejection
    - Cross-contract `bounty_escrow` + real `grainlify-core` version gates, including below-minimum rejection, at-minimum success, and numeric-encoded version checks
+   - Value-transfer gates for release, partial release, refund, expired-refund sweep, and batch release paths
 
 ### Running Tests
 


### PR DESCRIPTION
Closes #79.

## Summary
- Add the existing governance version gate to bounty escrow value-transfer paths: `release_funds`, `partial_release`, `refund`, `sweep_expired_refunds`, and `batch_release_funds`.
- Add integration coverage proving a too-low governance version blocks all covered value transfers and a governance version meeting the minimum allows them.
- Document the newly governance-protected value-transfer operations.

## Validation
- Red check before implementation: `cargo test test_governance_version_too_low_blocks_value_transfers --lib` failed because `release_funds` returned `Ok(Ok(()))` instead of `GovernanceVersionTooLow`.
- `cargo test test_governance_integration --lib` passed: 15 passed.
- `cargo build` passed.
- `git diff --check` passed.

## Notes
- The governance helper preserves the current no-governance behavior because the existing version check allows operations when no governance/minimum version is configured.
- A broader `cargo test --lib` run still hits existing analytics/proptest failures. I reproduced `test_counters_match_full_scan_after_partial_release` on `origin/main` at b1d769d, so those failures appear unrelated to this change.