### PR TITLE
test: add coverage for cancel_recipient_dispute and cancel_schedule_dispute

### DIFF
--- a/program-escrow/src/test_dispute_resolution.rs
+++ b/program-escrow/src/test_dispute_resolution.rs
@@ -591,3 +591,127 @@ fn test_resolve_schedule_dispute_scope_isolation() {
     assert!(!client.is_schedule_disputed(&sched1.schedule_id));
     assert!(client.is_schedule_disputed(&sched2.schedule_id));
 }
+
+// ─── Test 20: cancel recipient dispute re-enables payout ─────────────────────
+
+/// Opening → cancelling a recipient-scoped dispute must re-enable that
+/// recipient's single payouts and schedule releases.
+#[test]
+fn test_cancel_recipient_dispute_allows_payout() {
+    let env = Env::default();
+    let (client, _admin, _cid) = setup(&env, 100_000);
+
+    let disputed = Address::generate(&env);
+    let reason = String::from_str(&env, "Recipient payout disputed");
+    client.open_recipient_dispute(&disputed, &reason);
+    assert!(client.is_recipient_disputed(&disputed));
+
+    // Payout to disputed recipient must be blocked
+    let blocked = client.try_single_payout(&disputed, &10_000);
+    assert!(blocked.is_err());
+
+    // Cancel the recipient dispute
+    client.cancel_recipient_dispute(&disputed);
+    assert!(!client.is_recipient_disputed(&disputed));
+
+    // Payout to the previously-disputed recipient must now succeed
+    let data = client.single_payout(&disputed, &10_000);
+    assert_eq!(data.remaining_balance, 90_000);
+    assert_eq!(data.payout_history.len(), 1);
+}
+
+// ─── Test 21: cancel schedule dispute re-enables release ─────────────────────
+
+/// Opening → cancelling a schedule-scoped dispute must re-enable release
+/// for that schedule.
+#[test]
+fn test_cancel_schedule_dispute_allows_release() {
+    let env = Env::default();
+    env.ledger().set_timestamp(0);
+    let (client, _admin, _cid) = setup(&env, 100_000);
+
+    let recipient = Address::generate(&env);
+    let schedule = client.create_program_release_schedule(&50_000, &100, &recipient);
+
+    let reason = String::from_str(&env, "Schedule milestone challenged");
+    client.open_schedule_dispute(&schedule.schedule_id, &reason);
+    assert!(client.is_schedule_disputed(&schedule.schedule_id));
+
+    // Advance past the release time — release must be blocked by dispute
+    env.ledger().set_timestamp(150);
+    let released_count = client.trigger_program_releases();
+    assert_eq!(released_count, 0);
+
+    let blocked = client.try_release_prog_schedule_automatic(&schedule.schedule_id);
+    assert!(blocked.is_err());
+
+    // Cancel the schedule dispute
+    client.cancel_schedule_dispute(&schedule.schedule_id);
+    assert!(!client.is_schedule_disputed(&schedule.schedule_id));
+
+    // Release must now succeed
+    client.release_prog_schedule_automatic(&schedule.schedule_id);
+
+    let data = client.get_program_info();
+    assert_eq!(data.remaining_balance, 50_000);
+}
+
+// ─── Test 22: cancel recipient dispute panics when none open ─────────────────
+
+#[test]
+#[should_panic(expected = "No recipient dispute to cancel")]
+fn test_cancel_recipient_when_no_dispute_panics() {
+    let env = Env::default();
+    let (client, _admin, _cid) = setup(&env, 10_000);
+    let recipient = Address::generate(&env);
+    client.cancel_recipient_dispute(&recipient);
+}
+
+// ─── Test 23: cancel schedule dispute panics when none open ──────────────────
+
+#[test]
+#[should_panic(expected = "No schedule dispute to cancel")]
+fn test_cancel_schedule_when_no_dispute_panics() {
+    let env = Env::default();
+    let (client, _admin, _cid) = setup(&env, 10_000);
+    client.cancel_schedule_dispute(&1);
+}
+
+// ─── Test 24: cancel recipient dispute panics when dispute is resolved ───────
+
+/// Cancelling a recipient dispute that was already resolved (not Open)
+/// must panic because `cancel_dispute_at` requires status == Open.
+#[test]
+#[should_panic(expected = "No open dispute to cancel")]
+fn test_cancel_recipient_dispute_already_resolved_panics() {
+    let env = Env::default();
+    let (client, _admin, _cid) = setup(&env, 10_000);
+
+    let recipient = Address::generate(&env);
+    let reason = String::from_str(&env, "Test dispute");
+    client.open_recipient_dispute(&recipient, &reason);
+    client.resolve_recipient_dispute(&recipient);
+
+    // Trying to cancel a resolved dispute must panic
+    client.cancel_recipient_dispute(&recipient);
+}
+
+// ─── Test 25: cancel schedule dispute panics when dispute is resolved ────────
+
+/// Cancelling a schedule dispute that was already resolved (not Open)
+/// must panic because `cancel_dispute_at` requires status == Open.
+#[test]
+#[should_panic(expected = "No open dispute to cancel")]
+fn test_cancel_schedule_dispute_already_resolved_panics() {
+    let env = Env::default();
+    let (client, _admin, _cid) = setup(&env, 10_000);
+
+    let recipient = Address::generate(&env);
+    let schedule = client.create_program_release_schedule(&50_000, &100, &recipient);
+    let reason = String::from_str(&env, "Test dispute");
+    client.open_schedule_dispute(&schedule.schedule_id, &reason);
+    client.resolve_schedule_dispute(&schedule.schedule_id);
+
+    // Trying to cancel a resolved dispute must panic
+    client.cancel_schedule_dispute(&schedule.schedule_id);
+}


### PR DESCRIPTION
## Description

Adds 6 missing tests for  and  in `program-escrow/src/test_dispute_resolution.rs`.

These two functions share the same `cancel_dispute_at` helper as the Global-scope `cancel_dispute` (which is already tested), but neither their happy paths nor their panic paths had any test coverage.

## Changes

| # | Test | Type | What it verifies |
|---|------|------|------------------|
| 20 | `test_cancel_recipient_dispute_allows_payout` | Happy path | Cancelling an open recipient-scoped dispute re-enables single payouts for that recipient |
| 21 | `test_cancel_schedule_dispute_allows_release` | Happy path | Cancelling an open schedule-scoped dispute re-enables `release_prog_schedule_automatic` for that schedule |
| 22 | `test_cancel_recipient_when_no_dispute_panics` | Panic | Panics with `"No recipient dispute to cancel"` when no recipient dispute exists |
| 23 | `test_cancel_schedule_when_no_dispute_panics` | Panic | Panics with `"No schedule dispute to cancel"` when no schedule dispute exists |
| 24 | `test_cancel_recipient_dispute_already_resolved_panics` | Panic | Panics with `"No open dispute to cancel"` when the dispute exists but is Resolved (not Open) |
| 25 | `test_cancel_schedule_dispute_already_resolved_panics` | Panic | Panics with `"No open dispute to cancel"` when the dispute exists but is Resolved (not Open) |

## Acceptance criteria

- [x] Cancelling an open recipient-scoped dispute re-enables that recipient's payouts/releases
- [x] Cancelling an open schedule-scoped dispute re-enables that schedule's releases
- [x] Calling either cancel function with no open dispute at that scope panics with the documented message
- [x] Calling either cancel function on an already-resolved dispute panics (status must be Open)

## Related

Closes #321