### PR TITLE
#318 Add version-too-low branch coverage for bounty_escrow governance_integration.rs check_upgrade_approval() FIXED

### DIFF
--- a/bounty_escrow/contracts/escrow/src/test_governance_integration.rs
+++ b/bounty_escrow/contracts/escrow/src/test_governance_integration.rs
@@ -33,6 +33,30 @@ mod mock_governance {
     }
 }
 
+// Mock governance that returns version 1 (below minimum) but approves the same hash [7;32].
+// Used to exercise the version-gate short-circuit branch in check_upgrade_approval.
+mod mock_governance_low {
+    use soroban_sdk::{contract, contractimpl, BytesN, Env};
+
+    #[contract]
+    pub struct MockGovernanceLowVersion;
+
+    #[contractimpl]
+    impl MockGovernanceLowVersion {
+        pub fn get_ver(_env: Env) -> u32 {
+            1
+        }
+
+        pub fn get_version_numeric_encoded(_env: Env) -> u32 {
+            10_000 // v1.0.0 encoded
+        }
+
+        pub fn is_upg_ok(env: Env, wasm_hash: BytesN<32>) -> bool {
+            wasm_hash == BytesN::from_array(&env, &[7u8; 32])
+        }
+    }
+}
+
 fn create_token_contract<'a>(
     env: &Env,
     admin: &Address,
