### PR TITLE
test(bounty_escrow): harden claim reentrancy paths

### DIFF
--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -1555,6 +1555,15 @@ impl BountyEscrowContract {
             return Err(Error::FundsNotLocked);
         }
 
+        // Defense in depth: token transfer is an external call. Block nested
+        // entry into claim/release paths before interacting with the token.
+        if env.storage().instance().has(&DataKey::ReentrancyGuard) {
+            panic!("Reentrancy detected");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyGuard, &true);
+
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let client = token::Client::new(&env, &token_addr);
         client.transfer(
@@ -1594,6 +1603,7 @@ impl BountyEscrowContract {
                 claimed_at: now,
             },
         );
+        env.storage().instance().remove(&DataKey::ReentrancyGuard);
         Ok(())
     }
 
@@ -1769,6 +1779,15 @@ impl BountyEscrowContract {
             return Err(Error::InsufficientFunds);
         }
 
+        // Defense in depth: token transfer is an external call. Block nested
+        // entry into claim/release paths before interacting with the token.
+        if env.storage().instance().has(&DataKey::ReentrancyGuard) {
+            panic!("Reentrancy detected");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyGuard, &true);
+
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let client = token::Client::new(&env, &token_addr);
 
@@ -1810,6 +1829,7 @@ impl BountyEscrowContract {
             },
         );
 
+        env.storage().instance().remove(&DataKey::ReentrancyGuard);
         Ok(())
     }
 

--- a/bounty_escrow/contracts/escrow/src/test_reentrancy.rs
+++ b/bounty_escrow/contracts/escrow/src/test_reentrancy.rs
@@ -1,9 +1,230 @@
 #![cfg(test)]
