### PR TITLE
test: add direct unit tests for analytics.rs init/update helper functions

### DIFF
--- a/bounty_escrow/contracts/escrow/src/test_bounty_analytics.rs
+++ b/bounty_escrow/contracts/escrow/src/test_bounty_analytics.rs
@@ -150,4 +150,175 @@ fn test_state_lifecycle_cross_period() {
         assert_eq!(analytics.total_amount_refunded, 800);
         assert_eq!(analytics.remaining_amount, 0);
     });
+
+}
+
+// ============================================================
+// Direct unit tests for analytics helper functions
+// ============================================================
+
+/// Test init_bounty_analytics directly with full field assertions
+#[test]
+fn test_direct_init_bounty_analytics_full_assertions() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, DummyContract);
+
+    env.as_contract(&contract_id, || {
+        let bounty_id = 10u64;
+        let amount = 5000i128;
+        let timestamp = 12345678u64;
+
+        // Call the function directly
+        init_bounty_analytics(&env, bounty_id, amount, timestamp);
+
+        // Retrieve and assert every field
+        let analytics = get_bounty_analytics(&env, bounty_id).expect("should exist");
+        assert_eq!(analytics.total_amount_locked, amount, "total_amount_locked mismatch");
+        assert_eq!(analytics.total_amount_released, 0, "total_amount_released should be 0");
+        assert_eq!(analytics.total_amount_refunded, 0, "total_amount_refunded should be 0");
+        assert_eq!(analytics.remaining_amount, amount, "remaining_amount should equal locked amount");
+        assert_eq!(analytics.created_at, timestamp, "created_at mismatch");
+        assert_eq!(analytics.last_updated, timestamp, "last_updated mismatch");
+        assert_eq!(analytics.partial_releases_count, 0, "partial_releases_count should be 0");
+        assert_eq!(analytics.partial_refunds_count, 0, "partial_refunds_count should be 0");
+    });
+}
+
+/// Test multiple sequential releases update counters and remaining_amount correctly
+#[test]
+fn test_direct_sequential_releases() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, DummyContract);
+
+    env.as_contract(&contract_id, || {
+        let bounty_id = 11u64;
+        let amount = 1000i128;
+
+        init_bounty_analytics(&env, bounty_id, amount, 100);
+
+        // First partial release
+        update_analytics_on_release(&env, bounty_id, 200, 200);
+        let a = get_bounty_analytics(&env, bounty_id).unwrap();
+        assert_eq!(a.total_amount_released, 200);
+        assert_eq!(a.remaining_amount, 800);
+        assert_eq!(a.partial_releases_count, 1);
+
+        // Second partial release
+        update_analytics_on_release(&env, bounty_id, 300, 300);
+        let a = get_bounty_analytics(&env, bounty_id).unwrap();
+        assert_eq!(a.total_amount_released, 500);
+        assert_eq!(a.remaining_amount, 500);
+        assert_eq!(a.partial_releases_count, 2);
+
+        // Third partial release
+        update_analytics_on_release(&env, bounty_id, 100, 400);
+        let a = get_bounty_analytics(&env, bounty_id).unwrap();
+        assert_eq!(a.total_amount_released, 600);
+        assert_eq!(a.remaining_amount, 400);
+        assert_eq!(a.partial_releases_count, 3);
+
+        // Refund count should remain untouched
+        assert_eq!(a.partial_refunds_count, 0);
+        assert_eq!(a.total_amount_refunded, 0);
+    });
+}
+
+/// Test multiple sequential refunds update counters and remaining_amount correctly
+#[test]
+fn test_direct_sequential_refunds() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, DummyContract);
+
+    env.as_contract(&contract_id, || {
+        let bounty_id = 12u64;
+        let amount = 1000i128;
+
+        init_bounty_analytics(&env, bounty_id, amount, 100);
+
+        // First partial refund
+        update_analytics_on_refund(&env, bounty_id, 150, 200);
+        let a = get_bounty_analytics(&env, bounty_id).unwrap();
+        assert_eq!(a.total_amount_refunded, 150);
+        assert_eq!(a.remaining_amount, 850);
+        assert_eq!(a.partial_refunds_count, 1);
+
+        // Second partial refund
+        update_analytics_on_refund(&env, bounty_id, 250, 300);
+        let a = get_bounty_analytics(&env, bounty_id).unwrap();
+        assert_eq!(a.total_amount_refunded, 400);
+        assert_eq!(a.remaining_amount, 600);
+        assert_eq!(a.partial_refunds_count, 2);
+
+        // Release count should remain untouched
+        assert_eq!(a.partial_releases_count, 0);
+        assert_eq!(a.total_amount_released, 0);
+    });
+}
+
+/// Test saturating_sub boundary — release/refund exceeding remaining can go negative
+/// because saturating_sub on i128 prevents integer overflow (not negative balances).
+/// remaining_amount going negative is a known quirk worth surfacing.
+#[test]
+fn test_direct_saturating_sub_boundary() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, DummyContract);
+
+    env.as_contract(&contract_id, || {
+        let bounty_id = 13u64;
+        let amount = 100i128;
+
+        // Release more than remaining — saturating_sub prevents overflow but NOT underflow below 0
+        init_bounty_analytics(&env, bounty_id, amount, 100);
+        update_analytics_on_release(&env, bounty_id, 200, 200);
+        let a = get_bounty_analytics(&env, bounty_id).unwrap();
+        // saturating_sub(100, 200) on i128 = -100 — does NOT floor at zero
+        assert_eq!(a.remaining_amount, -100, "saturating_sub on i128 allows negative values");
+        assert_eq!(a.total_amount_released, 200, "total_released accumulates via raw +=");
+        assert_eq!(a.partial_releases_count, 1);
+
+        // Refund on a different bounty — refund more than remaining
+        let bounty_id2 = 14u64;
+        init_bounty_analytics(&env, bounty_id2, 50, 100);
+        update_analytics_on_refund(&env, bounty_id2, 500, 200);
+        let a2 = get_bounty_analytics(&env, bounty_id2).unwrap();
+        assert_eq!(a2.remaining_amount, -450, "refund excess goes negative via saturating_sub");
+        assert_eq!(a2.total_amount_refunded, 500, "total_refunded accumulates via raw +=");
+        assert_eq!(a2.partial_refunds_count, 1);
+    });
+}
+
+/// Test that calling update_analytics_on_release on uninitialized bounty is a silent no-op
+#[test]
+fn test_direct_release_on_uninitialized_bounty() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, DummyContract);
+
+    env.as_contract(&contract_id, || {
+        let bounty_id = 9999u64;
+
+        // This should not panic — just silent no-op
+        update_analytics_on_release(&env, bounty_id, 100, 200);
+
+        // Verify no record was created
+        let result = get_bounty_analytics(&env, bounty_id);
+        assert!(result.is_none(), "no analytics record should exist for uninitialized bounty");
+    });
+}
+
+/// Test that calling update_analytics_on_refund on uninitialized bounty is a silent no-op
+#[test]
+fn test_direct_refund_on_uninitialized_bounty() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, DummyContract);
+
+    env.as_contract(&contract_id, || {
+        let bounty_id = 9998u64;
+
+        // This should not panic — just silent no-op
+        update_analytics_on_refund(&env, bounty_id, 100, 200);
+
+        // Verify no record was created
+        let result = get_bounty_analytics(&env, bounty_id);
+        assert!(result.is_none(), "no analytics record should exist for uninitialized bounty");
+    });
 }

