### PR TITLE
test: add metric decay/reset coverage over simulated time

### DIFF
--- a/program-escrow/src/monitoring.rs
+++ b/program-escrow/src/monitoring.rs
@@ -1,9 +1,18 @@
 use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Symbol};
 
 // Storage keys
-const OPERATION_COUNT: &str = "op_count";
-const USER_COUNT: &str = "usr_count";
-const ERROR_COUNT: &str = "err_count";
+const OPERATION_COUNT: &str = "op_count"; // Lifetime metric (never decays)
+const USER_COUNT: &str = "usr_count"; // Lifetime metric (never decays)
+const ERROR_COUNT: &str = "err_count"; // Lifetime metric (never decays)
+
+// Window keys for metric decay
+const WINDOW_START: &str = "win_start";
+const WINDOW_OPS: &str = "win_ops";
+const WINDOW_ERRS: &str = "win_errs";
+
+const WINDOW_DURATION: u64 = 3600; // 1 hour rolling window
+const ERROR_RATE_THRESHOLD_BPS: u32 = 5000; // 50% error rate trips alert
+
 
 // Event: Operation metric
 #[contracttype]
@@ -77,12 +86,36 @@ pub fn track_operation(env: &Env, operation: Symbol, caller: Address, success: b
         env.storage().persistent().set(&err_key, &(err_count + 1));
     }
 
+    // Window logic for metric decay/reset
+    let start_key = Symbol::new(env, WINDOW_START);
+    let win_ops_key = Symbol::new(env, WINDOW_OPS);
+    let win_errs_key = Symbol::new(env, WINDOW_ERRS);
+    
+    let now = env.ledger().timestamp();
+    let win_start_opt: Option<u64> = env.storage().persistent().get(&start_key);
+    let win_start_val = win_start_opt.unwrap_or(now);
+    
+    // Explicit reset after WINDOW_DURATION or on first operation
+    if win_start_opt.is_none() || now.saturating_sub(win_start_val) >= WINDOW_DURATION {
+        env.storage().persistent().set(&start_key, &now);
+        env.storage().persistent().set(&win_ops_key, &1u64);
+        env.storage().persistent().set(&win_errs_key, &(if success { 0u64 } else { 1u64 }));
+    } else {
+        let w_ops: u64 = env.storage().persistent().get(&win_ops_key).unwrap_or(0);
+        env.storage().persistent().set(&win_ops_key, &(w_ops + 1));
+        
+        if !success {
+            let w_errs: u64 = env.storage().persistent().get(&win_errs_key).unwrap_or(0);
+            env.storage().persistent().set(&win_errs_key, &(w_errs + 1));
+        }
+    }
+
     env.events().publish(
         (symbol_short!("metric"), symbol_short!("op")),
         OperationMetric {
             operation,
             caller,
-            timestamp: env.ledger().timestamp(),
+            timestamp: now,
             success,
         },
     );