@@ -527,4 +551,172 @@ fn test_governance_not_initialized_error() {
 
     // Should fail because contract is not initialized
     let _ = client.set_governance_contract(&governance_addr);
+}
+
+// =============================================================================
+// Version-gate coverage for check_upgrade_approval
+// =============================================================================
+// Branch map for check_upgrade_approval (governance_integration.rs):
+//   1) No governance configured           -> return false
+//      Exercised by: test_upgrade_approval_denies_when_governance_is_not_configured
+//   2) Version gate: check_governance_version() == false -> return false (short-circuit)
+//      Exercised by: test_upgrade_approval_version_gate_rejects_matching_hash_when_version_too_low*
+//   3) Hash mismatch: is_upg_ok returns false -> return false
+//      Exercised by: test_upgrade_approval_requires_matching_executed_governance_hash (wrong_hash)
+//   4) Happy path: version ok + hash matches -> return true
+//      Exercised by: test_upgrade_approval_requires_matching_executed_governance_hash (approved_hash)
+//                    + test_upgrade_approval_version_gate_allows_matching_hash_when_version_meets*
+//                    + test_upgrade_approval_same_hash_transitions_from_reject_to_accept_when_min_version_lowered
+// * = new tests added for this bounty.
+
+/// A matching upgrade hash must be rejected when the linked governance contract's
+/// on-chain version is below min_governance_version. This pins down the version-gate
+/// short-circuit at the top of check_upgrade_approval — the hash would otherwise match,
+/// but the function must return false before ever reaching is_upg_ok.
+#[test]
+fn test_upgrade_approval_version_gate_rejects_matching_hash_when_version_too_low() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.init(&admin, &token);
+
+    // Mock governance returns version 1, but we require version 2 — so the version
+    // gate should short-circuit and reject even though the hash matches.
+    let gov_contract_id =
+        env.register_contract(None, mock_governance_low::MockGovernanceLowVersion);
+    client.set_governance_contract(&gov_contract_id);
+    client.set_min_governance_version(&2);
+
+    let matching_hash = BytesN::from_array(&env, &[7u8; 32]);
+
+    env.as_contract(&contract_id, || {
+        // Directly assert the version check fails, proving we are on the version-gate branch.
+        assert!(
+            !governance_integration::check_governance_version(&env),
+            "governance version should be too low (1 < 2)"
+        );
+        // The version gate must short-circuit the upgrade approval to false,
+        // even though is_upg_ok would return true for this hash.
+        assert!(
+            !governance_integration::check_upgrade_approval(&env, &matching_hash),
+            "matching hash must be rejected when governance version is below minimum"
+        );
+    });
+}
+
+/// The same matching hash must be accepted once the governance version meets
+/// min_governance_version. This is the complementary positive case to the rejection test above.
+#[test]
+fn test_upgrade_approval_version_gate_allows_matching_hash_when_version_meets() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.init(&admin, &token);
+
+    // Same low-version mock (version 1), but now min_version is also 1, so the gate passes.
+    let gov_contract_id =
+        env.register_contract(None, mock_governance_low::MockGovernanceLowVersion);
+    client.set_governance_contract(&gov_contract_id);
+    client.set_min_governance_version(&1);
+
+    let matching_hash = BytesN::from_array(&env, &[7u8; 32]);
+
+    env.as_contract(&contract_id, || {
+        assert!(
+            governance_integration::check_governance_version(&env),
+            "governance version 1 should meet min 1"
+        );
+        assert!(
+            governance_integration::check_upgrade_approval(&env, &matching_hash),
+            "matching hash should be accepted when version requirement is met"
+        );
+    });
+}
+
+/// Proves that with all else unchanged (same governance contract, same hash),
+/// lowering min_governance_version from a too-high value to a met value flips
+/// check_upgrade_approval from false to true. This demonstrates the version gate
+/// is the sole reason for the earlier rejection.
+#[test]
+fn test_upgrade_approval_same_hash_transitions_from_reject_to_accept_when_min_version_lowered() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.init(&admin, &token);
+
+    let gov_contract_id =
+        env.register_contract(None, mock_governance_low::MockGovernanceLowVersion);
+    client.set_governance_contract(&gov_contract_id);
+
+    let matching_hash = BytesN::from_array(&env, &[7u8; 32]);
+
+    // Step 1: min_version = 2, governance version = 1 => should reject (version too low).
+    client.set_min_governance_version(&2);
+    env.as_contract(&contract_id, || {
+        assert!(!governance_integration::check_upgrade_approval(
+            &env,
+            &matching_hash
+        ));
+    });
+
+    // Step 2: all else unchanged, lower min_version to 1 => should now accept same hash.
+    client.set_min_governance_version(&1);
+    env.as_contract(&contract_id, || {
+        assert!(governance_integration::check_upgrade_approval(
+            &env,
+            &matching_hash
+        ));
+    });
+}
+
+/// Same version-gate logic but exercising the numeric-encoded semver path
+/// (min_version >= 10_000 uses get_version_numeric_encoded).
+#[test]
+fn test_upgrade_approval_numeric_encoded_version_gate() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.init(&admin, &token);
+
+    // Mock low returns 10_000 (v1.0.0 encoded). Require 20_000 (v2.0.0) => should fail.
+    let gov_contract_id =
+        env.register_contract(None, mock_governance_low::MockGovernanceLowVersion);
+    client.set_governance_contract(&gov_contract_id);
+    client.set_min_governance_version(&20_000);
+
+    let matching_hash = BytesN::from_array(&env, &[7u8; 32]);
+
+    env.as_contract(&contract_id, || {
+        assert!(!governance_integration::check_governance_version(&env));
+        assert!(!governance_integration::check_upgrade_approval(
+            &env,
+            &matching_hash
+        ));
+    });
+
+    // Lower requirement to 10_000 => should now pass and accept the same hash.
+    client.set_min_governance_version(&10_000);
+    env.as_contract(&contract_id, || {
+        assert!(governance_integration::check_governance_version(&env));
+        assert!(governance_integration::check_upgrade_approval(
+            &env,
+            &matching_hash
+        ));
+    });
 }


### PR DESCRIPTION


CLOSE #318
#### **Findings – Exact Issue Located**

**File:** `bounty_escrow/contracts/escrow/src/governance_integration.rs` – function `check_upgrade_approval`:

