### PR TITLE
feat(grainlify-core): add contract version key and migration guard #181

### DIFF
--- a/grainlify-core/src/lib.rs
+++ b/grainlify-core/src/lib.rs
@@ -1201,6 +1201,11 @@ impl GrainlifyContract {
         env.storage().instance().get(&DataKey::Version).unwrap_or(0)
     }
 
+    /// Alias for get_version, exposed for off-chain tooling. Returns the current stored version.
+    pub fn version(env: Env) -> u32 {
+        Self::get_version(env)
+    }
+
     /// Short alias used by escrow governance integration cross-contract calls.
     pub fn get_ver(env: Env) -> u32 {
         Self::get_version(env)
@@ -1641,6 +1646,22 @@ mod test {
         signers.push_back(Address::generate(&env));
         signers.push_back(Address::generate(&env));
 
+        client.init(&signers, &2u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "Already initialized")]
+    fn test_init_twice_panics() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, GrainlifyContract);
+        let client = GrainlifyContractClient::new(&env, &contract_id);
+
+        let mut signers = soroban_sdk::Vec::new(&env);
+        signers.push_back(Address::generate(&env));
+        signers.push_back(Address::generate(&env));
+        signers.push_back(Address::generate(&env));
+
+        client.init(&signers, &2u32);
         client.init(&signers, &2u32);
     }
 


### PR DESCRIPTION
### Description
This PR addresses issue #181 by adding a read-only `version()` getter alias for off-chain tooling, and ensures that the contract has proper testing for the already-initialized guard to prevent it from being initialized twice. 

### Changes made:
- Added `version()` read-only function in `grainlify-core/src/lib.rs` which serves as an alias to `get_version()`.
- Added `test_init_twice_panics` in `lib.rs` test suite to explicitly cover the double-init rejection in `init`.

Closes #181
