### PR TITLE
Expand malicious_reentrant.rs test harness to cover cross-contract token-callback reentrancy #191

### DIFF
--- a/program-escrow/src/malicious_reentrant.rs
+++ b/program-escrow/src/malicious_reentrant.rs
@@ -183,4 +183,43 @@ impl MaliciousReentrantContract {
         // This should trigger the callback which will attempt reentrancy
         client.single_payout(&attacker, &amount);
     }
+
+    /// Standard token interface transfer method to perform callback attacks
+    pub fn transfer(env: Env, _from: Address, to: Address, amount: i128) {
+        let attack_mode = Self::get_attack_mode(env.clone());
+
+        // Only attack once to avoid infinite loops in tests
+        let attack_count = Self::get_attack_count(env.clone());
+        if attack_count > 0 {
+            return;
+        }
+
+        Self::increment_attack_count(&env);
+
+        match attack_mode {
+            1 => {
+                let target = Self::get_target(env.clone());
+                let client = crate::ProgramEscrowContractClient::new(&env, &target);
+                client.single_payout(&to, &amount);
+            }
+            2 => {
+                let target = Self::get_target(env.clone());
+                let client = crate::ProgramEscrowContractClient::new(&env, &target);
+                let recipients = soroban_sdk::vec![&env, to];
+                let amounts = soroban_sdk::vec![&env, amount];
+                client.batch_payout(&recipients, &amounts);
+            }
+            3 => {
+                let target = Self::get_target(env.clone());
+                let client = crate::ProgramEscrowContractClient::new(&env, &target);
+                client.trigger_program_releases();
+            }
+            _ => { }
+        }
+    }
+
+    /// Dummy balance method required by token interface
+    pub fn balance(_env: Env, _id: Address) -> i128 {
+        1000_0000000i128
+    }
 }

--- a/program-escrow/src/malicious_reentrant.rs
+++ b/program-escrow/src/malicious_reentrant.rs
@@ -184,3 +184,38 @@ impl MaliciousReentrantContract {
         client.single_payout(&attacker, &amount);
     }
 }
+
+
+#[contract]
+pub struct MaliciousTokenContract;
+
+#[contractimpl]
+impl MaliciousTokenContract {
+    pub fn init(env: Env, target_contract: Address, target_function: u32) {
+        env.storage().instance().set(&soroban_sdk::symbol_short!("Target"), &target_contract);
+        env.storage().instance().set(&soroban_sdk::symbol_short!("Func"), &target_function);
+    }
+    
+    pub fn transfer(env: Env, _from: Address, to: Address, amount: i128) {
+        if let Some(target) = env.storage().instance().get::<_, Address>(&soroban_sdk::symbol_short!("Target")) {
+            let func: u32 = env.storage().instance().get(&soroban_sdk::symbol_short!("Func")).unwrap_or(0);
+            let count: u32 = env.storage().instance().get(&soroban_sdk::symbol_short!("Count")).unwrap_or(0);
+            
+            if count == 0 {
+                env.storage().instance().set(&soroban_sdk::symbol_short!("Count"), &(count + 1));
+                let client = crate::ProgramEscrowContractClient::new(&env, &target);
+                
+                match func {
+                    1 => { client.single_payout(&to, &amount); },
+                    2 => { client.trigger_program_releases(); },
+                    3 => { client.refund_unallocated_funds(&to); },
+                    _ => {}
+                }
+            }
+        }
+    }
+    
+    pub fn balance(_env: Env, _id: Address) -> i128 {
+        1000_0000000i128
+    }
+}

--- a/program-escrow/src/reentrancy_tests.rs
+++ b/program-escrow/src/reentrancy_tests.rs
@@ -522,3 +522,76 @@ fn test_reentrancy_guard_model_documentation() {
 
     assert!(true, "Documentation test - see comments for guarantees");
 }
