### PR TITLE
Test/bounty escrow fund conservation proptest

### DIFF
--- a/bounty_escrow/contracts/escrow/src/proptest_invariants.rs
+++ b/bounty_escrow/contracts/escrow/src/proptest_invariants.rs
@@ -39,6 +39,8 @@ struct ModelEscrow {
     remaining: i128,
     deadline: u64,
     status: ModelStatus,
+    disputed: bool,
+    dispute_expires_at: u64,
 }
 
 struct ModelTotals {
@@ -86,6 +88,7 @@ impl<'a> TestSetup<'a> {
         let escrow = create_escrow_contract(&env);
 
         escrow.init(&admin, &token.address);
+        escrow.set_claim_window(&600);
 
         Self {
             env,
@@ -255,6 +258,8 @@ fn apply_lock(
         remaining: amount,
         deadline,
         status: ModelStatus::Locked,
+        disputed: false,
+        dispute_expires_at: 0,
     });
 }
 
@@ -265,7 +270,7 @@ fn apply_partial_release(
     op: LifecycleOp,
 ) {
     let Some(idx) = pick_index(model, op.selector, |escrow| {
-        escrow.status == ModelStatus::Locked && escrow.remaining > 0
+        escrow.status == ModelStatus::Locked && escrow.remaining > 0 && !escrow.disputed
     }) else {
         return;
     };
@@ -289,7 +294,7 @@ fn apply_full_release(
     op: LifecycleOp,
 ) {
     let Some(idx) = pick_index(model, op.selector, |escrow| {
-        escrow.status == ModelStatus::Locked && escrow.remaining == escrow.amount
+        escrow.status == ModelStatus::Locked && escrow.remaining == escrow.amount && !escrow.disputed
     }) else {
         return;
     };
@@ -312,6 +317,7 @@ fn apply_approved_refund(
     let Some(idx) = pick_index(model, op.selector, |escrow| {
         (escrow.status == ModelStatus::Locked || escrow.status == ModelStatus::PartiallyRefunded)
             && escrow.remaining > 0
+            && !escrow.disputed
     }) else {
         return;
     };
@@ -346,6 +352,7 @@ fn apply_deadline_refund(
     let Some(idx) = pick_index(model, op.selector, |escrow| {
         (escrow.status == ModelStatus::Locked || escrow.status == ModelStatus::PartiallyRefunded)
             && escrow.remaining > 0
+            && !escrow.disputed
     }) else {
         return;
     };
@@ -469,4 +476,142 @@ fn proptest_fee_basis_points_do_not_overflow_or_exceed_principal() {
             Ok(())
         })
         .expect("basis-point fee properties should hold");
+}
+
+fn apply_dispute(
+    setup: &TestSetup<'_>,
+    model: &mut [ModelEscrow],
+    op: LifecycleOp,
+) {
+    let Some(idx) = pick_index(model, op.selector, |escrow| {
+        escrow.status == ModelStatus::Locked && !escrow.disputed
+    }) else {
+        return;
+    };
+
+    setup.escrow.authorize_claim(&model[idx].id, &setup.contributor);
+    model[idx].disputed = true;
+    model[idx].dispute_expires_at = setup.env.ledger().timestamp().saturating_add(600);
+}
+
+fn apply_claim(
+    setup: &TestSetup<'_>,
+    model: &mut [ModelEscrow],
+    totals: &mut ModelTotals,
+    op: LifecycleOp,
+) {
+    let Some(idx) = pick_index(model, op.selector, |escrow| {
+        escrow.disputed && setup.env.ledger().timestamp() <= escrow.dispute_expires_at
+    }) else {
+        return;
+    };
+
+    setup.escrow.claim(&model[idx].id);
+    let payout = model[idx].remaining;
+    totals.released += payout;
+    model[idx].remaining = 0;
+    model[idx].status = ModelStatus::Released;
+    model[idx].disputed = false;
+    model[idx].dispute_expires_at = 0;
+}
+
+fn apply_cancel_dispute(
+    setup: &TestSetup<'_>,
+    model: &mut [ModelEscrow],
+    op: LifecycleOp,
+) {
+    let Some(idx) = pick_index(model, op.selector, |escrow| {
+        escrow.disputed
+    }) else {
+        return;
+    };
+
+    setup.escrow.cancel_pending_claim(&model[idx].id);
+    model[idx].disputed = false;
+    model[idx].dispute_expires_at = 0;
+}
+
+fn assert_fund_conservation_invariants(
+    setup: &TestSetup<'_>,
+    totals: &ModelTotals,
+) -> Result<(), TestCaseError> {
+    let contract_balance = setup.escrow.get_balance();
+    
+    // Invariant: total locked == total released + total refunded + current contract balance
+    prop_assert_eq!(
+        totals.locked,
+        totals.released + totals.refunded + contract_balance,
+        "Fund conservation invariant violated: totals.locked ({}) must equal totals.released ({}) + totals.refunded ({}) + contract_balance ({})",
+        totals.locked,
+        totals.released,
+        totals.refunded,
+        contract_balance
+    );
+
+    // Contributor's token balance must match total released (claimed/released)
+    prop_assert_eq!(
+        setup.token.balance(&setup.contributor),
+        totals.released,
+        "Contributor balance mismatch"
+    );
+
+    // Depositor's token balance must match minted - locked + refunded
+    prop_assert_eq!(
+        setup.token.balance(&setup.depositor),
+        totals.minted - totals.locked + totals.refunded,
+        "Depositor balance mismatch"
+    );
+
+    Ok(())
+}
+
+fn fund_conservation_op_strategy() -> impl Strategy<Value = LifecycleOp> {
+    (0_u8..=7, 0_usize..64, 1_i128..=20_000, 1_u64..=1_000).prop_map(
+        |(kind, selector, amount, deadline_delta)| LifecycleOp {
+            kind,
+            selector,
+            amount,
+            deadline_delta,
+        },
+    )
+}
+
+fn run_fund_conservation_ops(ops: std::vec::Vec<LifecycleOp>) -> Result<(), TestCaseError> {
+    let setup = TestSetup::new();
+    let mut model = std::vec::Vec::new();
+    let mut totals = ModelTotals {
+        minted: 0,
+        locked: 0,
+        released: 0,
+        refunded: 0,
+    };
+    let mut next_id = 10_000_u64;
+
+    assert_fund_conservation_invariants(&setup, &totals)?;
+
+    for op in ops {
+        match op.kind {
+            0 => apply_lock(&setup, &mut model, &mut totals, &mut next_id, op),
+            1 => apply_partial_release(&setup, &mut model, &mut totals, op),
+            2 => apply_full_release(&setup, &mut model, &mut totals, op),
+            3 => apply_approved_refund(&setup, &mut model, &mut totals, op),
+            4 => apply_deadline_refund(&setup, &mut model, &mut totals, op),
+            5 => apply_dispute(&setup, &mut model, op),
+            6 => apply_claim(&setup, &mut model, &mut totals, op),
+            _ => apply_cancel_dispute(&setup, &mut model, op),
+        }
+        assert_fund_conservation_invariants(&setup, &totals)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn proptest_fund_conservation_dedicated_invariant_holds() {
+    let mut runner = deterministic_runner();
+    let strategy = proptest::collection::vec(fund_conservation_op_strategy(), 0..=30);
+
+    runner
+        .run(&strategy, |ops| run_fund_conservation_ops(ops))
+        .expect("fund conservation invariant should hold across all valid operation sequences");
 }

--- a/program-escrow/src/test_balance_invariant.rs
+++ b/program-escrow/src/test_balance_invariant.rs
@@ -501,3 +501,98 @@ fn test_reconciliation_invariant_after_each_mixed_operation() {
     assert_eq!(pending_scheduled_total(&client), 0);
     assert_eq!(token_client.balance(&contract_id), 0);
 }
+
+// ---------------------------------------------------------------------------
+// Test A — incremental milestone claims maintain invariant
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_invariant_incremental_milestone_claims() {
+    let env = Env::default();
+    let total: i128 = 9_000;
+    let (client, contract_id, _admin, token_client, _token_sac, _token_id) = setup(&env, total);
+
+    // Create three equal milestones
+    let w1 = Address::generate(&env);
+    let w2 = Address::generate(&env);
+    let w3 = Address::generate(&env);
+    let sched1 = client.create_program_release_schedule(&3_000, &0, &w1);
+    let sched2 = client.create_program_release_schedule(&3_000, &0, &w2);
+    let sched3 = client.create_program_release_schedule(&3_000, &0, &w3);
+
+    assert_balance_invariant(&client, &token_client, &contract_id, "initial");
+
+    client.release_program_schedule_manual(&sched1.schedule_id);
+    assert_balance_invariant(&client, &token_client, &contract_id, "after claim 1");
+
+    client.release_program_schedule_manual(&sched2.schedule_id);
+    assert_balance_invariant(&client, &token_client, &contract_id, "after claim 2");
+
+    client.release_program_schedule_manual(&sched3.schedule_id);
+    assert_balance_invariant(&client, &token_client, &contract_id, "after claim 3");
+
+    assert_eq!(client.get_remaining_balance(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Test B — double‑claim of a milestone is rejected and does not affect balance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_invariant_double_claim_milestone_rejected() {
+    let env = Env::default();
+    let total: i128 = 5_000;
+    let (client, contract_id, _admin, token_client, _token_sac, _token_id) = setup(&env, total);
+
+    let winner = Address::generate(&env);
+    let sched = client.create_program_release_schedule(&total, &0, &winner);
+    assert_balance_invariant(&client, &token_client, &contract_id, "initial");
+
+    // First release succeeds
+    client.release_program_schedule_manual(&sched.schedule_id);
+    let bal_after_first = token_client.balance(&winner);
+
+    // Second attempt should fail
+    let res = client.try_release_program_schedule_manual(&sched.schedule_id);
+    assert!(res.is_err(), "double‑claim must be rejected");
+
+    let bal_after_second = token_client.balance(&winner);
+    assert_eq!(bal_after_second, bal_after_first, "balance must not change after double‑claim");
+
+    // Invariant still holds
+    assert_balance_invariant(&client, &token_client, &contract_id, "after double‑claim attempt");
+}
+
+// ---------------------------------------------------------------------------
+// Test C — out‑of‑order milestone releases keep invariant (contract permits independent releases)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_invariant_out_of_order_milestone_claims() {
+    let env = Env::default();
+    let total: i128 = 9_000;
+    let (client, contract_id, _admin, token_client, _token_sac, _token_id) = setup(&env, total);
+
+    let w1 = Address::generate(&env);
+    let w2 = Address::generate(&env);
+    let w3 = Address::generate(&env);
+    let sched1 = client.create_program_release_schedule(&3_000, &0, &w1);
+    let sched2 = client.create_program_release_schedule(&3_000, &0, &w2);
+    let sched3 = client.create_program_release_schedule(&3_000, &0, &w3);
+
+    assert_balance_invariant(&client, &token_client, &contract_id, "initial");
+
+    // Release milestone 2 first
+    client.release_program_schedule_manual(&sched2.schedule_id);
+    assert_balance_invariant(&client, &token_client, &contract_id, "after claim 2");
+
+    // Release milestone 1 next
+    client.release_program_schedule_manual(&sched1.schedule_id);
+    assert_balance_invariant(&client, &token_client, &contract_id, "after claim 1");
+
+    // Release milestone 3 finally
+    client.release_program_schedule_manual(&sched3.schedule_id);
+    assert_balance_invariant(&client, &token_client, &contract_id, "after claim 3");
+
+    assert_eq!(client.get_remaining_balance(), 0);
+}


### PR DESCRIPTION
Closes #227 This PR adds a dedicated, explicitly-named fund-conservation property test to verify that the total funds in, refunded, claimed, and still-escrowed always balance exactly.

This complements the existing invariant checks by testing the full state space of contract actions, including opening, claiming, and cancelling disputes.

Key Changes
Mock model state: Added dispute tracking properties to ModelEscrow.
Action helpers: Added apply_dispute, apply_claim, and apply_cancel_dispute to model contract dispute states.
Predicates: Updated release and refund transitions to only select non-disputed escrows.
Dedicated invariant: Implemented assert_fund_conservation_invariants checking the balance equation: 
totals.locked
=
totals.released
+
totals.refunded
+
contract_balance
totals.locked=totals.released+totals.refunded+contract_balance
Dedicated proptest: proptest_fund_conservation_dedicated_invariant_holds verifying this invariant across generated operation sequences of length 0 to 30.
Verification Results
Tests were run using the GNU toolchain locally:

bash


$env:PROPTEST_CASES=1000; cargo +stable-x86_64-pc-windows-gnu test -p bounty-escrow proptest_invariants
Output:

text


running 4 tests
test proptest_invariants::proptest_fee_basis_points_do_not_overflow_or_exceed_principal ... ok
test proptest_invariants::proptest_invariant_smoke_exercises_lifecycle_entrypoints ... ok
test proptest_invariants::proptest_fund_conservation_dedicated_invariant_holds ... ok
test proptest_invariants::proptest_lifecycle_invariants_hold_after_each_operation ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 399 filtered out; finished in 12.46s
During development, a deliberate accounting bug was injected (transferring claim_amount - 1 tokens on claim). The new property test caught the bug and shrank the input to the minimal sequence of operations:

text


thread 'proptest_invariants::proptest_fund_conservation_dedicated_invariant_holds' (39444) panicked at contracts\escrow\src\proptest_invariants.rs:616:10:
fund conservation invariant should hold across all valid operation sequences: Fail(Reason("assertion failed: `(left == right)` 
  left: `7247`, 
 right: `7248`: Fund conservation invariant violated: totals.locked (7247) must equal totals.released (7244) + totals.refunded (0) + contract_balance (4)..."), [LifecycleOp { kind: 0, selector: 0, amount: 3, deadline_delta: 1 }, LifecycleOp { kind: 0, selector: 3, amount: 7244, deadline_delta: 864 }, LifecycleOp { kind: 5, selector: 43, amount: 10603, deadline_delta: 331 }, LifecycleOp { kind: 6, selector: 0, amount: 19906, deadline_delta: 52 }])