-use crate::{BountyEscrowContract, BountyEscrowContractClient, Error as ContractError};
-use soroban_sdk::{
-    testutils::{Address as _},
-    token, Address, Env,
+use crate::{
+    BountyEscrowContract, BountyEscrowContractClient, Error as ContractError, EscrowStatus,
 };
+use soroban_sdk::{
+    contract, contractimpl, contracttype, testutils::Address as _, token, Address, Env, String,
+};
+
+#[derive(Clone, Copy)]
+#[repr(u32)]
+enum AttackMode {
+    None = 0,
+    Claim = 1,
+    PartialRelease = 2,
+}
+
+#[contracttype]
+#[derive(Clone)]
+enum HostileTokenKey {
+    Balance(Address),
+    Target,
+    AttackMode,
+    BountyId,
+    AttackCount,
+    EscrowTransferCount,
+    ReentryBlocked,
+}
+
+#[contract]
+struct HostileTokenContract;
+
+#[contractimpl]
+impl HostileTokenContract {
+    pub fn init(env: Env, target: Address) {
+        env.storage()
+            .instance()
+            .set(&HostileTokenKey::Target, &target);
+        env.storage()
+            .instance()
+            .set(&HostileTokenKey::AttackMode, &(AttackMode::None as u32));
+        env.storage()
+            .instance()
+            .set(&HostileTokenKey::BountyId, &0u64);
+        env.storage()
+            .instance()
+            .set(&HostileTokenKey::AttackCount, &0u32);
+        env.storage()
+            .instance()
+            .set(&HostileTokenKey::EscrowTransferCount, &0u32);
+        env.storage()
+            .instance()
+            .set(&HostileTokenKey::ReentryBlocked, &false);
+    }
+
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let balance = Self::balance(env.clone(), to.clone());
+        env.storage()
+            .persistent()
+            .set(&HostileTokenKey::Balance(to), &(balance + amount));
+    }
+
+    pub fn set_attack(env: Env, mode: u32, bounty_id: u64) {
+        env.storage()
+            .instance()
+            .set(&HostileTokenKey::AttackMode, &mode);
+        env.storage()
+            .instance()
+            .set(&HostileTokenKey::BountyId, &bounty_id);
+        env.storage()
+            .instance()
+            .set(&HostileTokenKey::AttackCount, &0u32);
+        env.storage()
+            .instance()
+            .set(&HostileTokenKey::EscrowTransferCount, &0u32);
+        env.storage()
+            .instance()
+            .set(&HostileTokenKey::ReentryBlocked, &false);
+    }
+
+    pub fn attack_count(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&HostileTokenKey::AttackCount)
+            .unwrap_or(0)
+    }
+
+    pub fn escrow_transfer_count(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&HostileTokenKey::EscrowTransferCount)
+            .unwrap_or(0)
+    }
+
+    pub fn reentry_blocked(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&HostileTokenKey::ReentryBlocked)
+            .unwrap_or(false)
+    }
+
+    pub fn allowance(_env: Env, _from: Address, _spender: Address) -> i128 {
+        0
+    }
+
+    pub fn approve(
+        env: Env,
+        from: Address,
+        _spender: Address,
+        _amount: i128,
+        _expiration_ledger: u32,
+    ) {
+        from.require_auth();
+        env.events().publish(("approve",), from);
+    }
+
+    pub fn balance(env: Env, id: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&HostileTokenKey::Balance(id))
+            .unwrap_or(0)
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+
+        let target: Address = env
+            .storage()
+            .instance()
+            .get(&HostileTokenKey::Target)
+            .unwrap();
+
+        if from == target {
+            let count = Self::escrow_transfer_count(env.clone());
+            env.storage()
+                .instance()
+                .set(&HostileTokenKey::EscrowTransferCount, &(count + 1));
+            Self::attempt_reentry(&env, &to, amount);
+        }
+
+        let from_balance = Self::balance(env.clone(), from.clone());
+        let to_balance = Self::balance(env.clone(), to.clone());
+        env.storage()
+            .persistent()
+            .set(&HostileTokenKey::Balance(from), &(from_balance - amount));
+        env.storage()
+            .persistent()
+            .set(&HostileTokenKey::Balance(to), &(to_balance + amount));
+    }
+
+    pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
+        spender.require_auth();
+        Self::transfer(env, from, to, amount);
+    }
+
+    pub fn burn(env: Env, from: Address, amount: i128) {
+        from.require_auth();
+        let balance = Self::balance(env.clone(), from.clone());
+        env.storage()
+            .persistent()
+            .set(&HostileTokenKey::Balance(from), &(balance - amount));
+    }
+
+    pub fn burn_from(env: Env, spender: Address, from: Address, amount: i128) {
+        spender.require_auth();
+        Self::burn(env, from, amount);
+    }
+
+    pub fn decimals(_env: Env) -> u32 {
+        7
+    }
+
+    pub fn name(env: Env) -> String {
+        String::from_str(&env, "Hostile Token")
+    }
+
+    pub fn symbol(env: Env) -> String {
+        String::from_str(&env, "HOST")
+    }
+
+    fn attempt_reentry(env: &Env, recipient: &Address, amount: i128) {
+        let attack_count = Self::attack_count(env.clone());
+        if attack_count > 0 {
+            return;
+        }
+
+        let mode: u32 = env
+            .storage()
+            .instance()
+            .get(&HostileTokenKey::AttackMode)
+            .unwrap_or(AttackMode::None as u32);
+        if mode == AttackMode::None as u32 {
+            return;
+        }
+
+        env.storage()
+            .instance()
+            .set(&HostileTokenKey::AttackCount, &(attack_count + 1));
+
+        let target: Address = env
+            .storage()
+            .instance()
+            .get(&HostileTokenKey::Target)
+            .unwrap();
+        let bounty_id: u64 = env
+            .storage()
+            .instance()
+            .get(&HostileTokenKey::BountyId)
+            .unwrap();
+        let client = BountyEscrowContractClient::new(env, &target);
+
+        let blocked = if mode == AttackMode::Claim as u32 {
+            match client.try_claim(&bounty_id) {
+                Ok(inner) => inner.is_err(),
+                Err(_) => true,
+            }
+        } else {
+            match client.try_partial_release(&bounty_id, recipient, &amount) {
+                Ok(inner) => inner.is_err(),
+                Err(_) => true,
+            }
+        };
+
+        env.storage()
+            .instance()
+            .set(&HostileTokenKey::ReentryBlocked, &blocked);
+    }
+}
 
 fn create_test_env() -> (Env, BountyEscrowContractClient<'static>, Address) {
     let env = Env::default();
@@ -22,6 +243,16 @@ fn create_token_contract<'a>(
     let token_client = token::Client::new(e, &token);
     let token_admin_client = token::StellarAssetClient::new(e, &token);
     (token, token_client, token_admin_client)
+}
+
+fn create_hostile_token<'a>(
+    env: &'a Env,
+    target: &Address,
+) -> (Address, HostileTokenContractClient<'a>) {
+    let token = env.register_contract(None, HostileTokenContract);
+    let client = HostileTokenContractClient::new(env, &token);
+    client.init(target);
+    (token, client)
 }
 
 #[test]
