### PR TITLE
Make large payout monitoring threshold admin-configurable with on-cha…

### DIFF
--- a/program-escrow/src/lib.rs
+++ b/program-escrow/src/lib.rs
@@ -787,7 +787,7 @@ impl ProgramEscrowContract {
         recipient: &Address,
         amount: i128,
     ) {
-        let threshold = program_data.total_funds / 10; // 10% of total funds
+        let threshold = monitoring::get_large_payout_threshold_amount(env, program_data.total_funds);
         if amount >= threshold {
             env.events().publish(
                 (LARGE_PAYOUT,),
@@ -1458,6 +1458,25 @@ impl ProgramEscrowContract {
             })
     }
 
+    /// Set the large payout threshold, expressed in basis points of total funds.
+    /// Admin only.
+    pub fn set_large_payout_threshold(env: Env, threshold_bps: u32) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Not initialized"));
+        admin.require_auth();
+        Self::check_governance_requirements(&env)?;
+        monitoring::set_large_payout_threshold_bps(&env, threshold_bps);
+        Ok(())
+    }
+
+    /// Get the current large payout threshold in basis points.
+    pub fn get_large_payout_threshold(env: Env) -> u32 {
+        monitoring::get_large_payout_threshold_bps(&env)
+    }
+
     /// Set the fund cap configuration (admin only).
     /// When enabled, `lock_program_funds` will reject locks that exceed either cap.
     /// Pass `None` for either field to leave that cap unset.
@@ -1748,7 +1767,7 @@ impl ProgramEscrowContract {
         let timestamp = env.ledger().timestamp();
         let contract_address = env.current_contract_address();
         let token_client = token::Client::new(&env, &program_data.token_address);
-        let threshold = program_data.total_funds / 10;
+        let threshold = monitoring::get_large_payout_threshold_amount(&env, program_data.total_funds);
         let program_id = program_data.program_id.clone();
 
         for i in 0..batch_len {

--- a/program-escrow/src/monitoring.rs
+++ b/program-escrow/src/monitoring.rs
@@ -182,3 +182,25 @@ pub fn get_performance_stats(env: &Env, function_name: Symbol) -> PerformanceSta
         last_called: last,
     }
 }
+
+const LARGE_PAYOUT_THRESHOLD: &str = "large_payout_threshold";
+const DEFAULT_LARGE_PAYOUT_THRESHOLD_BPS: u32 = 1000;
+const LARGE_PAYOUT_THRESHOLD_DENOMINATOR: i128 = 10_000;
+
+pub fn set_large_payout_threshold_bps(env: &Env, threshold_bps: u32) {
+    env.storage()
+        .instance()
+        .set(&Symbol::new(env, LARGE_PAYOUT_THRESHOLD), &threshold_bps);
+}
+
+pub fn get_large_payout_threshold_bps(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&Symbol::new(env, LARGE_PAYOUT_THRESHOLD))
+        .unwrap_or(DEFAULT_LARGE_PAYOUT_THRESHOLD_BPS)
+}
+
+pub fn get_large_payout_threshold_amount(env: &Env, total_funds: i128) -> i128 {
+    let threshold_bps = get_large_payout_threshold_bps(env) as i128;
+    total_funds * threshold_bps / LARGE_PAYOUT_THRESHOLD_DENOMINATOR
+}

--- a/program-escrow/src/test_monitoring.rs
+++ b/program-escrow/src/test_monitoring.rs
@@ -62,3 +62,48 @@ fn test_monitoring_analytics_and_health() {
     assert_eq!(snapshot.total_operations, 2);
     assert_eq!(snapshot.total_errors, 0);
 }
+
+#[test]
+fn test_default_large_payout_threshold_is_ten_percent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+
+    let threshold_bps = client.get_large_payout_threshold();
+    assert_eq!(threshold_bps, 1000);
+}
+
+#[test]
+fn test_admin_can_update_large_payout_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+
+    assert_eq!(client.get_large_payout_threshold(), 1000);
+    client.try_set_large_payout_threshold(&2000).unwrap();
+    assert_eq!(client.get_large_payout_threshold(), 2000);
+}
+
+#[test]
+#[should_panic]
+fn test_non_admin_cannot_update_large_payout_threshold() {
+    let env = Env::default();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+
+    client.try_set_large_payout_threshold(&2000).unwrap();
+}


### PR DESCRIPTION
## Description

Move the hardcoded large-payout threshold (10% of total funds) in `monitoring.rs` into contract storage with an admin-gated setter and read-only getter. Different deployments (testnet vs mainnet, different program sizes) can now configure this threshold without a contract code change or redeploy.

## Changes

- **`monitoring.rs`**: Added storage-backed `set_large_payout_threshold_bps`, `get_large_payout_threshold_bps`, and `get_large_payout_threshold_amount` with default 1000 bps (10%)
- **`lib.rs`**: Added admin-gated `set_large_payout_threshold` and read-only `get_large_payout_threshold`; replaced two hardcoded `total_funds / 10` usages
- **`test_monitoring.rs`**: Added 3 tests covering default value, admin update, and non-admin rejection

## Acceptance criteria

- [x] Thresholds are stored on-chain and admin-configurable
- [x] Default (1000 bps = 10%) matches previous hardcoded behavior exactly
- [x] Non-admin update attempts are rejected (tested via `test_non_admin_cannot_update_large_payout_threshold`)

## Testing

All 323 unit tests pass with no failures.

## Closes #193 