### PR TITLE
feat: validate deadline and amount bounds in escrow lock entrypoints

### DIFF
--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -7,6 +7,9 @@ mod error_recovery;
 #[cfg(test)]
 mod test_rbac;
 
+#[cfg(test)]
+mod test_deadline_amount_validation;
+
 use events::{
     emit_batch_funds_locked, emit_batch_funds_released, emit_bounty_expired,
     emit_bounty_initialized, emit_funds_locked, emit_funds_refunded, emit_funds_released,
@@ -438,6 +441,7 @@ pub enum DataKey {
     ClaimWindow,          // u64 seconds (global config)
     PauseFlags,           // PauseFlags struct
     AmountPolicy, // Option<(i128, i128)> — (min_amount, max_amount) set by set_amount_policy
+    DeadlineHorizon, // Option<u64> — max seconds from now for allowed deadlines (Issue #40)
     AggregateCounters, // AggregateStats — O(1) incremental counters maintained on state transitions
 }
 
@@ -1209,6 +1213,12 @@ impl BountyEscrowContract {
             return Err(Error::BountyExists);
         }
 
+        // Validate amount is positive (Issue #40).
+        // This catches zero and negative amounts even when no AmountPolicy is set.
+        if amount <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+
         // Enforce min/max amount policy if one has been configured (Issue #62).
         // When no policy is set this block is skipped entirely, preserving
         // backward-compatible behaviour for callers that never call set_amount_policy.
@@ -1222,6 +1232,23 @@ impl BountyEscrowContract {
             }
             if amount > max_amount {
                 return Err(Error::AmountAboveMaximum);
+            }
+        }
+
+        // Validate deadline (Issue #40):
+        // - Reject past deadlines (already expired)
+        // - Reject deadlines beyond the configurable max horizon
+        let now = env.ledger().timestamp();
+        if deadline <= now {
+            return Err(Error::InvalidDeadline);
+        }
+        if let Some(max_horizon) = env
+            .storage()
+            .instance()
+            .get::<DataKey, u64>(&DataKey::DeadlineHorizon)
+        {
+            if deadline > now.saturating_add(max_horizon) {
+                return Err(Error::InvalidDeadline);
             }
         }
 
@@ -2553,6 +2580,42 @@ impl BountyEscrowContract {
         Ok(())
     }
 