@@ -46,7 +277,10 @@ fn test_reentrancy_guard_leak_fix() {
     env.as_contract(&contract_id, || {
         use crate::DataKey;
         let has_guard = env.storage().instance().has(&DataKey::ReentrancyGuard);
-        assert!(!has_guard, "Reentrancy guard should NOT have leaked after failed call");
+        assert!(
+            !has_guard,
+            "Reentrancy guard should NOT have leaked after failed call"
+        );
     });
 
     // 2. Lock funds for a real bounty and release them.
@@ -69,9 +303,173 @@ fn test_genuine_reentrancy_blocked() {
     // Simulate a reentrant call by setting the guard manually.
     env.as_contract(&contract_id, || {
         use crate::DataKey;
-        env.storage().instance().set(&DataKey::ReentrancyGuard, &true);
-        
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyGuard, &true);
+
         // This should panic
         client.release_funds(&1, &Address::generate(&env));
     });
+}
+
+#[test]
+#[should_panic]
+fn test_claim_respects_reentrancy_guard() {
+    let (env, client, contract_id) = create_test_env();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let contributor = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token, _token_client, token_admin_client) = create_token_contract(&env, &token_admin);
+    let bounty_id = 10_u64;
+    let amount = 1_000_i128;
+
+    client.init(&admin, &token);
+    client.set_claim_window(&100);
+    token_admin_client.mint(&depositor, &amount);
+    client.lock_funds(
+        &depositor,
+        &bounty_id,
+        &amount,
+        &(env.ledger().timestamp() + 100),
+    );
+    client.authorize_claim(&bounty_id, &contributor);
+
+    env.as_contract(&contract_id, || {
+        use crate::DataKey;
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyGuard, &true);
+    });
+
+    client.claim(&bounty_id);
+}
+
+#[test]
+#[should_panic]
+fn test_partial_release_respects_reentrancy_guard() {
+    let (env, client, contract_id) = create_test_env();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let contributor = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token, _token_client, token_admin_client) = create_token_contract(&env, &token_admin);
+    let bounty_id = 11_u64;
+    let amount = 1_000_i128;
+
+    client.init(&admin, &token);
+    token_admin_client.mint(&depositor, &amount);
+    client.lock_funds(
+        &depositor,
+        &bounty_id,
+        &amount,
+        &(env.ledger().timestamp() + 100),
+    );
+
+    env.as_contract(&contract_id, || {
+        use crate::DataKey;
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyGuard, &true);
+    });
+
+    client.partial_release(&bounty_id, &contributor, &400);
+}
+
+#[test]
+fn hostile_token_cannot_double_spend_claim_during_transfer() {
+    let (env, client, contract_id) = create_test_env();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let contributor = Address::generate(&env);
+    let (token, hostile_token) = create_hostile_token(&env, &contract_id);
+    let bounty_id = 77_u64;
+    let amount = 1_000_i128;
+
+    client.init(&admin, &token);
+    client.set_claim_window(&100);
+    hostile_token.mint(&depositor, &amount);
+
+    client.lock_funds(
+        &depositor,
+        &bounty_id,
+        &amount,
+        &(env.ledger().timestamp() + 100),
+    );
+    client.authorize_claim(&bounty_id, &contributor);
+    hostile_token.set_attack(&(AttackMode::Claim as u32), &bounty_id);
+
+    client.claim(&bounty_id);
+
+    let claim = client.get_pending_claim(&bounty_id);
+    let escrow = client.get_escrow_info(&bounty_id);
+    assert!(claim.claimed, "claim must be consumed exactly once");
+    assert_eq!(escrow.status, EscrowStatus::Released);
+    assert_eq!(escrow.remaining_amount, 0);
+    assert_eq!(
+        hostile_token.attack_count(),
+        1,
+        "hostile token should have attempted reentry during claim transfer"
+    );
+    assert!(
+        hostile_token.reentry_blocked(),
+        "reentrant claim attempt should be rejected by contract state or guard"
+    );
+    assert_eq!(
+        hostile_token.escrow_transfer_count(),
+        1,
+        "claim must not execute a second escrow-to-recipient transfer"
+    );
+    assert_eq!(hostile_token.balance(&contributor), amount);
+}
+
+#[test]
+fn hostile_token_cannot_double_spend_partial_release_during_transfer() {
+    let (env, client, contract_id) = create_test_env();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let contributor = Address::generate(&env);
+    let (token, hostile_token) = create_hostile_token(&env, &contract_id);
+    let bounty_id = 88_u64;
+    let amount = 1_000_i128;
+    let payout_amount = 400_i128;
+
+    client.init(&admin, &token);
+    hostile_token.mint(&depositor, &amount);
+    client.lock_funds(
+        &depositor,
+        &bounty_id,
+        &amount,
+        &(env.ledger().timestamp() + 100),
+    );
+    hostile_token.set_attack(&(AttackMode::PartialRelease as u32), &bounty_id);
+
+    client.partial_release(&bounty_id, &contributor, &payout_amount);
+
+    let escrow = client.get_escrow_info(&bounty_id);
+    assert_eq!(escrow.status, EscrowStatus::Locked);
+    assert_eq!(escrow.remaining_amount, amount - payout_amount);
+    assert_eq!(
+        hostile_token.attack_count(),
+        1,
+        "hostile token should have attempted reentry during partial release transfer"
+    );
+    assert!(
+        hostile_token.reentry_blocked(),
+        "reentrant partial release should be rejected by contract state or guard"
+    );
+    assert_eq!(
+        hostile_token.escrow_transfer_count(),
+        1,
+        "partial release must not execute a second escrow-to-recipient transfer"
+    );
+    assert_eq!(hostile_token.balance(&contributor), payout_amount);
 }

