### PR TITLE
test: add not-found panic coverage for get_program_release_schedule

### DIFF
--- a/program-escrow/src/lib.rs
+++ b/program-escrow/src/lib.rs
@@ -3611,6 +3611,109 @@ mod integration_tests {
 
         client.update_rate_limit_config(&3600, &10, &30);
     }
+
+    // ========================================================================
+    // get_program_release_schedule() not-found panic
+    //
+    // `get_program_release_schedule` linearly scans the schedule list and either
+    // returns the matching entry or `panic!("Schedule not found")`. Every other
+    // call site passes an id known to exist, so the panic branch was never
+    // exercised. These tests lock in the fail-closed behavior and the exact
+    // panic wording: if the scan were ever refactored (e.g. to an indexed
+    // lookup) and started returning a defaulted/zeroed schedule on a miss,
+    // callers could silently act on bogus schedule data instead of failing.
+    // ========================================================================
+
+    /// Requesting a `schedule_id` that does not exist on a program that *does*
+    /// have schedules must panic with exactly "Schedule not found".
+    #[test]
+    #[should_panic(expected = "Schedule not found")]
+    fn test_get_program_release_schedule_nonexistent_panics() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, ProgramEscrowContract);
+        let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+        let authorized_key = Address::generate(&env);
+        let winner = Address::generate(&env);
+        let token = Address::generate(&env);
+        let program_id = String::from_str(&env, "Hackathon2024");
+        let amount = 1000_0000000;
+
+        env.mock_all_auths();
+
+        // One schedule (id 1) exists; ask for a wholly unrelated id.
+        setup_program_with_schedule(
+            &env,
+            &client,
+            &contract_id,
+            &authorized_key,
+            &token,
+            &program_id,
+            amount,
+            &winner,
+            1000,
+        );
+
+        client.get_program_release_schedule(&999);
+    }
+
+    /// A program with zero configured schedules must panic on any lookup rather
+    /// than returning a default/empty struct.
+    #[test]
+    #[should_panic(expected = "Schedule not found")]
+    fn test_get_program_release_schedule_zero_schedules_panics() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, ProgramEscrowContract);
+        let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+        let authorized_key = Address::generate(&env);
+        let token = Address::generate(&env);
+        let program_id = String::from_str(&env, "Hackathon2024");
+
+        env.mock_all_auths();
+
+        // Initialize a program but never create any release schedule.
+        client.initialize_program(&program_id, &authorized_key, &token);
+        assert_eq!(client.get_program_release_schedules().len(), 0);
+
+        client.get_program_release_schedule(&1);
+    }
+
+    /// A `schedule_id` exactly one past the highest configured id must be
+    /// treated as not-found, not accidentally matched to the last entry.
+    #[test]
+    #[should_panic(expected = "Schedule not found")]
+    fn test_get_program_release_schedule_one_past_highest_panics() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, ProgramEscrowContract);
+        let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+        let authorized_key = Address::generate(&env);
+        let winner1 = Address::generate(&env);
+        let winner2 = Address::generate(&env);
+        let program_id = String::from_str(&env, "Hackathon2024");
+        let amount1 = 600_0000000;
+        let amount2 = 400_0000000;
+        let total_amount = amount1 + amount2;
+
+        env.mock_all_auths();
+
+        let token_client = create_token_contract(&env, &authorized_key);
+        client.initialize_program(&program_id, &authorized_key, &token_client.address);
+        let tokenadmin = token::StellarAssetClient::new(&env, &token_client.address);
+        tokenadmin.mint(&authorized_key, &total_amount);
+        client.lock_program_funds(&authorized_key, &total_amount);
+
+        // Highest configured id is 2 after creating two schedules.
+        client.create_program_release_schedule(&amount1, &1000, &winner1);
+        client.create_program_release_schedule(&amount2, &2000, &winner2);
+
+        // Sanity: the highest configured id resolves before we probe past it.
+        assert_eq!(client.get_program_release_schedule(&2).schedule_id, 2);
+
+        // One past the highest must not be treated as a valid match.
+        client.get_program_release_schedule(&3);
+    }
 }
 #[cfg(test)]
 mod rbac_tests;


### PR DESCRIPTION
## Summary

`get_program_release_schedule(env, schedule_id)` linearly scans `get_program_release_schedules(env)` and returns the matching entry, or `panic!("Schedule not found")` if none matches. Although this getter is called from many existing tests, every call site passes a `schedule_id` known to already exist, so the not-found panic branch was never exercised. The literal string `"Schedule not found"` also appears in other release functions in the same file, so a `should_panic` test on this specific getter is useful to pin its exact wording down.

This PR adds dedicated not-found coverage in `program-escrow/src/lib.rs`.

closes #323

## Changes

Added three tests to the `integration_tests` module in `program-escrow/src/lib.rs`:

- `test_get_program_release_schedule_nonexistent_panics` - a program that *has* a schedule (id `1`) is queried with an unrelated id (`999`); asserts a panic with exactly `"Schedule not found"`.
- `test_get_program_release_schedule_zero_schedules_panics` - a program is initialized but no release schedule is ever created (`get_program_release_schedules().len() == 0`); asserts any lookup panics rather than returning a defaulted/empty struct.
- `test_get_program_release_schedule_one_past_highest_panics` - two schedules are created (highest id `2`); asserts id `2` still resolves (sanity), then asserts that id `3`, one past the highest, is treated as not-found and panics rather than matching the last entry.

## Why this matters

If this linear scan were ever refactored (for example to an indexed lookup) and accidentally started returning a default/zeroed `ProgramReleaseSchedule` instead of panicking on a miss, callers could silently act on bogus schedule data instead of failing loudly. These tests lock in the current fail-closed behavior and the exact panic message, covering the three ways a miss can happen: a nonexistent id, a program with no schedules at all, and the off-by-one id immediately past the highest configured one.

## Testing

The new tests were run locally against a repaired lockfile (the checked-in resolution greedily selects `soroban-env-host`'s `>=` dependency bounds up to `ed25519-dalek 3.0.0` / `curve25519-dalek 5.0.0`, which do not compile under the test profile; pinning them back to `2.1.1` / `4.1.3` restores a working test build - no source or committed-lock changes required):

```
cargo test -p program-escrow get_program_release_schedule
running 3 tests
test integration_tests::test_get_program_release_schedule_zero_schedules_panics - should panic ... ok
test integration_tests::test_get_program_release_schedule_nonexistent_panics - should panic ... ok
test integration_tests::test_get_program_release_schedule_one_past_highest_panics - should panic ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 390 filtered out; finished in 0.59s
```

`cargo build -p program-escrow` also succeeds, matching the crate's existing CI check.

## Acceptance criteria

- [x] Requesting a nonexistent `schedule_id` panics with exactly "Schedule not found".
- [x] A program with zero configured release schedules also panics rather than returning a default value.
- [x] A `schedule_id` one past the highest configured id is correctly treated as not-found.
