### PR TITLE
test: lock down stale-window time-based health_check recovery semantic

### DIFF
--- a/program-escrow/src/monitoring.rs
+++ b/program-escrow/src/monitoring.rs
@@ -1,3 +1,14 @@
+//! Monitoring and Analytics Module
+//!
+//! Note on Health Check Semantics:
+//! The `health_check` function evaluates health using a rolling time window.
+//! An alert state triggered by a high error rate will clear (`is_healthy` flips to `true`)
+//! purely from the passage of time once the `WINDOW_DURATION` has elapsed, even if there
+//! are no new successful operations. This is a time-based clear, not a recovery-based clear.
+//! Off-chain monitoring relying on `health_check` should be aware that a healthy status
+//! might simply mean the error window decayed, and not necessarily that the underlying
+//! issue was fixed.
+
 use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Symbol};
 
 // Storage keys

--- a/program-escrow/src/test_monitoring.rs
+++ b/program-escrow/src/test_monitoring.rs
@@ -310,4 +310,71 @@ fn test_metric_decay_and_alert_clearing() {
     assert_eq!(snap3.total_errors, 1);
 }
 
+#[test]
+fn test_stale_window_time_based_clear() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let tokenadmin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract(tokenadmin.clone());
+    let program_id = String::from_str(&env, "stale-clear");
+
+    env.ledger().set_timestamp(1000);
+    client.init_program(&program_id, &admin, &token_id);
+
+    // Drive error rate to >= 50% (threshold is 5000 bps)
+    env.as_contract(&contract_id, || {
+        crate::monitoring::track_operation(&env, symbol_short!("op"), admin.clone(), false);
+    });
+
+    // Verify unhealthy state
+    assert_eq!(client.health_check().is_healthy, false);
+
+    // Advance timestamp past WINDOW_DURATION with NO further operations
+    env.ledger().set_timestamp(1000 + 3600);
+
+    // Confirm is_healthy flips back to true purely from time decay
+    assert_eq!(client.health_check().is_healthy, true);
+}
+
+#[test]
+fn test_window_boundary_fresh_start() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let tokenadmin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract(tokenadmin.clone());
+    let program_id = String::from_str(&env, "fresh-start");
+
+    env.ledger().set_timestamp(1000);
+    client.init_program(&program_id, &admin, &token_id);
+
+    // Drive error rate to >= 50%
+    env.as_contract(&contract_id, || {
+        crate::monitoring::track_operation(&env, symbol_short!("op"), admin.clone(), false);
+    });
+    assert_eq!(client.health_check().is_healthy, false);
+
+    // Advance timestamp exactly to the window boundary
+    env.ledger().set_timestamp(1000 + 3600);
+
+    // Single new operation exactly at boundary
+    env.as_contract(&contract_id, || {
+        crate::monitoring::track_operation(&env, symbol_short!("op"), admin.clone(), true);
+    });
+
+    // Starts a fresh window, error rate is 0%, no stale counts inherited
+    assert_eq!(client.health_check().is_healthy, true);
+    let snap = client.get_state_snapshot();
+    assert_eq!(snap.total_operations, 3);
+    assert_eq!(snap.total_errors, 1);
+}
 


### PR DESCRIPTION
Closes #266 


# Lock down stale-window time-based health_check recovery semantic

## Objective
This PR explicitly locks down and tests the time-based window decay behavior in the `program-escrow/src/monitoring.rs` health check functionality. It also adds necessary module-level documentation to inform consumers of the contract about this edge case.

## Context & Rationale
The `health_check` method in `monitoring.rs` relies on a rolling time window (`WINDOW_DURATION` of 1 hour) to assess whether the error rate exceeds `ERROR_RATE_THRESHOLD_BPS`. 
However, because of the way the rolling window decays, an unhealthy state (e.g., an error rate of 50%+) will implicitly clear and flip back to `is_healthy: true` purely as a result of the passage of time—even if **zero** new successful operations have occurred to actually prove the system has recovered.

This "time-based clear" semantic is an unusual design for health-check implementations (which typically expect a "recovery-based clear" where a system proves it is healthy through successful pings/operations). This PR explicitly verifies this behavior via tests to ensure it operates as intended and ensures the code is properly documented so off-chain clients don't falsely interpret a time-cleared error as a resolved incident.

##  Changes Implemented

### 1. Module Documentation
- Added a detailed module-level doc-comment to `program-escrow/src/monitoring.rs`.
- Explicitly flags the semantic difference between a time-based clear and a recovery-based clear to ensure maximum visibility for future maintainers and integrators.

### 2. Targeted Test Coverage (`program-escrow/src/test_monitoring.rs`)
- **`test_stale_window_time_based_clear`**: 
  - Purposely drives the error rate above `ERROR_RATE_THRESHOLD_BPS` via simulated `track_operation` failures.
  - Asserts that `health_check().is_healthy` returns `false`.
  - Advances the `env.ledger().timestamp()` past the `WINDOW_DURATION` threshold with absolutely no new operations.
  - Confirms the status seamlessly flips back to `true` due to metric decay alone.
- **`test_window_boundary_fresh_start`**: 
  - Matches the initial setup of the previous test to trigger an unhealthy state.
  - Advances the ledger exactly to the window boundary.
  - Fires a single new *successful* operation exactly on the boundary.
  - Asserts that a completely fresh window is started (0% error rate), confirming no stale failure counts accidentally roll over into the new timeframe.

## Acceptance Criteria Met
- [x] Behavior of `is_healthy` flipping to `true` purely from time decay is explicitly tested.
- [x] Window-boundary reset is confirmed not to carry over stale counts.
- [x] The semantic is prominently documented in the module to avoid upstream confusion.

***