+    /// Set the maximum deadline horizon (admin only).
+    ///
+    /// When set to a positive value, `lock_funds` rejects deadlines that are more
+    /// than `max_horizon` seconds in the future. This prevents escrows with
+    /// unreachable deadlines that would lock funds forever.
+    ///
+    /// Pass `0` to clear the horizon restriction (no upper bound on deadlines).
+    pub fn set_deadline_horizon(
+        env: Env,
+        caller: Address,
+        max_horizon: u64,
+    ) -> Result<(), Error> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::NotInitialized);
+        }
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if caller != admin {
+            return Err(Error::Unauthorized);
+        }
+        admin.require_auth();
+
+        if max_horizon == 0 {
+            // Use u64::MAX as sentinel to indicate no horizon restriction.
+            // Soroban instance storage does not support remove().
+            env.storage()
+                .instance()
+                .set(&DataKey::DeadlineHorizon, &u64::MAX);
+        } else {
+            env.storage()
+                .instance()
+                .set(&DataKey::DeadlineHorizon, &max_horizon);
+        }
+
+        Ok(())
+    }
+
     /// Get escrow IDs by status
     pub fn get_escrow_ids_by_status(
         env: Env,
@@ -2803,6 +2866,20 @@ impl BountyEscrowContract {
             // Validate amount
             if item.amount <= 0 {
                 return Err(Error::InvalidAmount);
+            }
+
+            // Validate deadline (Issue #40)
+            if item.deadline <= timestamp {
+                return Err(Error::InvalidDeadline);
+            }
+            if let Some(max_horizon) = env
+                .storage()
+                .instance()
+                .get::<DataKey, u64>(&DataKey::DeadlineHorizon)
+            {
+                if item.deadline > timestamp.saturating_add(max_horizon) {
+                    return Err(Error::InvalidDeadline);
+                }
             }
 
             // Check for duplicate bounty_ids in the batch

--- a/bounty_escrow/contracts/escrow/src/test_bounty_escrow.rs
+++ b/bounty_escrow/contracts/escrow/src/test_bounty_escrow.rs
@@ -196,11 +196,9 @@ fn test_lock_funds_zero_amount_edge_case() {
     client.init(&admin, &token);
     token_admin_client.mint(&depositor, &1_000);
 
-    client.lock_funds(&depositor, &bounty_id, &amount, &deadline);
-
-    let escrow = client.get_escrow_info(&bounty_id);
-    assert_eq!(escrow.amount, 0);
-    assert_eq!(escrow.status, crate::EscrowStatus::Locked);
+    // Issue #40: zero amount is now rejected with InvalidAmount
+    let result = client.try_lock_funds(&depositor, &bounty_id, &amount, &deadline);
+    assert_eq!(result, Err(Ok(crate::Error::InvalidAmount)));
 }
 
 #[test]

--- a/bounty_escrow/contracts/escrow/src/test_deadline_amount_validation.rs
+++ b/bounty_escrow/contracts/escrow/src/test_deadline_amount_validation.rs
@@ -1,0 +1,360 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},
+    token, Address, Env, IntoVal,
+};
+
+fn create_token_contract<'a>(
+    e: &Env,
+    admin: &Address,
+) -> (token::Client<'a>, token::StellarAssetClient<'a>) {
+    let contract_address = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    (
+        token::Client::new(e, &contract_address),
+        token::StellarAssetClient::new(e, &contract_address),
+    )
+}
+
+fn create_escrow_contract<'a>(e: &Env) -> BountyEscrowContractClient<'a> {
+    let contract_id = e.register_contract(None, BountyEscrowContract);
+    BountyEscrowContractClient::new(e, &contract_id)
+}
+
+fn setup_contract(env: &Env) -> (Address, Address, token::Client, BountyEscrowContractClient) {
+    let admin = Address::generate(env);
+    let depositor = Address::generate(env);
+    let (token_client, token_admin) = create_token_contract(env, &admin);
+    let escrow_client = create_escrow_contract(env);
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "init",
+            args: (&admin, &token_client.address).into_val(env),
+            sub_invokes: &[],
+        },
+    }]);
+    escrow_client.init(&admin, &token_client.address);
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &token_client.address,
+            fn_name: "mint",
+            args: (depositor.clone(), 100000i128).into_val(env),
+            sub_invokes: &[],
+        },
+    }]);
+    token_admin.mint(&depositor, &100000);
+
+    (admin, depositor, token_client, escrow_client)
+}
+
+// ==================== Deadline Validation Tests (Issue #40) ====================
+
+#[test]
+fn test_lock_funds_rejects_past_deadline() {
+    let env = Env::default();
+    let (_admin, depositor, _token_client, escrow_client) = setup_contract(&env);
+
+    // Use 0 as a past deadline to avoid underflow
+    let past_deadline = 0u64;
+
+    env.mock_auths(&[MockAuth {
+        address: &depositor,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "lock_funds",
+            args: (depositor.clone(), 1u64, 1000i128, past_deadline).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = escrow_client.try_lock_funds(&depositor, &1u64, &1000i128, &past_deadline);
+    assert_eq!(result, Err(Ok(Error::InvalidDeadline)));
+}
+
+#[test]
+fn test_lock_funds_rejects_zero_deadline() {
+    let env = Env::default();
+    let (_admin, depositor, _token_client, escrow_client) = setup_contract(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &depositor,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "lock_funds",
+            args: (depositor.clone(), 1u64, 1000i128, 0u64).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = escrow_client.try_lock_funds(&depositor, &1u64, &1000i128, &0u64);
+    assert_eq!(result, Err(Ok(Error::InvalidDeadline)));
+}
+
+#[test]
+fn test_lock_funds_rejects_deadline_beyond_max_horizon() {
+    let env = Env::default();
+    let (admin, depositor, _token_client, escrow_client) = setup_contract(&env);
+
+    // Set max horizon to 1 day (86400 seconds)
+    let max_horizon = 86400u64;
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "set_deadline_horizon",
+            args: (admin.clone(), max_horizon).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    escrow_client.set_deadline_horizon(&admin, &max_horizon);
+
+    // Try to lock with deadline 2 days in the future
+    let too_far_deadline = env.ledger().timestamp() + 172800;
+
+    env.mock_auths(&[MockAuth {
+        address: &depositor,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "lock_funds",
+            args: (depositor.clone(), 1u64, 1000i128, too_far_deadline).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = escrow_client.try_lock_funds(&depositor, &1u64, &1000i128, &too_far_deadline);
+    assert_eq!(result, Err(Ok(Error::InvalidDeadline)));
+}
+
+#[test]
+fn test_lock_funds_accepts_valid_deadline_within_horizon() {
+    let env = Env::default();
+    let (admin, depositor, token_client, escrow_client) = setup_contract(&env);
+
+    // Set max horizon to 7 days
+    let max_horizon = 604800u64;
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "set_deadline_horizon",
+            args: (admin.clone(), max_horizon).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    escrow_client.set_deadline_horizon(&admin, &max_horizon);
+
+    // Lock with deadline 1 day in the future (within horizon)
+    let valid_deadline = env.ledger().timestamp() + 86400;
+
+    env.mock_auths(&[MockAuth {
+        address: &depositor,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "lock_funds",
+            args: (depositor.clone(), 1u64, 1000i128, valid_deadline).into_val(&env),
+            sub_invokes: &[MockAuthInvoke {
+                contract: &token_client.address,
+                fn_name: "transfer",
+                args: (
+                    depositor.clone(),
+                    escrow_client.address.clone(),
+                    1000i128,
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            }],
+        },
+    }]);
+
+    let result = escrow_client.try_lock_funds(&depositor, &1u64, &1000i128, &valid_deadline);
+    assert_eq!(result, Ok(Ok(())));
+}
+
+// ==================== Amount Validation Tests (Issue #40) ====================
+
+#[test]
+fn test_lock_funds_rejects_zero_amount() {
+    let env = Env::default();
+    let (admin, depositor, _token_client, escrow_client) = setup_contract(&env);
+
+    let deadline = env.ledger().timestamp() + 86400;
+
+    env.mock_auths(&[MockAuth {
+        address: &depositor,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "lock_funds",
+            args: (depositor.clone(), 1u64, 0i128, deadline).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = escrow_client.try_lock_funds(&depositor, &1u64, &0i128, &deadline);
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}
+
+#[test]
+fn test_lock_funds_rejects_negative_amount() {
+    let env = Env::default();
+    let (admin, depositor, _token_client, escrow_client) = setup_contract(&env);
+
+    let deadline = env.ledger().timestamp() + 86400;
+
+    env.mock_auths(&[MockAuth {
+        address: &depositor,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "lock_funds",
+            args: (depositor.clone(), 1u64, -100i128, deadline).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = escrow_client.try_lock_funds(&depositor, &1u64, &(-100i128), &deadline);
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}
+
+// ==================== Deadline Horizon Admin Tests ====================
+
+#[test]
+fn test_set_deadline_horizon_only_admin() {
+    let env = Env::default();
+    let (admin, depositor, _token_client, escrow_client) = setup_contract(&env);
+
+    // Non-admin tries to set horizon
+    env.mock_auths(&[MockAuth {
+        address: &depositor,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "set_deadline_horizon",
+            args: (depositor.clone(), 86400u64).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = escrow_client.try_set_deadline_horizon(&depositor, &86400u64);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_set_deadline_horizon_clear() {
+    let env = Env::default();
+    let (admin, depositor, token_client, escrow_client) = setup_contract(&env);
+
+    // Set horizon
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "set_deadline_horizon",
+            args: (admin.clone(), 86400u64).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    escrow_client.set_deadline_horizon(&admin, &86400u64);
+
+    // Clear horizon
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "set_deadline_horizon",
+            args: (admin.clone(), 0u64).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    escrow_client.set_deadline_horizon(&admin, &0u64);
+
+    // Now any future deadline should work
+    let far_future = env.ledger().timestamp() + 99999999;
+
+    env.mock_auths(&[MockAuth {
+        address: &depositor,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "lock_funds",
+            args: (depositor.clone(), 1u64, 1000i128, far_future).into_val(&env),
+            sub_invokes: &[MockAuthInvoke {
+                contract: &token_client.address,
+                fn_name: "transfer",
+                args: (
+                    depositor.clone(),
+                    escrow_client.address.clone(),
+                    1000i128,
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            }],
+        },
+    }]);
+
+    let result = escrow_client.try_lock_funds(&depositor, &1u64, &1000i128, &far_future);
+    assert_eq!(result, Ok(Ok(())));
+}
+
+// ==================== Batch Lock Deadline Validation Tests ====================
+
+#[test]
+fn test_batch_lock_funds_rejects_past_deadline() {
+    let env = Env::default();
+    let (_admin, depositor, _token_client, escrow_client) = setup_contract(&env);
+
+    // Use 0 as a past deadline to avoid underflow
+    let past_deadline = 0u64;
+
+    let item = LockFundsItem {
+        bounty_id: 1,
+        depositor: depositor.clone(),
+        amount: 1000,
+        deadline: past_deadline,
+    };
+
+    env.mock_auths(&[MockAuth {
+        address: &depositor,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "batch_lock_funds",
+            args: (vec![&env, item.clone()]).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = escrow_client.try_batch_lock_funds(&vec![&env, item]);
+    assert_eq!(result, Err(Ok(Error::InvalidDeadline)));
+}
+
+#[test]
+fn test_batch_lock_funds_rejects_zero_amount() {
+    let env = Env::default();
+    let (_admin, depositor, _token_client, escrow_client) = setup_contract(&env);
+
+    let deadline = env.ledger().timestamp() + 86400;
+
+    let item = LockFundsItem {
+        bounty_id: 1,
+        depositor: depositor.clone(),
+        amount: 0,
+        deadline,
+    };
+
+    env.mock_auths(&[MockAuth {
+        address: &depositor,
+        invoke: &MockAuthInvoke {
+            contract: &escrow_client.address,
+            fn_name: "batch_lock_funds",
+            args: (vec![&env, item.clone()]).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = escrow_client.try_batch_lock_funds(&vec![&env, item]);
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}


### PR DESCRIPTION
## Problem

`bounty_escrow` defines `Error::InvalidDeadline` (enum value 14) and `Error::InvalidAmount` (13), but `lock_funds` never validates the deadline (accepts any u64, including past timestamps or u64::MAX) and only enforces amount bounds when an optional AmountPolicy is set.

This allows escrows that can never be refunded (deadline in far future) or that are immediately past-deadline, and unbounded amounts.

## Changes

### bounty_escrow/contracts/escrow/src/lib.rs

1. **Deadline validation in lock_funds**: Rejects deadline <= now with Error::InvalidDeadline

2. **Configurable max deadline horizon**: New set_deadline_horizon(admin, max_horizon) admin function. When set, rejects deadlines more than max_horizon seconds in the future. Pass 0 to clear.

3. **Amount validation in lock_funds**: Rejects amount <= 0 with Error::InvalidAmount even when no AmountPolicy is configured

4. **Batch validation**: batch_lock_funds applies the same deadline/amount validation per item (atomic — entire batch reverts if any item fails)

### New DataKey variant

- DeadlineHorizon — stores the max horizon as u64. Uses u64::MAX as sentinel for no restriction.

### Tests (10 new tests)

- test_lock_funds_rejects_past_deadline
- test_lock_funds_rejects_zero_deadline
- test_lock_funds_rejects_deadline_beyond_max_horizon
- test_lock_funds_accepts_valid_deadline_within_horizon
- test_lock_funds_rejects_zero_amount
- test_lock_funds_rejects_negative_amount
- test_set_deadline_horizon_only_admin
- test_set_deadline_horizon_clear
- test_batch_lock_funds_rejects_past_deadline
- test_batch_lock_funds_rejects_zero_amount

### Updated existing test

- test_lock_funds_zero_amount_edge_case — now expects InvalidAmount error instead of success

## Test Results

All 10 new tests pass. 338 existing tests pass. 6 pre-existing failures (analytics/proptest) unrelated to this change.

## Acceptance Criteria

- lock_funds returns InvalidDeadline for past deadlines
- lock_funds returns InvalidDeadline for deadlines beyond max horizon
- amount <= 0 rejected without requiring a policy
- Batch path validates each item and tests pass
- Admin can set/clear deadline horizon
- Comprehensive test coverage

Closes #40
