### PR TITLE
docs(bounty-escrow): document error_recovery.rs retry semantics

### DIFF
--- a/bounty_escrow/contracts/escrow/src/error_recovery.rs
+++ b/bounty_escrow/contracts/escrow/src/error_recovery.rs
@@ -20,6 +20,31 @@
 // ## Storage Keys
 // All circuit breaker state is stored in persistent storage keyed by
 // `CircuitBreakerKey::*`.
+//
+// ## Retry Semantics
+//
+// This module classifies every error code as either **recoverable** or
+// **terminal**:
+//
+// - **Recoverable** (`ERR_TRANSFER_FAILED`, `ERR_INSUFFICIENT_BALANCE`): the
+//   underlying operation may succeed if attempted again — a transient token
+//   transfer failure, for example. Callers following the retry pattern
+//   should retry these, subject to the bound below.
+// - **Terminal** (`ERR_CIRCUIT_OPEN`): retrying will not help. The circuit
+//   breaker has already tripped from accumulated failures across *all*
+//   callers and is rejecting every attempt until an admin resets it (see
+//   `docs/bounty_escrow/CIRCUIT_BREAKER.md`).
+//
+// `execute_with_retry` bounds the number of attempts via
+// `RetryConfig::max_attempts` (default 3). **Current limitation**: when the
+// loop exhausts `max_attempts` without success, `RetryResult::final_error`
+// is set to whatever the *last attempt's* underlying error code was (e.g.
+// `ERR_TRANSFER_FAILED`) — the same recoverable-looking code a caller would
+// see on attempt 1. There is no distinct "attempts exhausted" signal today;
+// a caller must compare `RetryResult::attempts` against the `max_attempts`
+// it passed in to detect exhaustion itself. This is the gap tracked by the
+// companion issue that adds an explicit `ERR_RETRIES_EXHAUSTED` terminal
+// code.
 
 use soroban_sdk::{contracttype, symbol_short, Address, Env, String};
 
