### PR TITLE
test: add first coverage for query_releases_by_recipient

### DIFF
--- a/program-escrow/src/test.rs
+++ b/program-escrow/src/test.rs
@@ -1709,6 +1709,197 @@ fn test_combined_recipient_and_amount_filter_manual() {
     assert_eq!(last_amount, 200_000);
 }
 
+// ---------------------------------------------------------------------------
+// query_releases_by_recipient (issue #319): recipient isolation + pagination.
+// Fixtures use distinct amounts per entry (unlike identical-amount fixtures
+// elsewhere) so pagination assertions can pin down exact identity and order,
+// not just counts.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_query_releases_by_recipient_returns_correct_records() {
+    let env = Env::default();
+    let (client, _admin, _token, _tokenadmin) = setup_program(&env, 2_000_000);
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let r3 = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+    // Interleaved recipients, overlapping counts (r1: 2, r2: 2, r3: 1).
+    client.create_program_release_schedule(&111_000, &(now + 10), &r1);
+    client.create_program_release_schedule(&222_000, &(now + 10), &r2);
+    client.create_program_release_schedule(&333_000, &(now + 10), &r1);
+    client.create_program_release_schedule(&444_000, &(now + 10), &r3);
+    client.create_program_release_schedule(&555_000, &(now + 10), &r2);
+
+    env.ledger().set_timestamp(now + 10);
+    let released = client.trigger_program_releases();
+    assert_eq!(released, 5);
+
+    // r1: exact set, in creation order, by schedule_id and amount.
+    let r1_records = client.query_releases_by_recipient(&r1, &0, &10);
+    assert_eq!(r1_records.len(), 2);
+    assert_eq!(r1_records.get(0).unwrap().schedule_id, 1);
+    assert_eq!(r1_records.get(0).unwrap().amount, 111_000);
+    assert_eq!(r1_records.get(1).unwrap().schedule_id, 3);
+    assert_eq!(r1_records.get(1).unwrap().amount, 333_000);
+    for record in r1_records.iter() {
+        assert_eq!(record.recipient, r1);
+    }
+    // Explicitly assert no other recipient's amounts leaked into r1's set.
+    for record in r1_records.iter() {
+        assert_ne!(record.amount, 222_000);
+        assert_ne!(record.amount, 444_000);
+        assert_ne!(record.amount, 555_000);
+    }
+
+    // r2: exact set, in creation order.
+    let r2_records = client.query_releases_by_recipient(&r2, &0, &10);
+    assert_eq!(r2_records.len(), 2);
+    assert_eq!(r2_records.get(0).unwrap().schedule_id, 2);
+    assert_eq!(r2_records.get(0).unwrap().amount, 222_000);
+    assert_eq!(r2_records.get(1).unwrap().schedule_id, 5);
+    assert_eq!(r2_records.get(1).unwrap().amount, 555_000);
+    for record in r2_records.iter() {
+        assert_eq!(record.recipient, r2);
+        assert_ne!(record.amount, 111_000);
+        assert_ne!(record.amount, 333_000);
+        assert_ne!(record.amount, 444_000);
+    }
+
+    // r3: single exact record.
+    let r3_records = client.query_releases_by_recipient(&r3, &0, &10);
+    assert_eq!(r3_records.len(), 1);
+    assert_eq!(r3_records.get(0).unwrap().schedule_id, 4);
+    assert_eq!(r3_records.get(0).unwrap().amount, 444_000);
+    assert_eq!(r3_records.get(0).unwrap().recipient, r3);
+}
+
+#[test]
+fn test_query_releases_by_recipient_unknown_returns_empty() {
+    let env = Env::default();
+    let (client, _admin, _token, _tokenadmin) = setup_program(&env, 100_000);
+
+    let r1 = Address::generate(&env);
+    let unknown = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+    client.create_program_release_schedule(&50_000, &(now + 10), &r1);
+    env.ledger().set_timestamp(now + 10);
+    client.trigger_program_releases();
+
+    // r1 has release history, but `unknown` was never scheduled anything.
+    let results = client.query_releases_by_recipient(&unknown, &0, &10);
+    assert_eq!(results.len(), 0);
+}
+
+#[test]
+fn test_query_releases_by_recipient_empty_history_returns_empty() {
+    let env = Env::default();
+    // No schedules ever created, so RELEASE_HISTORY was never written to storage.
+    let (client, _admin, _token, _tokenadmin) = setup_program(&env, 0);
+
+    let recipient = Address::generate(&env);
+    let results = client.query_releases_by_recipient(&recipient, &0, &10);
+    assert_eq!(results.len(), 0);
+}
+
+#[test]
+fn test_query_releases_by_recipient_pagination_truncates_and_preserves_order() {
+    let env = Env::default();
+    let (client, _admin, _token, _tokenadmin) = setup_program(&env, 500_000);
+
+    let r1 = Address::generate(&env);
+    let now = env.ledger().timestamp();
+    let amounts = [10_000, 20_000, 30_000, 40_000, 50_000];
+    for amount in amounts {
+        client.create_program_release_schedule(&amount, &(now + 10), &r1);
+    }
+
+    env.ledger().set_timestamp(now + 10);
+    let released = client.trigger_program_releases();
+    assert_eq!(released, 5);
+
+    // limit=3, offset=0: expect exactly the first 3 entries, in order.
+    let page = client.query_releases_by_recipient(&r1, &0, &3);
+    assert_eq!(page.len(), 3);
+    assert_eq!(page.get(0).unwrap().schedule_id, 1);
+    assert_eq!(page.get(0).unwrap().amount, 10_000);
+    assert_eq!(page.get(1).unwrap().schedule_id, 2);
+    assert_eq!(page.get(1).unwrap().amount, 20_000);
+    assert_eq!(page.get(2).unwrap().schedule_id, 3);
+    assert_eq!(page.get(2).unwrap().amount, 30_000);
+}
+
+#[test]
+fn test_query_releases_by_recipient_pagination_offset_skips_in_order() {
+    let env = Env::default();
+    let (client, _admin, _token, _tokenadmin) = setup_program(&env, 500_000);
+
+    let r1 = Address::generate(&env);
+    let now = env.ledger().timestamp();
+    let amounts = [10_000, 20_000, 30_000, 40_000, 50_000];
+    for amount in amounts {
+        client.create_program_release_schedule(&amount, &(now + 10), &r1);
+    }
+
+    env.ledger().set_timestamp(now + 10);
+    client.trigger_program_releases();
+
+    // offset=2, limit=10: expect the last 3 entries, order preserved.
+    let page = client.query_releases_by_recipient(&r1, &2, &10);
+    assert_eq!(page.len(), 3);
+    assert_eq!(page.get(0).unwrap().schedule_id, 3);
+    assert_eq!(page.get(0).unwrap().amount, 30_000);
+    assert_eq!(page.get(1).unwrap().schedule_id, 4);
+    assert_eq!(page.get(1).unwrap().amount, 40_000);
+    assert_eq!(page.get(2).unwrap().schedule_id, 5);
+    assert_eq!(page.get(2).unwrap().amount, 50_000);
+}
+
+#[test]
+fn test_query_releases_by_recipient_pagination_offset_and_limit_combined() {
+    let env = Env::default();
+    let (client, _admin, _token, _tokenadmin) = setup_program(&env, 500_000);
+
+    let r1 = Address::generate(&env);
+    let now = env.ledger().timestamp();
+    let amounts = [10_000, 20_000, 30_000, 40_000, 50_000];
+    for amount in amounts {
+        client.create_program_release_schedule(&amount, &(now + 10), &r1);
+    }
+
+    env.ledger().set_timestamp(now + 10);
+    client.trigger_program_releases();
+
+    // offset=1, limit=2: expect exactly the middle slice [schedule 2, schedule 3].
+    let page = client.query_releases_by_recipient(&r1, &1, &2);
+    assert_eq!(page.len(), 2);
+    assert_eq!(page.get(0).unwrap().schedule_id, 2);
+    assert_eq!(page.get(0).unwrap().amount, 20_000);
+    assert_eq!(page.get(1).unwrap().schedule_id, 3);
+    assert_eq!(page.get(1).unwrap().amount, 30_000);
+}
+
+#[test]
+fn test_query_releases_by_recipient_offset_beyond_total_returns_empty() {
+    let env = Env::default();
+    let (client, _admin, _token, _tokenadmin) = setup_program(&env, 200_000);
+
+    let r1 = Address::generate(&env);
+    let now = env.ledger().timestamp();
+    client.create_program_release_schedule(&10_000, &(now + 10), &r1);
+    client.create_program_release_schedule(&20_000, &(now + 10), &r1);
+
+    env.ledger().set_timestamp(now + 10);
+    client.trigger_program_releases();
+
+    // Only 2 matching entries exist; offset=5 is well beyond that count.
+    let page = client.query_releases_by_recipient(&r1, &5, &10);
+    assert_eq!(page.len(), 0);
+}
+
 // ========================================================================
 // Fund Cap Tests
 // ========================================================================