```rust
pub fn check_upgrade_approval(env: &Env, wasm_hash: &BytesN<32>) -> bool {
    let Some(gov_addr) = get_governance_contract(env) else {
        return false; // BRANCH 1: no governance configured
    };
    if !check_governance_version(env) {
        return false; // BRANCH 2: version gate short-circuit – UNTESTED
    }
    GovernanceClient::new(env, &gov_addr).is_upg_ok(wasm_hash) // BRANCH 3: hash mismatch vs happy path
}

pub fn check_governance_version(env: &Env) -> bool {
    if let Some(gov_addr) = get_governance_contract(env) {
        let min_version = get_min_governance_version(env);
        if min_version > 0 {
            let governance = GovernanceClient::new(env, &gov_addr);
            let version = if min_version >= 10_000 {
                governance.get_version_numeric_encoded() // semver path
            } else {
                governance.get_ver() // simple path
            };
            return version >= min_version;
        }
    }
    true
}
```

**Existing test coverage in `test_governance_integration.rs`:**
- `test_upgrade_approval_denies_when_governance_is_not_configured` → **Branch 1** (no governance) = false → covered
- `test_upgrade_approval_requires_matching_executed_governance_hash`:
  - approved_hash `[7u8;32]` → true (happy path)
  - wrong_hash `[9u8;32]` → false (**Branch 3** hash mismatch) = covered
- **Missing Branch 2**: governance configured + hash matching + version below `min_governance_version` → should return false via short-circuit, never reaching `is_upg_ok`. No test did this.

**Security Impact:** Escrow relies on this gate before WASM upgrade. If version check inverted/bypassed, stale governance with old version could still bless upgrade. Regression hidden in untested middle branch.

#### **Fix Features – What Was Implemented**

**1. New Mock – `mock_governance_low`**
Added alongside existing `mock_governance` to simulate outdated governance that still approves hash:

```rust
mod mock_governance_low {
    #[contract]
    pub struct MockGovernanceLowVersion;
    #[contractimpl]
    impl MockGovernanceLowVersion {
        pub fn get_ver(_env: Env) -> u32 { 1 } // below min 2
        pub fn get_version_numeric_encoded(_env: Env) -> u32 { 10_000 } // v1.0.0
        pub fn is_upg_ok(env: Env, wasm_hash: BytesN<32>) -> bool {
            wasm_hash == BytesN::from_array(&env, &[7u8; 32]) // same matching logic
        }
    }
}
```
This ensures hash would match, isolating version gate.

**2. Four New Tests**

**a) `test_upgrade_approval_version_gate_rejects_matching_hash_when_version_too_low`**
- Wires up low mock (v1), sets min=2, hash=[7;32]
- Asserts `check_governance_version() == false`
- Asserts `check_upgrade_approval() == false` (must short-circuit)
- Pins **failure mode 2: version too low**

**b) `test_upgrade_approval_version_gate_allows_matching_hash_when_version_meets`**
- Same mock (v1), min=1, same hash
- Asserts version true + approval true
- Pins **happy path after gate passes**, complementary to (a)

**c) `test_upgrade_approval_same_hash_transitions_from_reject_to_accept_when_min_version_lowered`**
- Uses same contract address + same hash, only changes `min_version` 2→1 within same test
- First call false, second true
- Proves version gate is sole reason (all else unchanged) – directly satisfies issue requirement: "once version meets, same hash now returns true"

**d) `test_upgrade_approval_numeric_encoded_version_gate`**
- Tests second version path (`min>=10_000` uses `get_version_numeric_encoded`)
- Low returns 10_000, require 20_000 → false, then lower to 10_000 → true
- Covers both simple and semver-encoded branches

**3. Branch Documentation Added In-Code**
Added comment block mapping tests to branches for PR description compliance:

```
Branch 1 No governance -> test_upgrade_approval_denies_when_governance_is_not_configured
Branch 2 Version gate  -> test_upgrade_approval_version_gate_rejects...
Branch 3 Hash mismatch -> test_upgrade_approval_requires... (wrong_hash)
Branch 4 Happy path    -> approved_hash + new allow tests
```

**Result:** Three failure modes independently pinned, version-gate now has 100% coverage, efficient (no extra on-chain logic), easy to review (only tests added, no contract logic changed).