### PR TITLE
test: add circuit breaker cooldown/reset coverage

### DIFF
--- a/bounty_escrow/contracts/escrow/src/test_circuit_breaker.rs
+++ b/bounty_escrow/contracts/escrow/src/test_circuit_breaker.rs
@@ -6,6 +6,7 @@
 // - Initial state validation
 // - Failure threshold behavior
 // - State transitions (Closed -> Open -> HalfOpen -> Closed)
+// - Manual-only reset behavior (no auto-reset cooldown)
 // - Admin controls
 // - Circuit breaker integration with escrow operations
 // - Error logging
@@ -254,6 +255,87 @@ fn test_reset_from_half_open_to_closed() {
         reset_circuit_breaker(&env, &admin);
         assert_eq!(get_state(&env), CircuitState::Closed);
         assert_eq!(get_failure_count(&env), 0);
+    });
+}
+
+#[test]
+fn test_open_circuit_does_not_auto_reset_after_elapsed_time() {
+    let (env, _admin, contract_id) = setup_with_admin(1);
+    let opened_at = 2_000u64;
+
+    env.ledger().set_timestamp(opened_at);
+    simulate_failures(&env, &contract_id, 1);
+
+    env.as_contract(&contract_id, || {
+        let status = get_status(&env);
+        assert_eq!(status.state, CircuitState::Open);
+        assert_eq!(status.opened_at, opened_at);
+        assert_eq!(check_and_allow(&env), Err(ERR_CIRCUIT_OPEN));
+    });
+
+    env.ledger().set_timestamp(opened_at + 1);
+    env.as_contract(&contract_id, || {
+        let status = get_status(&env);
+        assert_eq!(
+            status.state,
+            CircuitState::Open,
+            "Circuit breaker has no before-cooldown auto reset path"
+        );
+        assert_eq!(status.opened_at, opened_at);
+        assert_eq!(check_and_allow(&env), Err(ERR_CIRCUIT_OPEN));
+    });
+
+    env.ledger().set_timestamp(opened_at + 86_400);
+    env.as_contract(&contract_id, || {
+        let status = get_status(&env);
+        assert_eq!(
+            status.state,
+            CircuitState::Open,
+            "Circuit breaker remains open after elapsed time until admin reset"
+        );
+        assert_eq!(status.opened_at, opened_at);
+        assert_eq!(check_and_allow(&env), Err(ERR_CIRCUIT_OPEN));
+    });
+}
+
+#[test]
+fn test_repeated_trip_while_open_refreshes_failure_window() {
+    let (env, _admin, contract_id) = setup_with_admin(1);
+    let first_trip_at = 2_000u64;
+    let second_trip_at = 2_030u64;
+
+    env.ledger().set_timestamp(first_trip_at);
+    simulate_failures(&env, &contract_id, 1);
+
+    env.as_contract(&contract_id, || {
+        let status = get_status(&env);
+        assert_eq!(status.state, CircuitState::Open);
+        assert_eq!(status.failure_count, 1);
+        assert_eq!(status.last_failure_timestamp, first_trip_at);
+        assert_eq!(status.opened_at, first_trip_at);
+    });
+
+    env.ledger().set_timestamp(second_trip_at);
+    env.as_contract(&contract_id, || {
+        record_failure(&env, 99, symbol_short!("retry"), ERR_TRANSFER_FAILED);
+
+        let status = get_status(&env);
+        assert_eq!(status.state, CircuitState::Open);
+        assert_eq!(
+            status.failure_count, 2,
+            "A new recorded trip while open must not be ignored"
+        );
+        assert_eq!(status.last_failure_timestamp, second_trip_at);
+        assert_eq!(
+            status.opened_at, second_trip_at,
+            "The open timestamp refreshes on a new trip while already open"
+        );
+
+        let log = get_error_log(&env);
+        assert_eq!(log.len(), 2);
+        let latest = log.get(1).unwrap();
+        assert_eq!(latest.bounty_id, 99);
+        assert_eq!(latest.timestamp, second_trip_at);
     });
 }
 

--- a/docs/bounty_escrow/CIRCUIT_BREAKER.md
+++ b/docs/bounty_escrow/CIRCUIT_BREAKER.md
@@ -95,6 +95,18 @@ Transitions:
 - `Open` -> `HalfOpen` (first reset)
 - `HalfOpen` -> `Closed` (second reset or sufficient successes)
 
+### Auto-Reset and Cooldown Behavior
+
+The Bounty Escrow circuit breaker is manual-reset-only. It does not define a
+cooldown duration and does not automatically transition out of `Open` based on
+elapsed ledger time. The `opened_at` and `last_failure_timestamp` values are
+diagnostic status fields; protected operations remain rejected while the circuit
+is `Open` until the registered circuit breaker admin calls `reset_circuit`.
+
+If another failure is recorded while the circuit is already `Open`, the trip is
+not silently ignored: the failure count and last failure timestamp are updated,
+and the open timestamp is refreshed to the latest trip time.
+
 ## Default Configuration
 
 ```rust
@@ -118,13 +130,16 @@ The circuit breaker maintains an error log with:
 2. **State Transitions**: Circuit can only be reset by the registered admin.
 3. **Automatic Opening**: Circuit opens automatically when failure threshold is reached.
 4. **Manual Reset**: Circuit requires manual admin intervention to transition from Open.
+5. **No Time-Based Auto Reset**: Elapsed ledger time alone cannot reopen fund-moving operations after a trip.
 
 ## Testing
 
-The circuit breaker includes 33 comprehensive tests covering:
+The circuit breaker includes 35 comprehensive tests covering:
 - Initial state validation
 - Failure threshold behavior
 - State transitions (Closed -> Open -> HalfOpen -> Closed)
+- Manual-only reset behavior and lack of auto-reset cooldown
+- Repeated trip handling while already Open
 - Admin controls (set admin, update admin, unauthorized access)
 - Configuration management
 - Error logging


### PR DESCRIPTION
## Summary

Closes #217 

- Confirms the bounty escrow circuit breaker is manual-reset-only, with no cooldown-based auto-reset path.
- Adds tests proving elapsed ledger time does not transition an open circuit out of `Open`.
- Adds coverage showing a repeated trip while already `Open` updates failure bookkeeping instead of being ignored.
- Documents the reset/cooldown behavior in the circuit breaker docs.

## Tests

- `cargo test -p bounty-escrow test_circuit_breaker`

Result: `35 passed; 0 failed; 415 filtered out`