### PR TITLE
fix: reject large-payout threshold values above 10000 bps

### DIFF
--- a/program-escrow/src/lib.rs
+++ b/program-escrow/src/lib.rs
@@ -543,6 +543,8 @@ pub enum BatchError {
 pub enum Error {
     /// Governance contract version is below the minimum required for admin operations.
     GovernanceVersionTooLow = 4,
+    /// large-payout threshold_bps exceeds 10_000 (100%).
+    InvalidThresholdBps = 5,
 }
 
 #[contracttype]
@@ -2866,14 +2868,19 @@ impl ProgramEscrowContract {
 
     /// Update the large-payout alert threshold (admin only).
     /// `threshold_bps` is expressed in basis points (e.g. 1000 = 10%, 2500 = 25%).
-    pub fn set_large_payout_threshold(env: Env, threshold_bps: u32) {
+    /// Returns `Err(Error::InvalidThresholdBps)` if `threshold_bps` exceeds 10_000 (100%).
+    pub fn set_large_payout_threshold(env: Env, threshold_bps: u32) -> Result<(), Error> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&DataKey::Admin)
             .expect("Admin not set");
         admin.require_auth();
+        if threshold_bps > 10_000 {
+            return Err(Error::InvalidThresholdBps);
+        }
         monitoring::set_large_payout_threshold_bps(&env, threshold_bps);
+        Ok(())
     }
 }
 

--- a/program-escrow/src/test_monitoring.rs
+++ b/program-escrow/src/test_monitoring.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::{ProgramEscrowContract, ProgramEscrowContractClient};
+use crate::{Error, ProgramEscrowContract, ProgramEscrowContractClient};
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Events, Ledger},
@@ -96,6 +96,52 @@ fn test_admin_can_update_large_payout_threshold() {
     assert_eq!(client.get_large_payout_threshold(), 2000);
 }
 
+#[test]
+fn test_set_large_payout_threshold_accepts_boundary_10000() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+    client.try_set_large_payout_threshold(&10_000).unwrap().unwrap();
+    assert_eq!(client.get_large_payout_threshold(), 10_000);
+}
+#[test]
+fn test_set_large_payout_threshold_accepts_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+    client.try_set_large_payout_threshold(&0).unwrap().unwrap();
+    assert_eq!(client.get_large_payout_threshold(), 0);
+}
+#[test]
+fn test_set_large_payout_threshold_rejects_above_10000() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+    let result = client.try_set_large_payout_threshold(&10_001);
+    assert_eq!(result, Err(Ok(Error::InvalidThresholdBps)));
+    assert_eq!(client.get_large_payout_threshold(), 1000);
+}
+#[test]
+fn test_set_large_payout_threshold_rejects_u32_max() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+    let result = client.try_set_large_payout_threshold(&u32::MAX);
+    assert_eq!(result, Err(Ok(Error::InvalidThresholdBps)));
+    assert_eq!(client.get_large_payout_threshold(), 1000);
+}
 #[test]
 #[should_panic]
 fn test_non_admin_cannot_update_large_payout_threshold() {


### PR DESCRIPTION
## Summary
`set_large_payout_threshold` performed no bounds validation, allowing an admin
to set `threshold_bps` above 10_000 (100%), which silently makes the
large-payout alert unreachable for any realistic payout.

## Changes
- Added `Error::InvalidThresholdBps` variant (code 5)
- `set_large_payout_threshold` now returns `Result<(), Error>` and rejects
  any `threshold_bps > 10_000`
- Updated doc comment to document the new error behavior

## Tests
Added 4 tests in `test_monitoring.rs`:
- `test_set_large_payout_threshold_accepts_boundary_10000` — 10_000 accepted
- `test_set_large_payout_threshold_accepts_zero` — 0 accepted
- `test_set_large_payout_threshold_rejects_above_10000` — 10_001 rejected
- `test_set_large_payout_threshold_rejects_u32_max` — u32::MAX rejected

Test output:
\`\`\`
running 8 tests
test test_monitoring::test_default_large_payout_threshold_is_ten_percent ... ok
test test_monitoring::test_admin_can_update_large_payout_threshold ... ok
test test_monitoring::test_set_large_payout_threshold_accepts_zero ... ok
test test_monitoring::test_set_large_payout_threshold_accepts_boundary_10000 ... ok
test test_monitoring::test_set_large_payout_threshold_rejects_u32_max ... ok
test test_monitoring::test_set_large_payout_threshold_rejects_above_10000 ... ok
test test_monitoring::test_non_admin_cannot_update_large_payout_threshold - should panic ... ok
test test_monitoring::test_large_payout_threshold_respects_custom_bps ... ok
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 444 filtered out
\`\`\`

Note: full package `cargo test -p program-escrow` has 1 pre-existing failing
test (`reentrancy_tests::test_token_callback_reentrancy_batch_payout`),
confirmed unrelated — it fails identically on `main` without these changes.

Fixes #391