--- a/docs/bounty_escrow/SECURITY.md
+++ b/docs/bounty_escrow/SECURITY.md
@@ -9,11 +9,13 @@ This document outlines the security measures implemented in the Bounty Escrow co
 - **Mechanism**: A boolean flag `ReentrancyGuard` is stored in the contract instance storage.
 - **Acquisition Timing**: To prevent the contract from being bricked, the guard is acquired *after* non-mutating validation checks (e.g., existence and status checks). This ensures that early `Err` returns (which commit state in Soroban) do not leak the guard into storage.
 - **Coverage (Bounty Escrow)**: All mutating entry points are protected, including `release_funds`, `partial_release`, `claim`, and `batch_release_funds`.
+- **Claim/partial-release transfer mitigation**: `claim` and `partial_release` acquire the same guard immediately before the external token transfer and clear it after the state/event updates complete. This blocks nested claim or release attempts during a hostile token callback.
+- **Hostile-token coverage**: `bounty_escrow/contracts/escrow/src/test_reentrancy.rs` includes a test-only SEP-41-compatible hostile token that attempts to re-enter both `claim()` and `partial_release()` from inside `transfer`. The tests assert that the attack is attempted, the nested call is blocked, and only one escrow-to-recipient transfer is executed.
 - **Coverage (Program Escrow)**: Core state-modifying functions (`lock_program_funds`, `batch_payout`, `single_payout`) are reviewed for reentrancy risks and follow checks-effects-interactions with no internal callbacks.
 - **Behavior**: If reentrancy is detected, the contract panics, reverting the transaction.
 
 ### 2. Checks-Effects-Interactions Pattern
