### PR TITLE
test: add wasm-hash-mismatch rejection coverage for scheduled upgrades

### DIFF
--- a/grainlify-core/src/lib.rs
+++ b/grainlify-core/src/lib.rs
@@ -1824,6 +1824,101 @@ mod test {
     }
 
     #[test]
+    fn test_upgrade_rejects_hash_mismatch_and_preserves_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|li| li.timestamp = 3_000);
+
+        let contract_id = env.register_contract(None, GrainlifyContract);
+        let client = GrainlifyContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.init_admin(&admin);
+
+        let initial_version = client.get_version();
+        assert_eq!(initial_version, VERSION);
+        assert_eq!(client.get_previous_version(), None);
+
+        let scheduled_hash = BytesN::from_array(&env, &[1u8; 32]);
+        let mismatch_hash = BytesN::from_array(&env, &[2u8; 32]);
+
+        client.set_upgrade_delay(&600);
+        let scheduled = client.schedule_upgrade(&scheduled_hash);
+
+        // Advance time past executable_at
+        env.ledger().with_mut(|li| li.timestamp = 3_600);
+
+        // Attempt upgrade with mismatched hash
+        let res = client.try_upgrade(&mismatch_hash);
+        assert!(res.is_err(), "upgrade() with mismatched WASM hash must be rejected");
+
+        // Verify contract version and state are provably unchanged
+        assert_eq!(client.get_version(), initial_version);
+        assert_eq!(client.get_previous_version(), None);
+        assert_eq!(client.get_scheduled_upgrade(), Some(scheduled));
+    }
+
+    #[test]
+    fn test_upgrade_rejects_no_schedule_and_preserves_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, GrainlifyContract);
+        let client = GrainlifyContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.init_admin(&admin);
+
+        let initial_version = client.get_version();
+        assert_eq!(initial_version, VERSION);
+        assert_eq!(client.get_previous_version(), None);
+        assert_eq!(client.get_scheduled_upgrade(), None);
+
+        let wasm_hash = BytesN::from_array(&env, &[8u8; 32]);
+
+        // Attempt upgrade without any scheduled upgrade
+        let res = client.try_upgrade(&wasm_hash);
+        assert!(res.is_err(), "upgrade() without active schedule must be rejected");
+
+        // Verify contract version and state are provably unchanged
+        assert_eq!(client.get_version(), initial_version);
+        assert_eq!(client.get_previous_version(), None);
+        assert_eq!(client.get_scheduled_upgrade(), None);
+    }
+
+    #[test]
+    fn test_upgrade_rejects_hash_mismatch_before_timelock_and_preserves_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|li| li.timestamp = 3_000);
+
+        let contract_id = env.register_contract(None, GrainlifyContract);
+        let client = GrainlifyContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.init_admin(&admin);
+
+        let initial_version = client.get_version();
+        let scheduled_hash = BytesN::from_array(&env, &[1u8; 32]);
+        let mismatch_hash = BytesN::from_array(&env, &[2u8; 32]);
+
+        client.set_upgrade_delay(&600);
+        let scheduled = client.schedule_upgrade(&scheduled_hash);
+
+        // Advance timestamp before timelock has elapsed
+        env.ledger().with_mut(|li| li.timestamp = 3_500);
+
+        // Attempt upgrade with mismatched hash before timelock
+        let res = client.try_upgrade(&mismatch_hash);
+        assert!(res.is_err(), "upgrade() with mismatched hash before timelock must be rejected");
+
+        // Verify contract version and state are provably unchanged
+        assert_eq!(client.get_version(), initial_version);
+        assert_eq!(client.get_previous_version(), None);
+        assert_eq!(client.get_scheduled_upgrade(), Some(scheduled));
+    }
+
+    #[test]
     fn test_upgrade_ready_at_exact_boundary() {
         let env = Env::default();
         env.mock_all_auths();


### PR DESCRIPTION
Closes #262

## Summary of Changes
Added test coverage in `grainlify-core/src/lib.rs` for single-admin scheduled upgrade WASM hash mismatch rejection and contract state/version preservation upon rejected upgrade calls.

## Added Tests
- `test_upgrade_rejects_hash_mismatch_and_preserves_state`: Verifies that attempting an upgrade with a 32-byte hash (`hash_b`) different from the scheduled hash (`hash_a`) after the timelock has elapsed is rejected, and confirms the contract version, previous version, and active schedule remain provably unchanged.
- `test_upgrade_rejects_no_schedule_and_preserves_state`: Verifies that attempting to call `upgrade()` on a fresh contract without an active schedule is rejected and preserves state.
- `test_upgrade_rejects_hash_mismatch_before_timelock_and_preserves_state`: Verifies that calling `upgrade()` with a mismatched hash before the timelock elapses is rejected and preserves state.

## Verification
Executed all `grainlify-core` unit tests via `cargo test -p grainlify-core`:
```text
running 35 tests
test governance::test::test_proposal_execution_delay ... ok
test governance::test::test_vote_period_and_execution_delay ... ok
test multisig::test::test_threshold_viability_rejects_breaking_removal ... ok
test multisig::test::test_signer_removal_works ... ok
test multisig::test::test_upgrade_proposal_preserves_signer_set ... ok
test test::multisig_init_works ... ok
test test::test_complete_upgrade_and_migration_workflow ... ok
test test::test_get_previous_version ... ok
test test::test_init_twice_panics ... ok
test test::test_migration_idempotency ... ok
test test::test_migration_invalid_target_version ... ok
test test::test_migration_v1_to_v2 ... ok
test test::test_schedule_upgrade_records_timelock ... ok
test test::test_set_version ... ok
test test::test_upgrade_executes_after_timelock ... ok
test test::test_upgrade_ready_at_exact_boundary ... ok
test test::test_upgrade_rejects_early_execution ... ok
test test::test_upgrade_rejects_hash_mismatch ... ok
test test::test_upgrade_rejects_hash_mismatch_and_preserves_state ... ok
test test::test_upgrade_rejects_hash_mismatch_before_timelock_and_preserves_state ... ok
test test::test_upgrade_rejects_no_schedule_and_preserves_state ... ok
test test::test_upgrade_requires_prior_schedule ... ok

test result: ok. 35 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s
```
