### PR TITLE
test: add correctness assertions for status full-scan reconciliation helpers

### DIFF
--- a/bounty_escrow/contracts/escrow/src/test_coverage_comprehensive.rs
+++ b/bounty_escrow/contracts/escrow/src/test_coverage_comprehensive.rs
@@ -161,3 +161,143 @@ fn fee_with_circuit_breaker_exercise() {
     s.client.set_circuit_breaker_admin(&s.admin.clone());
     let _log = s.client.get_circuit_error_log();
 }
+
+// ─── status full-scan reconciliation helpers ───
+//
+// `count_by_status_full_scan` and `volume_by_status_full_scan` are reconciliation
+// helpers: they recompute per-status counts and volumes from a full O(N) scan of
+// the escrow index, so they can cross-check the O(1) running counters. Previously
+// they were only touched by `exercise_all_getters`, which discards both return
+// values and only ever passes `Locked` — so neither the correctness of the scan
+// nor its agreement with the O(1) counters was ever verified. These tests supply
+// the missing assertions.
+
+/// Drive a mix of bounties into all four statuses and assert the full-scan
+/// helpers return exactly the manually-computed count and volume for each.
+///
+/// Volume semantics under scan (mirrors the contract):
+/// - `Locked` / `PartiallyRefunded` sum `remaining_amount`.
+/// - `Released` / `Refunded` sum the original `amount`.
+#[test]
+fn full_scan_correctness_all_statuses() {
+    let s = Cx::new();
+    s.fund(&s.depositor, 1_000_000i128);
+
+    // Two Locked bounties: remaining 1000 + 2000.
+    s.lock(1u64, 1000i128);
+    s.lock(2u64, 2000i128);
+
+    // Two Released bounties (claimed in full): amount 1000 + 3000.
+    s.lock(3u64, 1000i128);
+    s.client.authorize_claim(&3u64, &s.contributor);
+    s.client.claim(&3u64);
+    s.lock(4u64, 3000i128);
+    s.client.authorize_claim(&4u64, &s.contributor);
+    s.client.claim(&4u64);
+
+    // One fully Refunded bounty: amount 1000.
+    s.lock(5u64, 1000i128);
+    s.client.approve_refund(&5u64, &1000i128, &s.depositor, &RefundMode::Full);
+    s.client.refund(&5u64);
+
+    // One PartiallyRefunded bounty: 2000 locked, 500 refunded, remaining 1500.
+    s.lock(6u64, 2000i128);
+    s.client.approve_refund(&6u64, &500i128, &s.depositor, &RefundMode::Partial);
+    s.client.refund(&6u64);
+
+    assert_eq!(s.client.get_escrow_count(), 6);
+
+    // Locked: exactly the two untouched bounties.
+    assert_eq!(s.client.count_by_status_full_scan(&EscrowStatus::Locked), 2);
+    assert_eq!(s.client.volume_by_status_full_scan(&EscrowStatus::Locked), 3000i128);
+
+    // Released: both claimed bounties, valued at their original amount.
+    assert_eq!(s.client.count_by_status_full_scan(&EscrowStatus::Released), 2);
+    assert_eq!(s.client.volume_by_status_full_scan(&EscrowStatus::Released), 4000i128);
+
+    // Refunded: the single fully-refunded bounty.
+    assert_eq!(s.client.count_by_status_full_scan(&EscrowStatus::Refunded), 1);
+    assert_eq!(s.client.volume_by_status_full_scan(&EscrowStatus::Refunded), 1000i128);
+
+    // PartiallyRefunded: the single partially-refunded bounty, valued at its
+    // remaining_amount after the 500 refund.
+    assert_eq!(s.client.count_by_status_full_scan(&EscrowStatus::PartiallyRefunded), 1);
+    assert_eq!(s.client.volume_by_status_full_scan(&EscrowStatus::PartiallyRefunded), 1500i128);
+
+    // Document the intentional difference from the O(1) counter: the running
+    // `count_locked` folds PartiallyRefunded in with Locked, so it reports 3
+    // where the exact full scan reports 2. This is exactly the kind of drift the
+    // full-scan helper exists to expose.
+    assert_eq!(s.client.count_bounties_by_status(&EscrowStatus::Locked), 3);
+    assert_eq!(s.client.count_by_status_full_scan(&EscrowStatus::Locked), 2);
+}
+
+/// The reconciliation use case: with no partial refunds in play, the full-scan
+/// helpers must agree exactly with the contract's own O(1) running counters for
+/// Locked, Released, and Refunded — count and volume alike.
+#[test]
+fn full_scan_agrees_with_o1_counters() {
+    let s = Cx::new();
+    s.fund(&s.depositor, 1_000_000i128);
+
+    s.lock(1u64, 1000i128);
+    s.lock(2u64, 2000i128);
+
+    s.lock(3u64, 1500i128);
+    s.client.authorize_claim(&3u64, &s.contributor);
+    s.client.claim(&3u64);
+
+    s.lock(4u64, 1000i128);
+    s.client.approve_refund(&4u64, &1000i128, &s.depositor, &RefundMode::Full);
+    s.client.refund(&4u64);
+
+    for status in [
+        EscrowStatus::Locked,
+        EscrowStatus::Released,
+        EscrowStatus::Refunded,
+    ] {
+        assert_eq!(
+            s.client.count_by_status_full_scan(&status),
+            s.client.count_bounties_by_status(&status),
+            "count mismatch between full scan and O(1) counter",
+        );
+        assert_eq!(
+            s.client.volume_by_status_full_scan(&status),
+            s.client.get_volume_by_status(&status),
+            "volume mismatch between full scan and O(1) counter",
+        );
+    }
+}
+
+/// A status with zero matching bounties must return 0 count and 0 volume from
+/// the full-scan helpers, both on an empty index and alongside unrelated
+/// bounties — never a panic.
+#[test]
+fn full_scan_zero_match_returns_zero() {
+    // Empty index: every status is 0/0.
+    let empty = Cx::new();
+    for status in [
+        EscrowStatus::Locked,
+        EscrowStatus::Released,
+        EscrowStatus::Refunded,
+        EscrowStatus::PartiallyRefunded,
+    ] {
+        assert_eq!(empty.client.count_by_status_full_scan(&status), 0);
+        assert_eq!(empty.client.volume_by_status_full_scan(&status), 0i128);
+    }
+
+    // Populated with only Locked bounties: the other statuses stay 0/0.
+    let s = Cx::new();
+    s.fund(&s.depositor, 1_000_000i128);
+    s.lock(1u64, 1000i128);
+    s.lock(2u64, 2000i128);
+
+    for status in [
+        EscrowStatus::Released,
+        EscrowStatus::Refunded,
+        EscrowStatus::PartiallyRefunded,
+    ] {
+        assert_eq!(s.client.count_by_status_full_scan(&status), 0);
+        assert_eq!(s.client.volume_by_status_full_scan(&status), 0i128);
+    }
+}


