### PR TITLE
test: add correctness assertions for get_high_value_bounties

### DIFF
--- a/bounty_escrow/contracts/escrow/src/test_analytics_monitoring.rs
+++ b/bounty_escrow/contracts/escrow/src/test_analytics_monitoring.rs
@@ -12,6 +12,7 @@
 /// * `get_escrow_count`     – increments on each lock; never decrements
 /// * `query_escrows_by_status` – returns correct subset filtered by status
 /// * `query_escrows_by_amount` – range filter works for locked, released, and mixed states
+/// * `get_high_value_bounties` – filters bounties >= min_amount with inclusive boundary, limit truncation, and empty result handling
 /// * `query_escrows_by_deadline` – deadline range filter returns correct bounties
 /// * `query_escrows_by_depositor` – per-depositor index is populated on lock
 /// * `get_escrow_ids_by_status` – ID-only view mirrors full-object equivalent
@@ -511,6 +512,86 @@ fn test_query_by_amount_no_results_outside_range() {
 
     let results = escrow.query_escrows_by_amount(&600, &1_000, &0, &10);
     assert_eq!(results.len(), 0);
+}
+
+// ===========================================================================
+// 6b. Get high value bounties – correctness & edge case assertions
+// ===========================================================================
+
+#[test]
+fn test_get_high_value_bounties_inclusive_boundary_and_filtering() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let (token, token_admin) = create_token_contract(&env, &admin);
+    let escrow = create_escrow_contract(&env);
+    escrow.init(&admin, &token.address);
+    token_admin.mint(&depositor, &10_000_000);
+
+    let deadline = env.ledger().timestamp() + 2000;
+    escrow.lock_funds(&depositor, &10, &400, &deadline);
+    escrow.lock_funds(&depositor, &11, &500, &deadline);
+    escrow.lock_funds(&depositor, &12, &600, &deadline);
+
+    // Call get_high_value_bounties(500, 10)
+    let results = escrow.get_high_value_bounties(&500, &10);
+
+    // Asserts 500 (bounty 11) and 600 (bounty 12) are included (proving inclusive boundary >=),
+    // and excludes 400 (bounty 10).
+    assert_eq!(results.len(), 2);
+    assert_eq!(results.get(0), Some(11));
+    assert_eq!(results.get(1), Some(12));
+}
+
+#[test]
+fn test_get_high_value_bounties_limit_truncation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let (token, token_admin) = create_token_contract(&env, &admin);
+    let escrow = create_escrow_contract(&env);
+    escrow.init(&admin, &token.address);
+    token_admin.mint(&depositor, &10_000_000);
+
+    let deadline = env.ledger().timestamp() + 2000;
+    // Lock 5 bounties that all meet min_amount (>= 500)
+    for i in 1..=5 {
+        escrow.lock_funds(&depositor, &i, &(500 + (i as i128) * 100), &deadline);
+    }
+
+    // Call get_high_value_bounties(500, 2) when 5 qualify
+    let results = escrow.get_high_value_bounties(&500, &2);
+
+    // Asserts exactly limit = 2 IDs are returned
+    assert_eq!(results.len(), 2);
+    assert_eq!(results.get(0), Some(1));
+    assert_eq!(results.get(1), Some(2));
+}
+
+#[test]
+fn test_get_high_value_bounties_returns_empty_vec_when_none_qualify() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let (token, token_admin) = create_token_contract(&env, &admin);
+    let escrow = create_escrow_contract(&env);
+    escrow.init(&admin, &token.address);
+    token_admin.mint(&depositor, &10_000_000);
+
+    let deadline = env.ledger().timestamp() + 2000;
+    escrow.lock_funds(&depositor, &1, &100, &deadline);
+    escrow.lock_funds(&depositor, &2, &200, &deadline);
+    escrow.lock_funds(&depositor, &3, &300, &deadline);
+
+    // min_amount set higher than every escrow's amount
+    let results = escrow.get_high_value_bounties(&1000, &10);
+
+    // Asserts an empty Vec is returned without panicking or returning stale/partial data
+    assert_eq!(results.len(), 0);
+    assert!(results.is_empty());
 }
 
 // ===========================================================================