### PR DESCRIPTION
Closes #319

`query_releases_by_recipient` had zero test coverage anywhere in the repo (confirmed by repo-wide grep) despite being structurally identical to `query_payouts_by_recipient`, which is already tested.

## Closing a real coverage gap in the sibling test, not just copying it
The existing sibling test (`query_payouts_by_recipient`'s pagination coverage, `test.rs:1479-1629`) uses identical `10_000` amounts for every fixture entry, so it can only assert page **lengths** (2/2/1) — it structurally cannot detect an off-by-one or misordering bug in the offset/limit logic, since every entry is indistinguishable from every other. My tests give each fixture a distinct amount, enabling exact-identity and order assertions throughout.

## Tests added (7)
1. `test_query_releases_by_recipient_returns_correct_records` — 3 recipients, overlapping counts; asserts exact `schedule_id`+`amount` per returned entry, and explicitly asserts no other recipient's amount leaked in.
2. `test_query_releases_by_recipient_unknown_returns_empty` — recipient with no schedules, others populated → empty.
3. `test_query_releases_by_recipient_empty_history_returns_empty` — `RELEASE_HISTORY` key never written at all → empty, no panic.
4. `test_query_releases_by_recipient_pagination_truncates_and_preserves_order` — 5 distinct-amount entries, `limit=3` → exact first 3, in order.
5. `test_query_releases_by_recipient_pagination_offset_skips_in_order` — `offset=2` → exact last 3, in order.
6. `test_query_releases_by_recipient_pagination_offset_and_limit_combined` — `offset=1, limit=2` → exact middle slice.
7. `test_query_releases_by_recipient_offset_beyond_total_returns_empty` — `offset=5` with only 2 entries → empty, no panic.

## Implementation bug found?
No. `query_releases_by_recipient` (`lib.rs:2422`) is a correct, symmetric clone of `query_payouts_by_recipient` — filter by recipient, then apply offset/limit to the filtered subset, in `RELEASE_HISTORY` insertion order.

## Tests

running 7 tests
test test_query_releases_by_recipient_empty_history_returns_empty ... ok
test test_query_releases_by_recipient_offset_beyond_total_returns_empty ... ok
test test_query_releases_by_recipient_pagination_offset_skips_in_order ... ok
test test_query_releases_by_recipient_pagination_offset_and_limit_combined ... ok
test test_query_releases_by_recipient_pagination_truncates_and_preserves_order ... ok
test test_query_releases_by_recipient_unknown_returns_empty ... ok
test test_query_releases_by_recipient_returns_correct_records ... ok

test result: ok. 7 passed; 0 failed

Full crate: 416 passed (409 baseline + 7 new), 1 failed, 1 ignored — same pre-existing failure count as unmodified `main`.

## Acceptance criteria
- [x] Only the queried recipient's entries returned, excluding others (exact-set assertion)
- [x] Offset and limit correctly skip/truncate, order-aware
- [x] Empty history returns empty `Vec`, no panic

## Pre-existing, out of scope
`reentrancy_tests::test_token_callback_reentrancy_batch_payout` fails consistently on unmodified `main` — unrelated function/file, not touched here. Worth its own ticket.

---
Tests Implemented and Task Completed
@Jagadeeshftw Please Review