@@ -116,8 +149,31 @@ pub fn health_check(env: &Env) -> HealthStatus {
     let key = Symbol::new(env, OPERATION_COUNT);
     let ops: u64 = env.storage().persistent().get(&key).unwrap_or(0);
 
+    let start_key = Symbol::new(env, WINDOW_START);
+    let win_start_opt: Option<u64> = env.storage().persistent().get(&start_key);
+    let win_start_val = win_start_opt.unwrap_or(0); // If none, then error rate check doesn't matter much, but we handle it
+    let now = env.ledger().timestamp();
+    
+    // An alert triggered by a stale metric clears once the window decays
+    let is_healthy = if win_start_opt.is_none() || now.saturating_sub(win_start_val) >= WINDOW_DURATION {
+        true
+    } else {
+        let win_ops_key = Symbol::new(env, WINDOW_OPS);
+        let win_errs_key = Symbol::new(env, WINDOW_ERRS);
+        let w_ops: u64 = env.storage().persistent().get(&win_ops_key).unwrap_or(0);
+        let w_errs: u64 = env.storage().persistent().get(&win_errs_key).unwrap_or(0);
+        
+        if w_ops > 0 {
+            let error_rate = (w_errs as u128 * 10_000) / (w_ops as u128);
+            error_rate < ERROR_RATE_THRESHOLD_BPS as u128
+        } else {
+            true
+        }
+    };
+
+
     HealthStatus {
-        is_healthy: true,
+        is_healthy,
         last_operation: env.ledger().timestamp(),
         total_operations: ops,
         contract_version: String::from_str(env, "1.0.0"),

--- a/program-escrow/src/test_monitoring.rs
+++ b/program-escrow/src/test_monitoring.rs
@@ -240,13 +240,74 @@ fn test_large_payout_threshold_respects_custom_bps() {
     assert_eq!(threshold, 25_000);
 }
 
-// Rolling-window / rapid-successive-claims criterion (issue #192):
-// monitoring.rs has no rolling window or rate-of-claims tracking. This is a
-// documented gap, not a regression — the module only supports the large-payout
-// threshold check above. Left as `#[ignore]` so it surfaces as "skipped" rather
-// than silently passing.
+// Rolling-window / metric decay and alert clearing tests (issue #238)
 #[test]
-#[ignore]
-fn test_rolling_window_reset_behavior() {
-    panic!("monitoring.rs does not implement a rolling window / rapid-claims detector");
+fn test_metric_decay_and_alert_clearing() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    // Initial state: healthy
+    assert_eq!(client.health_check().is_healthy, true);
+
+    // Setup program for operations
+    let admin = Address::generate(&env);
+    let tokenadmin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract(tokenadmin.clone());
+    let program_id = String::from_str(&env, "decay-test");
+    
+    // Set initial time
+    env.ledger().set_timestamp(1000);
+    
+    // Operation 1 (Init): success
+    client.init_program(&program_id, &admin, &token_id);
+    assert_eq!(client.health_check().is_healthy, true);
+    
+    // Operation 2: Trigger error
+    // Since normal contract panics roll back the state, we directly inject a tracked failure
+    // as if a non-panicking internal check failed and tracked it.
+    env.as_contract(&contract_id, || {
+        crate::monitoring::track_operation(&env, symbol_short!("lock"), admin.clone(), false);
+    });
+    
+    // At this point in the window: 1 success, 1 failure -> 50% error rate
+    // Threshold is 50%, so it should trip the alert (is_healthy = false)
+    assert_eq!(client.health_check().is_healthy, false);
+    
+    let snap1 = client.get_state_snapshot();
+    assert_eq!(snap1.total_operations, 2);
+    assert_eq!(snap1.total_errors, 1);
+    
+    // Edge case: Metric right at the decay boundary (1 hour = 3600 seconds)
+    // At timestamp 1000 + 3599 = 4599, the window has NOT decayed
+    env.ledger().set_timestamp(4599);
+    assert_eq!(client.health_check().is_healthy, false);
+    
+    // Metric decays (window reset) at boundary: timestamp 1000 + 3600 = 4600
+    env.ledger().set_timestamp(4600);
+    
+    // Alert state clears due to decay of old metrics
+    assert_eq!(client.health_check().is_healthy, true);
+    
+    // The metric that should NEVER decay (ERROR_COUNT) is confirmed not to
+    let snap2 = client.get_state_snapshot();
+    assert_eq!(snap2.total_operations, 2);
+    assert_eq!(snap2.total_errors, 1);
+    
+    // Perform a new operation in the new window (success)
+    env.as_contract(&contract_id, || {
+        crate::monitoring::track_operation(&env, symbol_short!("lock"), admin.clone(), true);
+    });
+    
+    // Window now has 1 success, 0 errors -> 0% error rate
+    assert_eq!(client.health_check().is_healthy, true);
+    
+    // Overall metrics continue to accumulate
+    let snap3 = client.get_state_snapshot();
+    assert_eq!(snap3.total_operations, 3);
+    assert_eq!(snap3.total_errors, 1);
 }
+
+


### PR DESCRIPTION

Closes #238

📌 Description This PR addresses issue #238 by confirming and testing the decay/reset behavior for monitored metrics in program-escrow. Previously, metrics accumulated forever without decay, potentially leading to a permanently-tripped alert state (e.g., if a high failure rate occurred early in the lifecycle, error_rate could be permanently skewed).

I implemented a 1-hour rolling window (WINDOW_DURATION = 3600 seconds) in monitoring.rs to compute the error rate used by health_check(). Legacy operational counts (OPERATION_COUNT, ERROR_COUNT, USER_COUNT) are explicitly documented as lifetime analytical metrics that permanently accumulate.

🧩 Changes Made

program-escrow/src/monitoring.rs:
Documented OPERATION_COUNT, USER_COUNT, and ERROR_COUNT as lifetime metrics.
Introduced WINDOW_START, WINDOW_OPS, and WINDOW_ERRS to explicitly maintain a rolling window (resets every 3600 ledger seconds).
Updated health_check() to utilize the sliding window for evaluating if the error rate exceeds ERROR_RATE_THRESHOLD_BPS (50%), returning is_healthy = false during breaches.
program-escrow/src/test_monitoring.rs:
Added test_metric_decay_and_alert_clearing which explicitly tests the entire decay lifecycle.
Confirmed the metric decay correctly clears alerts after the window resets.
Confirmed that lifetime metrics (like ERROR_COUNT) safely accumulate regardless of window decay.
Handled the edge case where metric checking exactly at the boundary limits maintains strict policies

running 9 tests
test test_monitoring::test_default_large_payout_threshold_is_ten_percent ... ok
test test_monitoring::test_admin_can_update_large_payout_threshold ... ok
test test_monitoring::test_metric_decay_and_alert_clearing ... ok
test test_monitoring::test_large_payout_event_fires_above_threshold ... ok
test test_monitoring::test_large_payout_no_event_just_below_threshold ... ok
test test_monitoring::test_large_payout_event_fires_exactly_at_threshold ... ok
test test_monitoring::test_large_payout_threshold_respects_custom_bps ... ok
test test_monitoring::test_non_admin_cannot_update_large_payout_threshold - should panic ... ok
test test_monitoring::test_monitoring_analytics_and_health ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 349 filtered out; finished in 0.53s