--- a/bounty_escrow/contracts/escrow/src/test_coverage_comprehensive.rs
+++ b/bounty_escrow/contracts/escrow/src/test_coverage_comprehensive.rs
@@ -123,7 +123,10 @@ fn exercise_all_getters() {
     let _sc = s.client.count_by_status_full_scan(&EscrowStatus::Locked);
     let _vs = s.client.get_volume_by_status(&EscrowStatus::Locked);
     let _vf = s.client.volume_by_status_full_scan(&EscrowStatus::Locked);
-    let _hv = s.client.get_high_value_bounties(&500i128, &5u32);
+    let hv = s.client.get_high_value_bounties(&500i128, &5u32);
+    assert_eq!(hv.len(), 2);
+    assert_eq!(hv.get(0).unwrap(), 1u64);
+    assert_eq!(hv.get(1).unwrap(), 2u64);
     let _ds = s.client.get_depositor_stats(&s.depositor);
     let _ei = s.client.get_escrow_info(&1u64);
     let _rh = s.client.get_refund_history(&1u64);


### PR DESCRIPTION
Closes #307 
Previously, `BountyEscrowContract::get_high_value_bounties(env, min_amount, limit)` was only invoked via a smoke test in `test_coverage_comprehensive.rs` where the return value was discarded (`let _hv = ...`), leaving its filtering boundary, truncation logic, and edge-case behavior unverified.

This PR adds concrete correctness assertions and dedicated unit tests to thoroughly validate all requirements and edge cases for `get_high_value_bounties`.

---

## 🧪 Test Coverage & Key Assertions Added

1. **Inclusive Amount Boundary (`>= min_amount`) & Filtering**:
   - `test_get_high_value_bounties_inclusive_boundary_and_filtering`: Locks bounties with distinct amounts (`400`, `500`, `600`) and calls `get_high_value_bounties(500, 10)`.
   - **Assertion**: Verifies that bounties with amount `500` and `600` are returned while amount `400` is excluded, proving `escrow.amount >= min_amount` is an inclusive boundary.

2. **Limit Truncation**:
   - `test_get_high_value_bounties_limit_truncation`: Locks 5 bounties meeting `min_amount` (`>= 500`) and calls `get_high_value_bounties(500, 2)`.
   - **Assertion**: Verifies that the returned vector length is capped at exactly `2`.

3. **Empty Result Handling**:
   - `test_get_high_value_bounties_returns_empty_vec_when_none_qualify`: Locks bounties below `min_amount` (`1000`) and queries `get_high_value_bounties(1000, 10)`.
   - **Assertion**: Verifies an empty vector (`len() == 0`) is returned without panicking or returning stale data.

4. **Updated Discard-Only Smoke Test**:
   - Updated `exercise_all_getters()` in `test_coverage_comprehensive.rs` to validate the returned vector rather than discarding it.

---

## 🔒 Security & Quality Notes
Ensures off-chain monitoring systems and high-value bounty dashboards relying on `get_high_value_bounties` do not miss high-value escrows due to boundary or limit truncation issues.

---

## 📁 Modified Files
- [`bounty_escrow/contracts/escrow/src/test_analytics_monitoring.rs`](file:///c:/Users/TOSHIBA/Grainlify-Stellar-Contracts/bounty_escrow/contracts/escrow/src/test_analytics_monitoring.rs)
- [`bounty_escrow/contracts/escrow/src/test_coverage_comprehensive.rs`](file:///c:/Users/TOSHIBA/Grainlify-Stellar-Contracts/bounty_escrow/contracts/escrow/src/test_coverage_comprehensive.rs)