### PR TITLE
Test: add program escrow analytics event ordering coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,15 +102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "bounty-escrow"
 version = "0.0.0"
 dependencies = [
@@ -196,15 +187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crate-git-revision"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,7 +204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -235,16 +217,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-dependencies = [
- "hybrid-array",
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -264,27 +236,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto 0.2.9",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "curve25519-dalek-derive",
- "digest 0.11.3",
- "fiat-crypto 0.3.0",
- "rand_core 0.10.1",
+ "digest",
+ "fiat-crypto",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -406,20 +361,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.1.6",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -441,10 +386,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
+ "signature",
 ]
 
 [[package]]
@@ -454,16 +399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
-dependencies = [
- "signature 3.0.0",
+ "signature",
 ]
 
 [[package]]
@@ -472,26 +408,11 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek 4.1.3",
- "ed25519 2.2.3",
- "rand_core 0.6.4",
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
  "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
-dependencies = [
- "curve25519-dalek 5.0.0",
- "ed25519 3.0.0",
- "rand_core 0.10.1",
- "sha2 0.11.0",
- "signature 3.0.0",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -510,11 +431,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -544,7 +465,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -553,12 +474,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "fiat-crypto"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -650,7 +565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -687,16 +602,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
-dependencies = [
- "typenum",
+ "digest",
 ]
 
 [[package]]
@@ -793,7 +699,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -802,7 +708,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -913,7 +819,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -1022,7 +928,7 @@ checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1032,7 +938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1045,18 +951,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1241,19 +1141,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1262,7 +1151,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
 
@@ -1278,17 +1167,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
-dependencies = [
- "rand_core 0.10.1",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -1351,9 +1231,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b7a32c28f281c423189f1298960194f0e0fc4eeb72378028171e556d8cd6160"
 dependencies = [
  "backtrace",
- "curve25519-dalek 5.0.0",
+ "curve25519-dalek",
  "ecdsa",
- "ed25519-dalek 3.0.0",
+ "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
  "getrandom",
@@ -1367,7 +1247,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "sec1",
- "sha2 0.10.9",
+ "sha2",
  "sha3",
  "soroban-builtin-sdk-macros",
  "soroban-env-common",
@@ -1416,7 +1296,7 @@ dependencies = [
  "bytes-lit",
  "ctor",
  "derive_arbitrary",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek",
  "rand",
  "rustc_version",
  "serde",
@@ -1440,7 +1320,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "sha2 0.10.9",
+ "sha2",
  "soroban-env-common",
  "soroban-spec",
  "soroban-spec-rust",
@@ -1469,7 +1349,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sha2 0.10.9",
+ "sha2",
  "soroban-spec",
  "stellar-xdr",
  "syn 2.0.119",

--- a/docs/program-escrow/ANALYTICS_EVENTS.md
+++ b/docs/program-escrow/ANALYTICS_EVENTS.md
@@ -98,6 +98,22 @@ for schedule in schedules {
 }
 ```
 
+### Event Ordering and Revert Guarantees
+
+For a successful `single_payout()` that qualifies as a large payout, off-chain
+consumers can rely on this relative contract-event order within the same
+transaction:
+
+1. `LrgPay` is emitted first, after the token transfer succeeds and program
+   balance state is updated.
+2. `Payout` is emitted immediately after `LrgPay` and reports the same
+   finalized remaining balance.
+3. `AggStats` is emitted after `Payout` and reflects the same finalized balance.
+
+If a contract call reverts, analytics events are all-or-nothing: no partial
+`LrgPay`, `Payout`, or `AggStats` events from the failed call persist for
+off-chain consumers.
+
 ## Testing
 
 Comprehensive test suite in `src/test_analytics_events.rs`:
@@ -107,13 +123,15 @@ Comprehensive test suite in `src/test_analytics_events.rs`:
 3. **test_large_payout_event_emitted_above_threshold** - Tests large payout detection (15% of funds)
 4. **test_large_payout_event_not_emitted_below_threshold** - Tests threshold boundary (5% of funds)
 5. **test_large_payout_event_in_batch** - Tests large payout detection in batch operations
-6. **test_schedule_triggered_event_automatic** - Tests automatic schedule trigger events
-7. **test_schedule_triggered_event_manual** - Tests manual schedule trigger events
-8. **test_multiple_schedule_triggers_emit_multiple_events** - Tests multiple schedule releases
-9. **test_aggregate_stats_includes_scheduled_count** - Verifies scheduled_count calculation
-10. **test_aggregate_stats_after_schedule_release** - Verifies stats update after release
-11. **test_event_payload_compactness** - Ensures payloads are not bloated
-12. **test_all_analytics_events_have_program_id** - Verifies program_id in all events
+6. **test_large_single_payout_event_ordering_is_stable** - Locks in large payout event ordering
+7. **test_reverted_large_single_payout_emits_no_partial_events** - Verifies failed calls leave no partial analytics events
+8. **test_schedule_triggered_event_automatic** - Tests automatic schedule trigger events
+9. **test_schedule_triggered_event_manual** - Tests manual schedule trigger events
+10. **test_multiple_schedule_triggers_emit_multiple_events** - Tests multiple schedule releases
+11. **test_aggregate_stats_includes_scheduled_count** - Verifies scheduled_count calculation
+12. **test_aggregate_stats_after_schedule_release** - Verifies stats update after release
+13. **test_event_payload_compactness** - Ensures payloads are not bloated
+14. **test_all_analytics_events_have_program_id** - Verifies program_id in all events
 
 ## Security Considerations
 
@@ -121,6 +139,7 @@ Comprehensive test suite in `src/test_analytics_events.rs`:
 2. **Threshold-Based Alerts**: Large payout events enable fraud detection
 3. **Audit Trail**: Schedule triggered events provide complete execution history
 4. **Version Compatibility**: v2 schema ensures forward compatibility
+5. **Atomic Event Trail**: Reverted calls do not leave partial analytics events for indexers to misread
 
 ## Performance Impact
 

--- a/program-escrow/src/lib.rs
+++ b/program-escrow/src/lib.rs
@@ -1757,20 +1757,6 @@ impl ProgramEscrowContract {
             let recipient = recipients.get(i).unwrap();
             let amount = amounts.get(i).unwrap();
 
-            // Check and emit large payout event
-            if amount >= threshold {
-                env.events().publish(
-                    (LARGE_PAYOUT,),
-                    LargePayoutEvent {
-                        version: EVENT_VERSION_V2,
-                        program_id: program_id.clone(),
-                        recipient: recipient.clone(),
-                        amount,
-                        threshold,
-                    },
-                );
-            }
-
             // Transfer funds from contract to recipient
             token_client.transfer(&contract_address, &recipient, &amount);
 
@@ -1798,6 +1784,24 @@ impl ProgramEscrowContract {
         // Store updated data
         env.storage().persistent().set(&PROGRAM_DATA, &program_data);
         Self::bump_persistent_symbol_ttl(&env, &PROGRAM_DATA);
+
+        // Emit large payout analytics only after every transfer and state update succeeds.
+        for i in 0..batch_len {
+            let recipient = recipients.get(i).unwrap();
+            let amount = amounts.get(i).unwrap();
+            if amount >= threshold {
+                env.events().publish(
+                    (LARGE_PAYOUT,),
+                    LargePayoutEvent {
+                        version: EVENT_VERSION_V2,
+                        program_id: program_id.clone(),
+                        recipient,
+                        amount,
+                        threshold,
+                    },
+                );
+            }
+        }
 
         // Emit BatchPayout event
         env.events().publish(
@@ -1920,9 +1924,6 @@ impl ProgramEscrowContract {
             panic!("Insufficient balance");
         }
 
-        // Check and emit large payout event
-        Self::check_and_emit_large_payout(&env, &program_data, &recipient, amount);
-
         // Transfer funds from contract to recipient
         let contract_address = env.current_contract_address();
         let token_client = token::Client::new(&env, &program_data.token_address);
@@ -1950,6 +1951,9 @@ impl ProgramEscrowContract {
         // Store updated data
         env.storage().persistent().set(&PROGRAM_DATA, &updated_data);
         Self::bump_persistent_symbol_ttl(&env, &PROGRAM_DATA);
+
+        // Emit large payout analytics only after transfer and state update succeed.
+        Self::check_and_emit_large_payout(&env, &updated_data, &recipient, amount);
 
         // Emit Payout event
         env.events().publish(

--- a/program-escrow/src/test_analytics_events.rs
+++ b/program-escrow/src/test_analytics_events.rs
@@ -54,6 +54,58 @@ fn find_event_by_topic(env: &Env, topic: Symbol) -> Option<(Vec<Val>, Val)> {
     None
 }
 
+fn event_index_by_topic_since(env: &Env, start: u32, topic: Symbol) -> Option<u32> {
+    let events = env.events().all();
+    for i in start..events.len() {
+        let event = events.get(i).unwrap();
+        let topics = event.1;
+        if topics.len() > 0 {
+            let first_topic = topics.get(0).unwrap();
+            if let Ok(sym) = Symbol::try_from_val(env, &first_topic) {
+                if sym == topic {
+                    return Some(i);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn event_data_by_topic_since(env: &Env, start: u32, topic: Symbol) -> Option<Val> {
+    let events = env.events().all();
+    for i in start..events.len() {
+        let event = events.get(i).unwrap();
+        let topics = event.1;
+        if topics.len() > 0 {
+            let first_topic = topics.get(0).unwrap();
+            if let Ok(sym) = Symbol::try_from_val(env, &first_topic) {
+                if sym == topic {
+                    return Some(event.2);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn count_events_by_topic_since(env: &Env, start: u32, topic: Symbol) -> u32 {
+    let events = env.events().all();
+    let mut count = 0u32;
+    for i in start..events.len() {
+        let event = events.get(i).unwrap();
+        let topics = event.1;
+        if topics.len() > 0 {
+            let first_topic = topics.get(0).unwrap();
+            if let Ok(sym) = Symbol::try_from_val(env, &first_topic) {
+                if sym == topic {
+                    count += 1;
+                }
+            }
+        }
+    }
+    count
+}
+
 fn assert_event_has_version(env: &Env, data: &Val) {
     let data_map: Map<Symbol, Val> =
         Map::try_from_val(env, data).unwrap_or_else(|_| panic!("event payload should be a map"));
@@ -226,6 +278,101 @@ fn test_large_payout_event_in_batch() {
     assert_eq!(
         large_payout_count, 1,
         "Exactly one LargePayout event should be emitted"
+    );
+}
+
+#[test]
+fn test_large_single_payout_event_ordering_is_stable() {
+    let env = Env::default();
+    let (client, _admin, _token, _tokenadmin) = setup_program(&env, 100_000);
+
+    let recipient = Address::generate(&env);
+    let event_start = env.events().all().len();
+
+    let updated = client.single_payout(&recipient, &15_000);
+    assert_eq!(updated.remaining_balance, 85_000);
+    assert_eq!(client.get_remaining_balance(), 85_000);
+
+    let large_idx = event_index_by_topic_since(&env, event_start, symbol_short!("LrgPay"))
+        .expect("large payout alert should be emitted");
+    let payout_idx = event_index_by_topic_since(&env, event_start, symbol_short!("Payout"))
+        .expect("payout event should be emitted");
+    let aggregate_idx = event_index_by_topic_since(&env, event_start, symbol_short!("AggStats"))
+        .expect("aggregate stats event should be emitted");
+
+    assert!(
+        large_idx < payout_idx,
+        "LargePayout alert should precede the finalized Payout event"
+    );
+    assert!(
+        payout_idx < aggregate_idx,
+        "AggregateStats should be emitted after the finalized Payout event"
+    );
+
+    let payout_data =
+        event_data_by_topic_since(&env, event_start, symbol_short!("Payout")).unwrap();
+    let payout_map: Map<Symbol, Val> = Map::try_from_val(&env, &payout_data).unwrap();
+    let payout_remaining_val = payout_map
+        .get(Symbol::new(&env, "remaining_balance"))
+        .unwrap();
+    let payout_remaining =
+        <i128 as TryFromVal<Env, Val>>::try_from_val(&env, &payout_remaining_val).unwrap();
+    assert_eq!(
+        payout_remaining, 85_000,
+        "Payout event should describe the post-state-update balance"
+    );
+
+    let aggregate_data =
+        event_data_by_topic_since(&env, event_start, symbol_short!("AggStats")).unwrap();
+    let aggregate_map: Map<Symbol, Val> = Map::try_from_val(&env, &aggregate_data).unwrap();
+    let aggregate_remaining_val = aggregate_map
+        .get(Symbol::new(&env, "remaining_balance"))
+        .unwrap();
+    let aggregate_remaining =
+        <i128 as TryFromVal<Env, Val>>::try_from_val(&env, &aggregate_remaining_val).unwrap();
+    let aggregate_paid_val = aggregate_map.get(Symbol::new(&env, "total_paid_out")).unwrap();
+    let aggregate_paid =
+        <i128 as TryFromVal<Env, Val>>::try_from_val(&env, &aggregate_paid_val).unwrap();
+
+    assert_eq!(aggregate_remaining, 85_000);
+    assert_eq!(aggregate_paid, 15_000);
+}
+
+#[test]
+fn test_reverted_large_single_payout_emits_no_partial_events() {
+    let env = Env::default();
+    let (client, _admin, token_client, _tokenadmin) = setup_program(&env, 100_000);
+
+    let recipient = Address::generate(&env);
+    let drain = Address::generate(&env);
+
+    token_client.transfer(&client.address, &drain, &100_000);
+    assert_eq!(token_client.balance(&client.address), 0);
+    assert_eq!(client.get_remaining_balance(), 100_000);
+
+    let event_start = env.events().all().len();
+    let result = client.try_single_payout(&recipient, &15_000);
+    assert!(
+        result.is_err(),
+        "payout should revert before any analytics events are emitted"
+    );
+
+    assert_eq!(client.get_remaining_balance(), 100_000);
+    assert_eq!(token_client.balance(&recipient), 0);
+    assert_eq!(
+        count_events_by_topic_since(&env, event_start, symbol_short!("LrgPay")),
+        0,
+        "reverted operation must not persist a LargePayout event"
+    );
+    assert_eq!(
+        count_events_by_topic_since(&env, event_start, symbol_short!("Payout")),
+        0,
+        "reverted operation must not persist a finalized Payout event"
+    );
+    assert_eq!(
+        count_events_by_topic_since(&env, event_start, symbol_short!("AggStats")),
+        0,
+        "reverted operation must not persist aggregate analytics"
     );
 }
 


### PR DESCRIPTION
## Summary

Closes #231 

- Adds program escrow analytics event ordering coverage for a multi-event large payout operation.
- Ensures `LrgPay`, `Payout`, and `AggStats` are emitted in a stable, documented order after payout state is finalized.
- Adds rollback coverage proving failed payout calls leave no partial analytics event trail.
- Fixes payout paths so `LrgPay` is emitted only after transfers and state updates succeed.
- Repairs the root lockfile to avoid incompatible Soroban test dependency resolution.

## Tests

- `cargo test -p program-escrow test_analytics_events`

Result: `14 passed; 0 failed; 428 filtered out`