--- a/bounty_escrow/contracts/escrow/test_snapshots/test_bounty_analytics/test_direct_init_bounty_analytics_full_assertions.1.json
+++ b/bounty_escrow/contracts/escrow/test_snapshots/test_bounty_analytics/test_direct_init_bounty_analytics_full_assertions.1.json
@@ -1,0 +1,197 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "BountyMetrics"
+                },
+                {
+                  "u64": 10
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BountyMetrics"
+                    },
+                    {
+                      "u64": 10
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": 12345678
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "last_updated"
+                      },
+                      "val": {
+                        "u64": 12345678
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "partial_refunds_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "partial_releases_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "remaining_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 5000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_locked"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 5000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_refunded"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_released"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/bounty_escrow/contracts/escrow/test_snapshots/test_bounty_analytics/test_direct_refund_on_uninitialized_bounty.1.json
+++ b/bounty_escrow/contracts/escrow/test_snapshots/test_bounty_analytics/test_direct_refund_on_uninitialized_bounty.1.json
@@ -1,0 +1,75 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/bounty_escrow/contracts/escrow/test_snapshots/test_bounty_analytics/test_direct_release_on_uninitialized_bounty.1.json
+++ b/bounty_escrow/contracts/escrow/test_snapshots/test_bounty_analytics/test_direct_release_on_uninitialized_bounty.1.json
@@ -1,0 +1,75 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/bounty_escrow/contracts/escrow/test_snapshots/test_bounty_analytics/test_direct_saturating_sub_boundary.1.json
+++ b/bounty_escrow/contracts/escrow/test_snapshots/test_bounty_analytics/test_direct_saturating_sub_boundary.1.json
@@ -1,0 +1,319 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "BountyMetrics"
+                },
+                {
+                  "u64": 13
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BountyMetrics"
+                    },
+                    {
+                      "u64": 13
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": 100
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "last_updated"
+                      },
+                      "val": {
+                        "u64": 200
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "partial_refunds_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "partial_releases_count"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "remaining_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551516
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_locked"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 100
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_refunded"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_released"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 200
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "BountyMetrics"
+                },
+                {
+                  "u64": 14
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BountyMetrics"
+                    },
+                    {
+                      "u64": 14
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": 100
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "last_updated"
+                      },
+                      "val": {
+                        "u64": 200
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "partial_refunds_count"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "partial_releases_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "remaining_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551166
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_locked"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 50
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_refunded"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 500
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_released"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/bounty_escrow/contracts/escrow/test_snapshots/test_bounty_analytics/test_direct_sequential_refunds.1.json
+++ b/bounty_escrow/contracts/escrow/test_snapshots/test_bounty_analytics/test_direct_sequential_refunds.1.json
@@ -1,0 +1,197 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "BountyMetrics"
+                },
+                {
+                  "u64": 12
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BountyMetrics"
+                    },
+                    {
+                      "u64": 12
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": 100
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "last_updated"
+                      },
+                      "val": {
+                        "u64": 300
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "partial_refunds_count"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "partial_releases_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "remaining_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 600
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_locked"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_refunded"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 400
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_released"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/bounty_escrow/contracts/escrow/test_snapshots/test_bounty_analytics/test_direct_sequential_releases.1.json
+++ b/bounty_escrow/contracts/escrow/test_snapshots/test_bounty_analytics/test_direct_sequential_releases.1.json
@@ -1,0 +1,197 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "BountyMetrics"
+                },
+                {
+                  "u64": 11
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "BountyMetrics"
+                    },
+                    {
+                      "u64": 11
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": 100
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "last_updated"
+                      },
+                      "val": {
+                        "u64": 400
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "partial_refunds_count"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "partial_releases_count"
+                      },
+                      "val": {
+                        "u32": 3
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "remaining_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 400
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_locked"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_refunded"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount_released"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 600
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
Closes #397

## What

Adds 6 direct unit tests to `test_bounty_analytics.rs` for the three analytics helper functions that lacked direct test coverage.

## Tests added

| test | covers |
|------|--------|
| `test_direct_init_bounty_analytics_full_assertions` | all 8 fields of `BountyAnalytics` after init |
| `test_direct_sequential_releases` | 3 partial releases, counter tracking, no cross-contamination |
| `test_direct_sequential_refunds` | 2 partial refunds, counter tracking, no cross-contamination |
| `test_direct_saturating_sub_boundary` | release/refund amount exceeding remaining — pins actual behaviour |
| `test_direct_release_on_uninitialized_bounty` | silent no-op when calling release on nonexistent bounty |
| `test_direct_refund_on_uninitialized_bounty` | silent no-op when calling refund on nonexistent bounty |

## Test output

```
running 6 tests
test test_direct_refund_on_uninitialized_bounty ... ok
test test_direct_release_on_uninitialized_bounty ... ok
test test_direct_init_bounty_analytics_full_assertions ... ok
test test_direct_sequential_refunds ... ok
test test_direct_saturating_sub_boundary ... ok
test test_direct_sequential_releases ... ok

test result: ok. 6 passed; 0 failed (102 total passed)
```

## ⚠ Note on saturating_sub

`remaining_amount` uses `saturating_sub` which on i128 flushes at `i128::MIN`, not at zero. So `100.saturating_sub(200) = -100`. The test documents this accurately.

In practice this never triggers because contract-level validation prevents releasing/refunding more than locked. The test exercises the helper in isolation — which is the correct unit-test boundary. No production impact.

If you want `remaining_amount` pinned at floor zero regardless, add `.max(0)` to both helpers. Happy to adjust if you prefer that approach.