@@ -111,11 +136,14 @@ pub struct CircuitBreakerStatus {
 // Error codes (u32 — no_std compatible)
 // ─────────────────────────────────────────────────────────
 
-/// Circuit is open; operation rejected without attempting.
+/// **Terminal.** Circuit is open; operation rejected without attempting.
+/// Do not retry until the registered circuit breaker admin resets it.
 pub const ERR_CIRCUIT_OPEN: u32 = 1001;
-/// Token transfer failed (transient).
+/// **Recoverable.** Token transfer failed (transient) — safe to retry, up
+/// to the caller's own retry budget.
 pub const ERR_TRANSFER_FAILED: u32 = 1002;
-/// Insufficient contract balance.
+/// **Recoverable.** Insufficient contract balance at the time of the
+/// attempt — may resolve if funds arrive before a later retry.
 pub const ERR_INSUFFICIENT_BALANCE: u32 = 1003;
 /// Operation succeeded — for logging.
 pub const ERR_NONE: u32 = 0;
@@ -392,7 +420,7 @@ pub fn get_error_log(env: &Env) -> soroban_sdk::Vec<ErrorEntry> {
 // Retry logic
 // ─────────────────────────────────────────────────────────
 
-/// Retry configuration.
+/// Bounds how many attempts `execute_with_retry` makes before giving up.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RetryConfig {
@@ -406,7 +434,13 @@ impl RetryConfig {
     }
 }
 
-/// Result of a retry operation.
+/// Outcome of an `execute_with_retry` call.
+///
+/// When `succeeded` is `false`, `attempts` reports how many were actually
+/// made (bounded by the `RetryConfig::max_attempts` passed in), and
+/// `final_error` carries the error code — see the module-level docs above
+/// for why `final_error` does not yet distinguish "exhausted the attempt
+/// budget" from "failed on the most recent attempt".
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RetryResult {
@@ -418,7 +452,13 @@ pub struct RetryResult {
 /// Execute a fallible operation with retry, integrated with the circuit breaker.
 ///
 /// `op` is a closure that returns `Ok(())` on success or `Err(error_code)` on
-/// transient failure. A non-zero error triggers a `record_failure` call.
+/// transient (recoverable) failure. A non-zero error triggers a
+/// `record_failure` call, which counts toward the circuit breaker's
+/// `failure_threshold` in addition to this call's own `max_attempts` bound —
+/// so a caller can still see `ERR_CIRCUIT_OPEN` cut a retry loop short before
+/// `max_attempts` is reached, if enough failures (from this loop or any
+/// other caller) have already tripped the breaker. Each attempt is preceded
+/// by a `check_and_allow` call for exactly this reason.
 ///
 /// Returns a `RetryResult` describing the outcome.
 ///

--- a/docs/bounty_escrow/CIRCUIT_BREAKER.md
+++ b/docs/bounty_escrow/CIRCUIT_BREAKER.md
@@ -171,6 +171,51 @@ The circuit breaker emits events for state changes:
 - `cb_close` - When circuit closes
 - `cb_reject` - When operation is rejected due to open circuit
 
+## Retry Logic
+
+`error_recovery.rs` also defines `execute_with_retry`, a bounded-retry helper
+that integrates with the circuit breaker above. It is not currently wired
+into any contract entrypoint — production code (`lib.rs`) calls
+`check_and_allow` / `record_success` / `record_failure` directly — so today
+it's primarily useful for test scenarios, simulation, and as a reference
+implementation for integrators building their own retry loop against those
+primitives (e.g. the backend's `internal/soroban` client).
+
+### Error classification
+
+| Error | Classification | Meaning |
+| --- | --- | --- |
+| `ERR_TRANSFER_FAILED` (1002) | Recoverable | Transient token transfer failure; safe to retry. |
+| `ERR_INSUFFICIENT_BALANCE` (1003) | Recoverable | May resolve once funds arrive; safe to retry. |
+| `ERR_CIRCUIT_OPEN` (1001) | Terminal | The breaker has tripped from accumulated failures (from any caller); stop until an admin resets it. |
+
+### `execute_with_retry`
+
+```rust
+pub fn execute_with_retry<F>(
+    env: &Env,
+    config: &RetryConfig,   // { max_attempts: u32 }, default 3
+    bounty_id: u64,
+    operation: Symbol,
+    op: F,
+) -> RetryResult             // { succeeded: bool, attempts: u32, final_error: u32 }
+where
+    F: FnMut() -> Result<(), u32>;
+```
+
+Before each attempt it calls `check_and_allow`, so a circuit that opens
+mid-loop (from this call's own failures or any other caller's) short-circuits
+the remaining attempts with `ERR_CIRCUIT_OPEN` rather than burning the full
+`max_attempts` budget.
+
+**Current limitation**: when the loop exhausts `max_attempts` without
+success, `RetryResult.final_error` is the *last attempt's* underlying
+recoverable error code (e.g. `ERR_TRANSFER_FAILED`) — indistinguishable from
+a first-attempt failure by error code alone. A caller must compare
+`RetryResult.attempts` against the `max_attempts` it configured to detect
+exhaustion. Adding a distinct terminal `ERR_RETRIES_EXHAUSTED` code so this
+is signalled explicitly is tracked separately.
+
 ## Future Enhancements
 
 Potential improvements could include:

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ Welcome to the Grainlify Stellar Contracts documentation. This index provides a 
 |----------|-------------|
 | [Bounty Escrow README](../bounty_escrow/README.md) | Overview of the bounty escrow contract |
 | [Security](bounty_escrow/SECURITY.md) | Security model, threat analysis, and mitigations |
-| [Circuit Breaker](bounty_escrow/CIRCUIT_BREAKER.md) | Circuit breaker mechanism documentation |
+| [Circuit Breaker](bounty_escrow/CIRCUIT_BREAKER.md) | Circuit breaker mechanism and retry-logic documentation |
 | [Implementation Checklist](bounty_escrow/IMPLEMENTATION_CHECKLIST.md) | Implementation task tracking |
 | [Analytics Documentation](bounty_escrow/ANALYTICS_DOCUMENTATION.md) | Analytics views and query functions |
 | [Analytics Implementation Summary](bounty_escrow/ANALYTICS_IMPLEMENTATION_SUMMARY.md) | Analytics module implementation details |


### PR DESCRIPTION
Closes #167

`error_recovery.rs` implements circuit-breaker + retry logic but never
documented, at the module or function level, which error codes are
recoverable vs terminal, or how `execute_with_retry`'s attempt bound
interacts with the circuit breaker. Integrators (including the
backend's `internal/soroban` client) had to read the implementation to
know what to expect.

- Module-level comment now classifies every error code and states the
  current limitation plainly: `RetryResult.final_error` does not yet
  distinguish "exhausted the attempt budget" from "failed on the most
  recent attempt" (that gap is tracked by a companion issue, #168).
- Each error code constant is annotated recoverable/terminal.
- `RetryConfig`, `RetryResult`, and `execute_with_retry` get doc
  comments describing the classification and the
  check-before-each-attempt interaction with the circuit breaker.
- Added a "Retry Logic" section to
  `docs/bounty_escrow/CIRCUIT_BREAKER.md` (the existing matching doc
  page, already linked from `docs/index.md`) with the classification
  table and the `execute_with_retry` contract.

**No functional change** — verified against the current implementation,
not invented, per the issue's requirement.

## Test plan
- [x] `cargo build -p bounty-escrow` — compiles clean, same pre-existing
      warnings as baseline
- [x] `cargo test -p bounty-escrow -- circuit_breaker retry
      serialization` — 51/51 passing, unmodified
- [x] Confirmed the pre-existing `cargo fmt --check` diffs (e.g.
      `record_failure`'s signature) exist identically on unmodified
      `main` — not introduced by this change, and in scope for #388
      (CI fmt/clippy gates) rather than this docs PR