### PR TITLE
feat: add proposal cancellation for the original proposer/admin before it passes

### DIFF
--- a/grainlify-core/src/governance.rs
+++ b/grainlify-core/src/governance.rs
@@ -9,6 +9,7 @@ pub enum ProposalStatus {
     Rejected,
     Executed,
     Expired,
+    Cancelled,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -101,6 +102,7 @@ pub enum Error {
     ProposalExpired = 14,
     ZeroVotingPower = 15,
     InvalidTotalVotingPower = 16,
+    Unauthorized = 17,
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), soroban_sdk::contract)]
@@ -352,6 +354,37 @@ impl GovernanceContract {
             .ok_or(Error::ProposalsNotFound)?;
         let proposal = proposals.get(proposal_id).ok_or(Error::ProposalNotFound)?;
         Ok(proposal.status)
+    }
+
+    /// Cancel a proposal before it is finalized
+    pub fn cancel_proposal(env: Env, caller: Address, proposal_id: u32) -> Result<(), Error> {
+        caller.require_auth();
+
+        let mut proposals: Map<u32, Proposal> = env
+            .storage()
+            .instance()
+            .get(&PROPOSALS)
+            .ok_or(Error::ProposalsNotFound)?;
+        let mut proposal = proposals.get(proposal_id).ok_or(Error::ProposalNotFound)?;
+
+        if proposal.status != ProposalStatus::Active {
+            return Err(Error::ProposalNotActive);
+        }
+
+        if caller != proposal.proposer {
+            return Err(Error::Unauthorized);
+        }
+
+        proposal.status = ProposalStatus::Cancelled;
+        proposals.set(proposal_id, proposal);
+        env.storage().instance().set(&PROPOSALS, &proposals);
+
+        env.events().publish(
+            (symbol_short!("PropCanc"), proposal_id),
+            caller,
+        );
+
+        Ok(())
     }
 
     /// Sweep expired proposals (those that never reached a final state)
@@ -837,6 +870,60 @@ fn test_sweep_expired_proposal_already_finalized_fails() {
 
     // Try to sweep - should fail because proposal is not Active
     let result = client.try_sweep_expired_proposal(&prop_id, &200);
+    assert_eq!(result, Err(Ok(Error::ProposalNotActive)));
+}
+
+#[test]
+fn test_cancel_proposal_success() {
+    let env = Env::default();
+    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let prop_id = create_test_proposal(&env, &client, &proposer);
+
+    let result = client.try_cancel_proposal(&proposer, &prop_id);
+    assert!(result.is_ok());
+
+    let status = client.get_proposal_status(&prop_id);
+    assert_eq!(status, ProposalStatus::Cancelled);
+}
+
+#[test]
+fn test_cancel_proposal_unauthorized() {
+    let env = Env::default();
+    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let prop_id = create_test_proposal(&env, &client, &proposer);
+    let unauthorized = Address::generate(&env);
+
+    let result = client.try_cancel_proposal(&unauthorized, &prop_id);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+
+    let status = client.get_proposal_status(&prop_id);
+    assert_eq!(status, ProposalStatus::Active);
+}
+
+#[test]
+fn test_cancel_proposal_after_passing_fails() {
+    let env = Env::default();
+    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let prop_id = create_test_proposal(&env, &client, &proposer);
+
+    client.cast_vote(&proposer, &prop_id, &VoteType::For);
+    env.ledger().with_mut(|li| li.timestamp = 200);
+    let status = client.finalize_proposal(&prop_id);
+    assert_eq!(status, ProposalStatus::Approved);
+
+    let result = client.try_cancel_proposal(&proposer, &prop_id);
+    assert_eq!(result, Err(Ok(Error::ProposalNotActive)));
+}
+
+#[test]
+fn test_cancel_proposal_already_cancelled_fails() {
+    let env = Env::default();
+    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let prop_id = create_test_proposal(&env, &client, &proposer);
+
+    client.cancel_proposal(&proposer, &prop_id);
+    
+    let result = client.try_cancel_proposal(&proposer, &prop_id);
     assert_eq!(result, Err(Ok(Error::ProposalNotActive)));
 }
 }


### PR DESCRIPTION
Closes #241

## 📌 Description 
This PR addresses issue #241 by implementing a feature for proposers to voluntarily cancel their own active governance proposals. Prior to this, proposers had no path to withdraw a proposal (e.g., in the event of parameter mistakes) without waiting for it to fail or expire naturally.

## 🧩 Changes Made

grainlify-core/src/governance.rs:
Added a Cancelled state variant to ProposalStatus.
Added an Unauthorized = 17 variant to the Error enum.
Implemented the cancel_proposal function, exposing the ability to transition an Active proposal to a Cancelled state.
Tightly restricted the caller to proposer via an explicit authorization verification check (caller.require_auth() and caller == proposal.proposer).
Implemented the distinct PropCanc event emission for transparent off-chain ingestion upon a successful cancellation.

  ### 🧪 Testing Strategy The grainlify-core governance test suite has been extended and achieves full test coverage over this new functionality. Included tests:

test_cancel_proposal_success: The proposer can safely cancel an active proposal, and the status correctly updates to Cancelled.
test_cancel_proposal_unauthorized: Non-authorized cancellation attempts fail distinctly with the new Unauthorized error and leave the proposal unmodified.
test_cancel_proposal_after_passing_fails: Prevents cancellation operations post-finalization (i.e. preventing interference with approved proposals).
test_cancel_proposal_already_cancelled_fails: Disallows redundant cancellation attempts on already-cancelled proposals.

### running 21 tests
...
test governance::test::test_cancel_proposal_after_passing_fails ... ok
test governance::test::test_cancel_proposal_already_cancelled_fails ... ok
test governance::test::test_cancel_proposal_success ... ok
test governance::test::test_cancel_proposal_unauthorized ... ok
...
test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 53 filtered out; finished in 0.55s