### PR DESCRIPTION
## Summary

`count_by_status_full_scan` and `volume_by_status_full_scan` are reconciliation helpers: they recompute per-status counts and volumes from a full O(N) scan of the escrow index so they can cross-check the contract's O(1) running counters. Before this change their only call site was `test_coverage_comprehensive.rs` (`exercise_all_getters`), where both return values are discarded, only `EscrowStatus::Locked` is ever passed, and nothing is ever compared against the O(1) counters the helpers exist to verify. A bug in the scan itself would have gone completely undetected.

This PR replaces that discard-only smoke coverage with dedicated tests that assert real values.

closes #324

## Changes

Added three tests to `bounty_escrow/contracts/escrow/src/test_coverage_comprehensive.rs` (the module that already houses the discard-only call site and the `Cx` harness):

- `full_scan_correctness_all_statuses` - drives a mix of six bounties into all four statuses (2 Locked, 2 Released via claim, 1 fully Refunded, 1 PartiallyRefunded) and asserts `count_by_status_full_scan` and `volume_by_status_full_scan` return the manually-computed count and volume for each status. Volume semantics mirror the contract: `Locked`/`PartiallyRefunded` sum `remaining_amount`, `Released`/`Refunded` sum the original `amount`. The test also documents the intentional difference from the O(1) counter, where `count_locked` folds `PartiallyRefunded` in with `Locked` (reports 3) while the exact full scan reports 2 - precisely the drift these helpers exist to expose.
- `full_scan_agrees_with_o1_counters` - the actual reconciliation use case. With no partial refunds in play, asserts the full-scan count and volume agree exactly with the contract's own O(1) counters (`count_bounties_by_status` / `get_volume_by_status`) for `Locked`, `Released`, and `Refunded`.
- `full_scan_zero_match_returns_zero` - asserts a status with zero matching bounties returns `0` count and `0` volume rather than panicking, both on an empty index and alongside unrelated (`Locked`-only) bounties.

## Why this matters

These functions exist specifically to catch drift between the O(1) counters and ground truth. With the previous discard-only smoke test, a bug that made the full scan itself wrong (not just the counters) would have gone undetected, defeating the purpose of having a reconciliation mechanism at all. The new tests pin down both the absolute correctness of the scan and its agreement with the O(1) counters.

## Testing

Run from the `bounty_escrow` workspace:

```
cargo test -p bounty-escrow full_scan

running 10 tests
test test_coverage_comprehensive::full_scan_zero_match_returns_zero ... ok
test test_coverage_comprehensive::full_scan_agrees_with_o1_counters ... ok
test test_coverage_comprehensive::full_scan_correctness_all_statuses ... ok
... (7 pre-existing test_analytics_monitoring::*full_scan* tests also matched the filter)
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 395 filtered out; finished in 0.67s
```

## Acceptance criteria

- [x] `count_by_status_full_scan` and `volume_by_status_full_scan` return correct values for each of the four escrow statuses.
- [x] Full-scan results agree with the contract's O(1) running counters for at least one status (Locked, Released, and Refunded covered).
- [x] A status with zero matching bounties returns 0/0 without panicking.