-- **Bounty Escrow**: State updates (e.g., setting status to `Released`, `Refunded`, or `PartiallyRefunded`) are performed *before* any external token transfers in both single and batch flows.
+- **Bounty Escrow**: Value-moving paths are reviewed for external token calls. Where a path performs an external token transfer before final state/event persistence, it holds `ReentrancyGuard` across the transfer so a callback cannot consume the same escrow or claim twice. Paths that can update state before transfer should continue to prefer checks-effects-interactions when it does not break existing transaction semantics.
 - **Program Escrow**: State updates to `ProgramData` (balances and payout history) are performed before token transfers; batch flows are atomic within a single transaction.
 - **Goal**: Prevent reentrancy attacks where an external call calls back into the contract before the state is updated.
 
@@ -86,11 +88,11 @@ This document outlines the security measures implemented in the Bounty Escrow co
 
 ## Audit Checklist (Bounty Escrow)
 
-- [ ] Verify Reentrancy Guards on all state-modifying paths (`lock_funds`, `release_funds`, `refund`, `batch_lock_funds`, `batch_release_funds`).
+- [ ] Verify Reentrancy Guards on all value-moving external-transfer paths (`release_funds`, `claim`, `partial_release`, `refund`, `batch_release_funds`).
 - [ ] Verify `set_emergency_pause` is admin-gated, emits a pause event, and can both enable and clear the global pause.
 - [ ] Confirm `global_paused` blocks every value-moving path while query functions remain callable.
 - [ ] Confirm `partial_release`, claim flows, and batch variants honor the relevant granular pause flag in addition to the global pause.
-- [ ] Confirm Checks-Effects-Interactions pattern is strictly followed (state update before token transfers).
+- [ ] Confirm each external token-transfer path either follows checks-effects-interactions or holds `ReentrancyGuard` across the transfer.
 - [ ] Review Access Control logic for `release_funds` and `approve_refund` (admin only).
 - [ ] Review Access Control logic for `lock_funds` and batch locking (depositor signatures and auth aggregation).
 - [ ] Verify Arithmetic safety (overflow/underflow protection via Rust/Soroban defaults and bounds checks on remaining amounts).
@@ -99,7 +101,7 @@ This document outlines the security measures implemented in the Bounty Escrow co
    - Past deadline
    - Double release
    - Double/over-refund
-   - Reentrancy attempts across single and batch flows
+   - Reentrancy attempts across single, claim, partial release, and batch flows
 
 ## Audit Checklist (Program Escrow)
 


### PR DESCRIPTION
Closes #88

## Summary
- Added a test-only hostile token contract that attempts to re-enter `claim()` and `partial_release()` during token `transfer`.
- Added explicit `ReentrancyGuard` coverage to `claim()` and `partial_release()` before the external token transfer, clearing it after the state/event updates complete.
- Documented the claim/partial-release mitigation and hostile-token coverage in `docs/bounty_escrow/SECURITY.md`.

## Validation
- Red test before fix: `cargo test respects_reentrancy_guard --lib -- --nocapture` failed because the new `claim` / `partial_release` guard tests did not panic, proving those paths did not respect an active guard.
- `cargo build`
- `rustfmt --check src/test_reentrancy.rs`
- `cargo test test_reentrancy --lib -- --nocapture` (6 passed)
- `git diff --check`

## Notes
- Full `cargo test` currently has 5 unrelated baseline failures that were already present around analytics/full-scan counters and proptest lifecycle invariants: `proptest_invariants::proptest_invariant_smoke_exercises_lifecycle_entrypoints`, `proptest_invariants::proptest_lifecycle_invariants_hold_after_each_operation`, `test_analytics_monitoring::test_counters_match_full_scan_after_partial_refund`, `test_analytics_monitoring::test_counters_match_full_scan_after_partial_release`, and `test_analytics_monitoring::test_counters_match_full_scan_after_complex_lifecycle`.
- Full `cargo fmt --check` also reports existing formatting diffs outside this PR; I checked the modified reentrancy test file directly to avoid unrelated formatting churn.