+
+
+// ============================================================================
+// Token Callback Reentrancy Tests
+// ============================================================================
+
+#[test]
+#[should_panic(expected = "Reentrancy detected")]
+fn test_token_callback_reentrancy_single_payout() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let authorized_key = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let program_id = String::from_str(&env, "test-program");
+    let amount = 1000_0000000i128;
+
+    // Register our malicious reentrant contract and use it as the token
+    let token_address = env.register_contract(None, crate::malicious_reentrant::MaliciousReentrantContract);
+    let malicious_token = crate::malicious_reentrant::MaliciousReentrantContractClient::new(&env, &token_address);
+    malicious_token.init(&contract_id);
+    malicious_token.set_attack_mode(&1u32); // 1 = attack single_payout
+
+    client.init_program(&program_id, &authorized_key, &token_address);
+    
+    malicious_token.set_attack_mode(&0u32);
+    // Lock funds with normal mode
+    client.lock_program_funds(&authorized_key, &amount);
+    
+    // Now enable attack mode before payout
+    malicious_token.set_attack_mode(&1u32);
+    malicious_token.reset_attack_count();
+
+    // This should panic when it calls transfer() on our malicious token
+    client.single_payout(&recipient, &(amount / 2));
+}
+
+#[test]
+#[should_panic(expected = "Reentrancy detected")]
+fn test_token_callback_reentrancy_trigger_releases() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let authorized_key = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let program_id = String::from_str(&env, "test-program");
+    let amount = 1000_0000000i128;
+    let release_timestamp = 1000u64;
+
+    let token_address = env.register_contract(None, crate::malicious_reentrant::MaliciousReentrantContract);
+    let malicious_token = crate::malicious_reentrant::MaliciousReentrantContractClient::new(&env, &token_address);
+    malicious_token.init(&contract_id);
+    malicious_token.set_attack_mode(&0u32); 
+
+    client.init_program(&program_id, &authorized_key, &token_address);
+    client.lock_program_funds(&authorized_key, &amount);
+    client.create_program_release_schedule(&amount, &release_timestamp, &recipient);
+
+    env.ledger().set_timestamp(release_timestamp + 1);
+
+    // Enable attack mode 3 = attack trigger_program_releases
+    malicious_token.set_attack_mode(&3u32);
+    malicious_token.reset_attack_count();
+
+    // This should panic when it calls transfer()
+    client.trigger_program_releases();
+}

--- a/program-escrow/src/reentrancy_tests.rs
+++ b/program-escrow/src/reentrancy_tests.rs
@@ -522,3 +522,59 @@ fn test_reentrancy_guard_model_documentation() {
 
     assert!(true, "Documentation test - see comments for guarantees");
 }
+
+
+// ============================================================================
+// Token Callback Reentrancy Tests
+// ============================================================================
+
+#[test]
+#[should_panic(expected = "Reentrancy detected")]
+fn test_token_callback_reentrancy_single_payout() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let authorized_key = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let program_id = String::from_str(&env, "test-program");
+    let amount = 1000_0000000i128;
+
+    // Register our malicious token contract
+    let token_address = env.register_contract(None, crate::malicious_reentrant::MaliciousTokenContract);
+    let malicious_token = crate::malicious_reentrant::MaliciousTokenContractClient::new(&env, &token_address);
+    malicious_token.init(&contract_id, &1u32); // 1 = attack single_payout
+
+    client.init_program(&program_id, &authorized_key, &token_address);
+    client.lock_program_funds(&authorized_key, &amount);
+
+    // This should panic when it calls transfer() on our malicious token
+    client.single_payout(&recipient, &(amount / 2));
+}
+
+#[test]
+#[should_panic(expected = "Reentrancy detected")]
+fn test_token_callback_reentrancy_refund() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let authorized_key = Address::generate(&env);
+    let program_id = String::from_str(&env, "test-program");
+    let amount = 1000_0000000i128;
+
+    // Register our malicious token contract
+    let token_address = env.register_contract(None, crate::malicious_reentrant::MaliciousTokenContract);
+    let malicious_token = crate::malicious_reentrant::MaliciousTokenContractClient::new(&env, &token_address);
+    malicious_token.init(&contract_id, &3u32); // 3 = attack refund
+
+    client.init_program(&program_id, &authorized_key, &token_address);
+    client.lock_program_funds(&authorized_key, &amount);
+
+    // This should panic when it calls transfer()
+    client.refund_unallocated_funds(&authorized_key);
+}


### PR DESCRIPTION
This PR expands the `malicious_reentrant.rs` test harness to include a malicious token contract (`MaliciousTokenContract`) that simulates a realistic cross-contract token-callback reentrancy attack. 

It wires this new attack scenario into the `reentrancy_tests.rs` suite and confirms that the existing `reentrancy_guard` correctly blocks the attempted re-entrant calls when performing token transfers. Both the `single_payout` release and `refund_unallocated_funds` entrypoints are now covered by these tests.

Closes #191
