### PR TITLE
test: add double-execute rejection coverage for multisig execute

### DIFF
--- a/grainlify-core/src/multisig.rs
+++ b/grainlify-core/src/multisig.rs
@@ -597,18 +597,30 @@ mod test {
 
         setup.env.as_contract(&setup.contract_id, || {
             MultiSig::approve(&setup.env, proposal_id, setup.signer_a.clone());
-        });
-
-        setup.env.as_contract(&setup.contract_id, || {
             MultiSig::approve(&setup.env, proposal_id, setup.signer_b.clone());
         });
 
-        setup.env.as_contract(&setup.contract_id, || {
-            MultiSig::execute(&setup.env, proposal_id, action.clone(), 0, || {});
-        });
+        let mut side_effect_counter = 0u32;
 
         setup.env.as_contract(&setup.contract_id, || {
-            MultiSig::execute(&setup.env, proposal_id, action, 0, || {});
+            MultiSig::execute(&setup.env, proposal_id, action.clone(), 0, || {
+                side_effect_counter += 1;
+            });
+        });
+
+        assert_eq!(side_effect_counter, 1);
+
+        let current_nonce =
+            setup.env.as_contract(&setup.contract_id, || MultiSig::nonce(&setup.env));
+        assert_eq!(current_nonce, 1);
+
+        // Re-executing the same proposal with the updated current nonce and matching action
+        // must still be rejected with AlreadyExecuted, proving the AlreadyExecuted guard
+        // fires before the action closure can run a second time.
+        setup.env.as_contract(&setup.contract_id, || {
+            MultiSig::execute(&setup.env, proposal_id, action, current_nonce, || {
+                side_effect_counter += 1;
+            });
         });
     }
 


### PR DESCRIPTION
Closes #291 
This PR adds double-execute rejection test coverage for `MultiSig::execute` in `grainlify-core/src/multisig.rs`.

### Problem Solved
While `MultiSig::execute` contains an explicit guard (`if proposal.executed { panic!("{:?}", MultiSigError::AlreadyExecuted); }`), prior test coverage called `execute` a second time using a stale nonce (`0`), which could obscure whether `AlreadyExecuted` or `NonceMismatch` was triggered under valid nonces.

### Changes Made
- Updated `second_execute_is_rejected` test in `grainlify-core/src/multisig.rs`:
  1. Captured side-effects using a test-local closure counter (`side_effect_counter`).
  2. Verified `side_effect_counter` is incremented exactly once (`assert_eq!(side_effect_counter, 1)`).
  3. Fetched the updated current contract nonce (`MultiSig::nonce(&env) == 1`).
  4. Re-invoked `MultiSig::execute` on the same `proposal_id` with the valid current nonce (`1`) and matching `ProposalAction`.
  5. Verified that re-execution panics with `MultiSigError::AlreadyExecuted` before the bound action closure can run a second time.

### Test Results
```text
running 23 tests
test multisig::test::already_approved_is_rejected ... ok
test multisig::test::approve_after_execute_is_rejected ... ok
test multisig::test::exactly_at_threshold_is_executable ... ok
test multisig::test::execute_rejects_below_threshold ... ok
test multisig::test::execute_rejects_mismatched_payload ... ok
test multisig::test::execute_rejects_wrong_nonce ... ok
test multisig::test::execute_runs_bound_action_and_marks_proposal_once ... ok
test multisig::test::n_of_n_requires_all_signers ... ok
test multisig::test::nonce_starts_at_zero_and_increments_per_execution ... ok
test multisig::test::one_of_n_single_approval_suffices ... ok
test multisig::test::one_short_of_threshold_is_not_executable ... ok
test multisig::test::rejected_replay_leaves_state_untouched ... ok
test multisig::test::remove_signer_below_threshold_is_rejected ... ok
test multisig::test::remove_signer_boundary_exactly_at_threshold_is_allowed ... ok
test multisig::test::remove_signer_normal_above_threshold_succeeds ... ok
test multisig::test::replayed_signatures_and_nonce_are_rejected ... ok
test multisig::test::second_execute_is_rejected ... ok
test multisig::test::signer_and_threshold_snapshot_prevents_retroactive_validation ... ok
test multisig::test::test_add_signer_emits_event ... ok
test multisig::test::test_rotate_signers_rejected_no_events ... ok
test multisig::test::test_rotate_signers_simultaneous_threshold_change ... ok
test multisig::test::threshold_exceeding_signer_count_is_rejected ... ok
test multisig::test::zero_threshold_is_rejected ... ok

test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s