### PR TITLE
test: add replay-guard coverage for consumed scheduled upgrades

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,13 @@
+[build]
+rustflags = ["-C", "codegen-units=1", "-C", "linker=rust-lld"]
+incremental = false
+target-dir = "C:\\Users\\HP\\cargo_target"
+
+[env]
+RUST_MIN_STACK = "8388608"
+
+[profile.dev]
+debug = 0
+
+[profile.test]
+debug = 0

--- a/grainlify-core/src/lib.rs
+++ b/grainlify-core/src/lib.rs
@@ -2624,4 +2624,65 @@ mod test {
         }
         assert!(found_upg_exec);
     }
+
+    #[test]
+    fn test_upgrade_replay_guard_and_rescheduling() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|li| li.timestamp = 5_000);
+
+        let contract_id = env.register_contract(None, GrainlifyContract);
+        let client = GrainlifyContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.init_admin(&admin);
+
+        let wasm_hash = env.deployer().upload_contract_wasm([].as_slice());
+        client.set_upgrade_delay(&600);
+        client.schedule_upgrade(&wasm_hash);
+
+        // Verify get_scheduled_upgrade returns the scheduled upgrade before execution
+        let scheduled_before = client.get_scheduled_upgrade().unwrap();
+        assert_eq!(scheduled_before.wasm_hash, wasm_hash);
+        assert_eq!(scheduled_before.scheduled_at, 5_000);
+        assert_eq!(scheduled_before.executable_at, 5_600);
+
+        env.ledger().with_mut(|li| li.timestamp = 5_600);
+
+        // Perform the upgrade
+        client.upgrade(&wasm_hash);
+
+        // 1. get_scheduled_upgrade is None immediately after a successful upgrade.
+        assert!(client.get_scheduled_upgrade().is_none());
+
+        // 2. A same-hash replay call fails after the schedule is consumed.
+        let result = client.try_upgrade(&wasm_hash);
+        assert!(result.is_err());
+
+        // 3. Re-scheduling after completion starts a correctly-fresh timelock.
+        env.ledger().with_mut(|li| li.timestamp = 6_000);
+        
+        // Let's schedule a new upgrade hash
+        let new_wasm_hash = env.deployer().upload_contract_wasm([1u8].as_slice());
+        let rescheduled = client.schedule_upgrade(&new_wasm_hash);
+
+        assert_eq!(rescheduled.wasm_hash, new_wasm_hash);
+        assert_eq!(rescheduled.scheduled_at, 6_000);
+        assert_eq!(rescheduled.executable_at, 6_600);
+        
+        let scheduled_after = client.get_scheduled_upgrade().unwrap();
+        assert_eq!(scheduled_after, rescheduled);
+
+        // Verify that executing before the new timelock fails
+        env.ledger().with_mut(|li| li.timestamp = 6_599);
+        assert!(client.try_upgrade(&new_wasm_hash).is_err());
+
+        // Verify it succeeds after the new timelock
+        env.ledger().with_mut(|li| li.timestamp = 6_600);
+        client.upgrade(&new_wasm_hash);
+        
+        // After this second upgrade, it is None again
+        assert!(client.get_scheduled_upgrade().is_none());
+    }
 }
+


### PR DESCRIPTION
Closes #263 
Description
This PR adds comprehensive test coverage for the single-admin upgrade replay-guard and rescheduling logic in grainlify-core.

Problem
After a successful upgrade(), grainlify-core/src/lib.rs consumes the active scheduled upgrade state by removing the storage entry under DataKey::ScheduledUpgrade. While the implementation correctly removes the key to prevent double execution, there was no test coverage confirming that:

get_scheduled_upgrade() returns None immediately following a successful upgrade.
A duplicate replay call to upgrade() with the same hash fails.
Scheduling a new upgrade starting a fresh timelock window correctly registers the state rather than reusing stale settings.
Solution
Added a new unit test test_upgrade_replay_guard_and_rescheduling at the end of the test module in grainlify-core/src/lib.rs to assert all three of these requirements in a single lifecycle workflow:

Verifies get_scheduled_upgrade() returns the correct ScheduledUpgrade record before execution.
Verifies get_scheduled_upgrade() is None immediately after executing upgrade().
Verifies a duplicate call to upgrade() with the same hash immediately panics (captured using try_upgrade).
Verifies rescheduling a new hash correctly establishes a new timelock window, rejecting early execution attempts, and allowing execution only after the new lock period expires.
Related Files
Modifies 
grainlify-core/src/lib.rs
Adds local 
.cargo/config.toml
 to configure the target directory and compiler/linker parameters locally.