### PR TITLE
Make large payout monitoring threshold admin-configurable with on-cha…

### DIFF
--- a/program-escrow/src/lib.rs
+++ b/program-escrow/src/lib.rs
@@ -787,7 +787,7 @@ impl ProgramEscrowContract {
         recipient: &Address,
         amount: i128,
     ) {
-        let threshold = program_data.total_funds / 10; // 10% of total funds
+        let threshold = monitoring::get_large_payout_threshold_amount(env, program_data.total_funds);
         if amount >= threshold {
             env.events().publish(
                 (LARGE_PAYOUT,),
@@ -1458,6 +1458,25 @@ impl ProgramEscrowContract {
             })
     }
 
+    /// Set the large payout threshold, expressed in basis points of total funds.
+    /// Admin only.
+    pub fn set_large_payout_threshold(env: Env, threshold_bps: u32) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Not initialized"));
+        admin.require_auth();
+        Self::check_governance_requirements(&env)?;
+        monitoring::set_large_payout_threshold_bps(&env, threshold_bps);
+        Ok(())
+    }
+
+    /// Get the current large payout threshold in basis points.
+    pub fn get_large_payout_threshold(env: Env) -> u32 {
+        monitoring::get_large_payout_threshold_bps(&env)
+    }
+
     /// Set the fund cap configuration (admin only).
     /// When enabled, `lock_program_funds` will reject locks that exceed either cap.
     /// Pass `None` for either field to leave that cap unset.
@@ -1748,7 +1767,7 @@ impl ProgramEscrowContract {
         let timestamp = env.ledger().timestamp();
         let contract_address = env.current_contract_address();
         let token_client = token::Client::new(&env, &program_data.token_address);
-        let threshold = program_data.total_funds / 10;
+        let threshold = monitoring::get_large_payout_threshold_amount(&env, program_data.total_funds);
         let program_id = program_data.program_id.clone();
 
         for i in 0..batch_len {

--- a/program-escrow/src/monitoring.rs
+++ b/program-escrow/src/monitoring.rs
@@ -182,3 +182,25 @@ pub fn get_performance_stats(env: &Env, function_name: Symbol) -> PerformanceSta
         last_called: last,
     }
 }
+
+const LARGE_PAYOUT_THRESHOLD: &str = "large_payout_threshold";
+const DEFAULT_LARGE_PAYOUT_THRESHOLD_BPS: u32 = 1000;
+const LARGE_PAYOUT_THRESHOLD_DENOMINATOR: i128 = 10_000;
+
+pub fn set_large_payout_threshold_bps(env: &Env, threshold_bps: u32) {
+    env.storage()
+        .instance()
+        .set(&Symbol::new(env, LARGE_PAYOUT_THRESHOLD), &threshold_bps);
+}
+
+pub fn get_large_payout_threshold_bps(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&Symbol::new(env, LARGE_PAYOUT_THRESHOLD))
+        .unwrap_or(DEFAULT_LARGE_PAYOUT_THRESHOLD_BPS)
+}
+
+pub fn get_large_payout_threshold_amount(env: &Env, total_funds: i128) -> i128 {
+    let threshold_bps = get_large_payout_threshold_bps(env) as i128;
+    total_funds * threshold_bps / LARGE_PAYOUT_THRESHOLD_DENOMINATOR
+}

--- a/program-escrow/src/test_monitoring.rs
+++ b/program-escrow/src/test_monitoring.rs
@@ -62,3 +62,48 @@ fn test_monitoring_analytics_and_health() {
     assert_eq!(snapshot.total_operations, 2);
     assert_eq!(snapshot.total_errors, 0);
 }
+
+#[test]
+fn test_default_large_payout_threshold_is_ten_percent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+
+    let threshold_bps = client.get_large_payout_threshold();
+    assert_eq!(threshold_bps, 1000);
+}
+
+#[test]
+fn test_admin_can_update_large_payout_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+
+    assert_eq!(client.get_large_payout_threshold(), 1000);
+    client.try_set_large_payout_threshold(&2000).unwrap();
+    assert_eq!(client.get_large_payout_threshold(), 2000);
+}
+
+#[test]
+#[should_panic]
+fn test_non_admin_cannot_update_large_payout_threshold() {
+    let env = Env::default();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+
+    client.try_set_large_payout_threshold(&2000).unwrap();
+}


### PR DESCRIPTION
# Summary

This PR adds an admin-configurable large payout monitoring threshold to the `program-escrow` contract and persists the configuration on-chain, allowing the alert threshold to be updated without modifying the contract's default behavior.

## Changes

### `program-escrow/src/monitoring.rs`

- Added storage-backed getters and setters for `large_payout_threshold_bps`.
- Preserved the default threshold value of **10%**.
- Added helper logic to calculate the alert amount using the stored threshold.

### `program-escrow/src/lib.rs`

- Updated large payout alert checks to use the on-chain configured threshold.
- Added the following public contract methods:
  - `set_large_payout_threshold`
  - `get_large_payout_threshold`
- Restricted threshold updates to authorized admin users.

### `program-escrow/src/test_monitoring.rs`

Added test coverage for:

- Default threshold is **10%**.
- Admin can successfully update the threshold.
- Non-admin attempts to update the threshold are rejected.

## Why

Previously, the large payout alert threshold was fixed. This change makes the threshold configurable at runtime while preserving the existing default behavior. It also ensures that only authorized administrators can modify the configuration, improving operational flexibility without compromising security.

## Files Changed

- `program-escrow/src/monitoring.rs`
- `program-escrow/src/lib.rs`
- `program-escrow/src/test_monitoring.rs`

## Acceptance Checklist

- [x] Threshold is stored on-chain.
- [x] Default threshold remains **10%**.
- [x] Admin can update the threshold through a public contract method.
- [x] Non-admin updates are rejected.
- [x] Large payout monitoring uses the configured threshold.
- [x] Comprehensive tests cover default behavior, successful updates, and unauthorized access.

## How to Review

1. Review the storage implementation in `monitoring.rs`.
2. Verify that alert calculations use the stored threshold.
3. Confirm that `set_large_payout_threshold` enforces admin authorization.
4. Run the monitoring tests to verify the default value, admin update flow, and unauthorized update rejection.

## Closes #193 