### PR TITLE
feat(bounty-escrow): add a max-retry cap with a distinct exhausted-retries error

### DIFF
--- a/bounty_escrow/contracts/escrow/src/error_recovery.rs
+++ b/bounty_escrow/contracts/escrow/src/error_recovery.rs
@@ -20,6 +20,31 @@
 // ## Storage Keys
 // All circuit breaker state is stored in persistent storage keyed by
 // `CircuitBreakerKey::*`.
+//
+// ## Retry Semantics
+//
+// This module classifies every error code as either **recoverable** or
+// **terminal**:
+//
+// - **Recoverable** (`ERR_TRANSFER_FAILED`, `ERR_INSUFFICIENT_BALANCE`): the
+//   underlying operation may succeed if attempted again — a transient token
+//   transfer failure, for example. Callers following the retry pattern
+//   should retry these, subject to the bound below.
+// - **Terminal** (`ERR_CIRCUIT_OPEN`): retrying will not help. The circuit
+//   breaker has already tripped from accumulated failures across *all*
+//   callers and is rejecting every attempt until an admin resets it (see
+//   `docs/bounty_escrow/CIRCUIT_BREAKER.md`).
+//
+// `execute_with_retry` bounds the number of attempts via
+// `RetryConfig::max_attempts` (default 3). **Current limitation**: when the
+// loop exhausts `max_attempts` without success, `RetryResult::final_error`
+// is set to whatever the *last attempt's* underlying error code was (e.g.
+// `ERR_TRANSFER_FAILED`) — the same recoverable-looking code a caller would
+// see on attempt 1. There is no distinct "attempts exhausted" signal today;
+// a caller must compare `RetryResult::attempts` against the `max_attempts`
+// it passed in to detect exhaustion itself. This is the gap tracked by the
+// companion issue that adds an explicit `ERR_RETRIES_EXHAUSTED` terminal
+// code.
 
 use soroban_sdk::{contracttype, symbol_short, Address, Env, String};
 
@@ -111,11 +136,14 @@ pub struct CircuitBreakerStatus {
 // Error codes (u32 — no_std compatible)
 // ─────────────────────────────────────────────────────────
 
-/// Circuit is open; operation rejected without attempting.
+/// **Terminal.** Circuit is open; operation rejected without attempting.
+/// Do not retry until the registered circuit breaker admin resets it.
 pub const ERR_CIRCUIT_OPEN: u32 = 1001;
-/// Token transfer failed (transient).
+/// **Recoverable.** Token transfer failed (transient) — safe to retry, up
+/// to the caller's own retry budget.
 pub const ERR_TRANSFER_FAILED: u32 = 1002;
-/// Insufficient contract balance.
+/// **Recoverable.** Insufficient contract balance at the time of the
+/// attempt — may resolve if funds arrive before a later retry.
 pub const ERR_INSUFFICIENT_BALANCE: u32 = 1003;
 /// Operation succeeded — for logging.
 pub const ERR_NONE: u32 = 0;
@@ -392,7 +420,7 @@ pub fn get_error_log(env: &Env) -> soroban_sdk::Vec<ErrorEntry> {
 // Retry logic
 // ─────────────────────────────────────────────────────────
 
-/// Retry configuration.
+/// Bounds how many attempts `execute_with_retry` makes before giving up.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RetryConfig {
@@ -406,7 +434,13 @@ impl RetryConfig {
     }
 }
 
-/// Result of a retry operation.
+/// Outcome of an `execute_with_retry` call.
+///
+/// When `succeeded` is `false`, `attempts` reports how many were actually
+/// made (bounded by the `RetryConfig::max_attempts` passed in), and
+/// `final_error` carries the error code — see the module-level docs above
+/// for why `final_error` does not yet distinguish "exhausted the attempt
+/// budget" from "failed on the most recent attempt".
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RetryResult {
@@ -418,7 +452,13 @@ pub struct RetryResult {
 /// Execute a fallible operation with retry, integrated with the circuit breaker.
 ///
 /// `op` is a closure that returns `Ok(())` on success or `Err(error_code)` on
-/// transient failure. A non-zero error triggers a `record_failure` call.
+/// transient (recoverable) failure. A non-zero error triggers a
+/// `record_failure` call, which counts toward the circuit breaker's
+/// `failure_threshold` in addition to this call's own `max_attempts` bound —
+/// so a caller can still see `ERR_CIRCUIT_OPEN` cut a retry loop short before
+/// `max_attempts` is reached, if enough failures (from this loop or any
+/// other caller) have already tripped the breaker. Each attempt is preceded
+/// by a `check_and_allow` call for exactly this reason.
 ///
 /// Returns a `RetryResult` describing the outcome.
 ///

--- a/bounty_escrow/contracts/escrow/src/error_recovery.rs
+++ b/bounty_escrow/contracts/escrow/src/error_recovery.rs
@@ -30,21 +30,22 @@
 //   underlying operation may succeed if attempted again — a transient token
 //   transfer failure, for example. Callers following the retry pattern
 //   should retry these, subject to the bound below.
-// - **Terminal** (`ERR_CIRCUIT_OPEN`): retrying will not help. The circuit
-//   breaker has already tripped from accumulated failures across *all*
-//   callers and is rejecting every attempt until an admin resets it (see
-//   `docs/bounty_escrow/CIRCUIT_BREAKER.md`).
+// - **Terminal** (`ERR_CIRCUIT_OPEN`, `ERR_RETRIES_EXHAUSTED`): retrying
+//   will not help. `ERR_CIRCUIT_OPEN` means the circuit breaker has already
+//   tripped from accumulated failures across *all* callers and is rejecting
+//   every attempt until an admin resets it (see
+//   `docs/bounty_escrow/CIRCUIT_BREAKER.md`). `ERR_RETRIES_EXHAUSTED` means
+//   *this specific* `execute_with_retry` call used up its configured
+//   attempt budget (`RetryConfig::max_attempts`,
+//   `DEFAULT_MAX_RETRY_ATTEMPTS` by default) without success; the caller
+//   must stop, not loop again.
 //
 // `execute_with_retry` bounds the number of attempts via
-// `RetryConfig::max_attempts` (default 3). **Current limitation**: when the
-// loop exhausts `max_attempts` without success, `RetryResult::final_error`
-// is set to whatever the *last attempt's* underlying error code was (e.g.
-// `ERR_TRANSFER_FAILED`) — the same recoverable-looking code a caller would
-// see on attempt 1. There is no distinct "attempts exhausted" signal today;
-// a caller must compare `RetryResult::attempts` against the `max_attempts`
-// it passed in to detect exhaustion itself. This is the gap tracked by the
-// companion issue that adds an explicit `ERR_RETRIES_EXHAUSTED` terminal
-// code.
+// `RetryConfig::max_attempts`. When the loop exhausts that budget without
+// success, `RetryResult::final_error` is set to `ERR_RETRIES_EXHAUSTED` —
+// distinct from the recoverable code the underlying operation was actually
+// failing with — so a caller can match on it directly instead of comparing
+// `RetryResult::attempts` against the config it passed in.
 
 use soroban_sdk::{contracttype, symbol_short, Address, Env, String};
 
@@ -145,6 +146,10 @@ pub const ERR_TRANSFER_FAILED: u32 = 1002;
 /// **Recoverable.** Insufficient contract balance at the time of the
 /// attempt — may resolve if funds arrive before a later retry.
 pub const ERR_INSUFFICIENT_BALANCE: u32 = 1003;
+/// **Terminal.** `execute_with_retry` exhausted `RetryConfig::max_attempts`
+/// without success. Distinct from the recoverable code the last attempt
+/// actually failed with — do not retry again with the same config.
+pub const ERR_RETRIES_EXHAUSTED: u32 = 1004;
 /// Operation succeeded — for logging.
 pub const ERR_NONE: u32 = 0;
 
@@ -420,7 +425,13 @@ pub fn get_error_log(env: &Env) -> soroban_sdk::Vec<ErrorEntry> {
 // Retry logic
 // ─────────────────────────────────────────────────────────
 
-/// Bounds how many attempts `execute_with_retry` makes before giving up.
+/// Default `RetryConfig::max_attempts` when not otherwise configured. A
+/// named constant so the cap is explicit and easy to audit, rather than a
+/// magic number repeated at call sites.
+pub const DEFAULT_MAX_RETRY_ATTEMPTS: u32 = 3;
+
+/// Bounds how many attempts `execute_with_retry` makes before giving up and
+/// returning `ERR_RETRIES_EXHAUSTED`.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RetryConfig {
@@ -430,17 +441,20 @@ pub struct RetryConfig {
 
 impl RetryConfig {
     pub fn default() -> Self {
-        RetryConfig { max_attempts: 3 }
+        RetryConfig {
+            max_attempts: DEFAULT_MAX_RETRY_ATTEMPTS,
+        }
     }
 }
 
 /// Outcome of an `execute_with_retry` call.
 ///
 /// When `succeeded` is `false`, `attempts` reports how many were actually
-/// made (bounded by the `RetryConfig::max_attempts` passed in), and
-/// `final_error` carries the error code — see the module-level docs above
-/// for why `final_error` does not yet distinguish "exhausted the attempt
-/// budget" from "failed on the most recent attempt".
+/// made (bounded by `RetryConfig::max_attempts`). `final_error` is either
+/// the terminal error that stopped the loop early (`ERR_CIRCUIT_OPEN`), or
+/// `ERR_RETRIES_EXHAUSTED` if every attempt in the budget ran and failed —
+/// never the underlying recoverable error code of the last attempt itself;
+/// that remains available via `get_error_log` if needed.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RetryResult {
@@ -480,7 +494,6 @@ where
     F: FnMut() -> Result<(), u32>,
 {
     let mut attempts = 0u32;
-    let mut last_error = ERR_NONE;
 
     for _ in 0..config.max_attempts {
         // Check circuit before each attempt
@@ -503,16 +516,23 @@ where
                 };
             }
             Err(code) => {
-                last_error = code;
+                // The underlying (recoverable) error code is preserved in
+                // the circuit breaker's error log via record_failure, so it
+                // remains discoverable via get_error_log even though the
+                // terminal RetryResult below reports ERR_RETRIES_EXHAUSTED.
                 record_failure(env, bounty_id, operation.clone(), code);
             }
         }
     }
 
+    // Every attempt in the budget was made and none succeeded: this is a
+    // distinct terminal outcome from any single attempt's recoverable
+    // error, so callers can match on it directly instead of comparing
+    // `attempts` against the config they passed in.
     RetryResult {
         succeeded: false,
         attempts,
-        final_error: last_error,
+        final_error: ERR_RETRIES_EXHAUSTED,
     }
 }
 

--- a/bounty_escrow/contracts/escrow/src/test_coverage_boost_small.rs
+++ b/bounty_escrow/contracts/escrow/src/test_coverage_boost_small.rs
@@ -114,6 +114,10 @@ fn circuit_breaker_retry_branches() {
     });
     assert!(!fail.succeeded);
     assert_eq!(fail.attempts, 2);
+    // Exhausting the attempt budget is a distinct terminal outcome, not the
+    // last attempt's own (recoverable-looking) error code.
+    assert_eq!(fail.final_error, error_recovery::ERR_RETRIES_EXHAUSTED);
+    assert_ne!(fail.final_error, 1u32);
 
     // Success closure -> record_success + immediate return.
     let ok = s.env.as_contract(&s.contract_id, || {
@@ -126,4 +130,66 @@ fn circuit_breaker_retry_branches() {
         )
     });
     assert!(ok.succeeded);
+}
+
+#[test]
+fn circuit_breaker_retry_exhausted_uses_default_cap_and_distinct_terminal_error() {
+    let s = Boost::new();
+    s.client.set_circuit_breaker_config(&100u32, &1u32, &5u32);
+    s.client.set_circuit_breaker_admin(&s.admin.clone());
+
+    // A high failure_threshold keeps the circuit Closed throughout, so this
+    // exercises retry-budget exhaustion specifically, not a circuit trip.
+    let config = error_recovery::RetryConfig::default();
+    assert_eq!(config.max_attempts, error_recovery::DEFAULT_MAX_RETRY_ATTEMPTS);
+
+    let result = s.env.as_contract(&s.contract_id, || {
+        error_recovery::execute_with_retry(
+            &s.env,
+            &config,
+            3u64,
+            Symbol::new(&s.env, "always_fails"),
+            || Err(error_recovery::ERR_TRANSFER_FAILED),
+        )
+    });
+
+    assert!(!result.succeeded);
+    assert_eq!(result.attempts, error_recovery::DEFAULT_MAX_RETRY_ATTEMPTS);
+    assert_eq!(result.final_error, error_recovery::ERR_RETRIES_EXHAUSTED);
+    // The distinct terminal code is never confused with the recoverable
+    // code every individual attempt actually failed with.
+    assert_ne!(result.final_error, error_recovery::ERR_TRANSFER_FAILED);
+
+    // The underlying per-attempt error remains discoverable via the error
+    // log even though the RetryResult itself now reports the terminal code.
+    let log = s.env.as_contract(&s.contract_id, || error_recovery::get_error_log(&s.env));
+    assert_eq!(log.len(), error_recovery::DEFAULT_MAX_RETRY_ATTEMPTS);
+    assert_eq!(log.get(0).unwrap().error_code, error_recovery::ERR_TRANSFER_FAILED);
+}
+
+#[test]
+fn circuit_breaker_open_short_circuits_retry_with_its_own_terminal_error() {
+    let s = Boost::new();
+    // A low failure_threshold means the circuit opens after the 1st failure,
+    // so the 2nd configured attempt never runs.
+    s.client.set_circuit_breaker_config(&1u32, &1u32, &5u32);
+    s.client.set_circuit_breaker_admin(&s.admin.clone());
+
+    let result = s.env.as_contract(&s.contract_id, || {
+        error_recovery::execute_with_retry(
+            &s.env,
+            &error_recovery::RetryConfig { max_attempts: 5 },
+            4u64,
+            Symbol::new(&s.env, "trips_breaker"),
+            || Err(error_recovery::ERR_TRANSFER_FAILED),
+        )
+    });
+
+    assert!(!result.succeeded);
+    assert_eq!(result.attempts, 1);
+    // Circuit-open is its own terminal error, distinct from exhausting the
+    // retry budget — the loop stopped early, not because it ran out of
+    // configured attempts.
+    assert_eq!(result.final_error, error_recovery::ERR_CIRCUIT_OPEN);
+    assert_ne!(result.final_error, error_recovery::ERR_RETRIES_EXHAUSTED);
 }

--- a/docs/bounty_escrow/CIRCUIT_BREAKER.md
+++ b/docs/bounty_escrow/CIRCUIT_BREAKER.md
@@ -171,6 +171,51 @@ The circuit breaker emits events for state changes:
 - `cb_close` - When circuit closes
 - `cb_reject` - When operation is rejected due to open circuit
 
+## Retry Logic
+
+`error_recovery.rs` also defines `execute_with_retry`, a bounded-retry helper
+that integrates with the circuit breaker above. It is not currently wired
+into any contract entrypoint — production code (`lib.rs`) calls
+`check_and_allow` / `record_success` / `record_failure` directly — so today
+it's primarily useful for test scenarios, simulation, and as a reference
+implementation for integrators building their own retry loop against those
+primitives (e.g. the backend's `internal/soroban` client).
+
+### Error classification
+
+| Error | Classification | Meaning |
+| --- | --- | --- |
+| `ERR_TRANSFER_FAILED` (1002) | Recoverable | Transient token transfer failure; safe to retry. |
+| `ERR_INSUFFICIENT_BALANCE` (1003) | Recoverable | May resolve once funds arrive; safe to retry. |
+| `ERR_CIRCUIT_OPEN` (1001) | Terminal | The breaker has tripped from accumulated failures (from any caller); stop until an admin resets it. |
+
+### `execute_with_retry`
+
+```rust
+pub fn execute_with_retry<F>(
+    env: &Env,
+    config: &RetryConfig,   // { max_attempts: u32 }, default 3
+    bounty_id: u64,
+    operation: Symbol,
+    op: F,
+) -> RetryResult             // { succeeded: bool, attempts: u32, final_error: u32 }
+where
+    F: FnMut() -> Result<(), u32>;
+```
+
+Before each attempt it calls `check_and_allow`, so a circuit that opens
+mid-loop (from this call's own failures or any other caller's) short-circuits
+the remaining attempts with `ERR_CIRCUIT_OPEN` rather than burning the full
+`max_attempts` budget.
+
+**Current limitation**: when the loop exhausts `max_attempts` without
+success, `RetryResult.final_error` is the *last attempt's* underlying
+recoverable error code (e.g. `ERR_TRANSFER_FAILED`) — indistinguishable from
+a first-attempt failure by error code alone. A caller must compare
+`RetryResult.attempts` against the `max_attempts` it configured to detect
+exhaustion. Adding a distinct terminal `ERR_RETRIES_EXHAUSTED` code so this
+is signalled explicitly is tracked separately.
+
 ## Future Enhancements
 
 Potential improvements could include:

--- a/docs/bounty_escrow/CIRCUIT_BREAKER.md
+++ b/docs/bounty_escrow/CIRCUIT_BREAKER.md
@@ -188,13 +188,14 @@ primitives (e.g. the backend's `internal/soroban` client).
 | `ERR_TRANSFER_FAILED` (1002) | Recoverable | Transient token transfer failure; safe to retry. |
 | `ERR_INSUFFICIENT_BALANCE` (1003) | Recoverable | May resolve once funds arrive; safe to retry. |
 | `ERR_CIRCUIT_OPEN` (1001) | Terminal | The breaker has tripped from accumulated failures (from any caller); stop until an admin resets it. |
+| `ERR_RETRIES_EXHAUSTED` (1004) | Terminal | `execute_with_retry` used up its configured `max_attempts` budget without success; stop, don't retry again with the same config. |
 
 ### `execute_with_retry`
 
 ```rust
 pub fn execute_with_retry<F>(
     env: &Env,
-    config: &RetryConfig,   // { max_attempts: u32 }, default 3
+    config: &RetryConfig,   // { max_attempts: u32 }, default DEFAULT_MAX_RETRY_ATTEMPTS (3)
     bounty_id: u64,
     operation: Symbol,
     op: F,
@@ -208,13 +209,15 @@ mid-loop (from this call's own failures or any other caller's) short-circuits
 the remaining attempts with `ERR_CIRCUIT_OPEN` rather than burning the full
 `max_attempts` budget.
 
-**Current limitation**: when the loop exhausts `max_attempts` without
-success, `RetryResult.final_error` is the *last attempt's* underlying
-recoverable error code (e.g. `ERR_TRANSFER_FAILED`) — indistinguishable from
-a first-attempt failure by error code alone. A caller must compare
-`RetryResult.attempts` against the `max_attempts` it configured to detect
-exhaustion. Adding a distinct terminal `ERR_RETRIES_EXHAUSTED` code so this
-is signalled explicitly is tracked separately.
+When the loop instead exhausts `max_attempts` without success,
+`RetryResult.final_error` is set to the distinct terminal code
+`ERR_RETRIES_EXHAUSTED` — not the last attempt's underlying recoverable
+error code. A caller can match on `final_error` directly to tell "circuit
+tripped" apart from "ran out of attempts" without also comparing
+`RetryResult.attempts` against the config it passed in. The last attempt's
+actual recoverable error code (e.g. `ERR_TRANSFER_FAILED`) remains
+available via `get_error_log`, which `record_failure` populates on every
+failed attempt.
 
 ## Future Enhancements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ Welcome to the Grainlify Stellar Contracts documentation. This index provides a 
 |----------|-------------|
 | [Bounty Escrow README](../bounty_escrow/README.md) | Overview of the bounty escrow contract |
 | [Security](bounty_escrow/SECURITY.md) | Security model, threat analysis, and mitigations |
-| [Circuit Breaker](bounty_escrow/CIRCUIT_BREAKER.md) | Circuit breaker mechanism documentation |
+| [Circuit Breaker](bounty_escrow/CIRCUIT_BREAKER.md) | Circuit breaker mechanism and retry-logic documentation |
 | [Implementation Checklist](bounty_escrow/IMPLEMENTATION_CHECKLIST.md) | Implementation task tracking |
 | [Analytics Documentation](bounty_escrow/ANALYTICS_DOCUMENTATION.md) | Analytics views and query functions |
 | [Analytics Implementation Summary](bounty_escrow/ANALYTICS_IMPLEMENTATION_SUMMARY.md) | Analytics module implementation details |


### PR DESCRIPTION
## Summary

`execute_with_retry` in `bounty_escrow/contracts/escrow/src/error_recovery.rs` now returns a dedicated terminal error code, `ERR_RETRIES_EXHAUSTED` (1004), when it uses up its configured `RetryConfig::max_attempts` budget without success — instead of surfacing the last attempt's own recoverable error code (e.g. `ERR_TRANSFER_FAILED`), which was indistinguishable from a first-attempt failure by error code alone.

- Added `pub const ERR_RETRIES_EXHAUSTED: u32 = 1004;`, doc-commented as **Terminal**.
- `execute_with_retry` now sets `RetryResult.final_error = ERR_RETRIES_EXHAUSTED` on exhaustion, so callers can match on `final_error` directly to distinguish "circuit tripped" (`ERR_CIRCUIT_OPEN`) from "ran out of attempts" (`ERR_RETRIES_EXHAUSTED`), without also comparing `RetryResult.attempts` against the config they passed in.
- The last attempt's actual recoverable error code remains discoverable via `get_error_log`, which `record_failure` still populates on every failed attempt — no information is lost, it's just no longer conflated with the terminal outcome.
- `RetryConfig::default()`'s previously-magic `3` is now the named constant `pub const DEFAULT_MAX_RETRY_ATTEMPTS: u32 = 3;`, making the cap explicit and easy to audit/reference from tests and docs.
- Updated `docs/bounty_escrow/CIRCUIT_BREAKER.md`'s "Retry Logic" section (added in #167 / #414) to remove the now-stale "Current limitation" paragraph and add `ERR_RETRIES_EXHAUSTED` to the error classification table.
- Removed the now-unused `last_error` loop variable.

Closes #168

## Test plan

Added two new tests to `test_coverage_boost_small.rs` covering the acceptance criteria directly:
- `circuit_breaker_retry_exhausted_uses_default_cap_and_distinct_terminal_error` — asserts `RetryConfig::default().max_attempts == DEFAULT_MAX_RETRY_ATTEMPTS`, that exhausting the budget returns `final_error == ERR_RETRIES_EXHAUSTED` (not `ERR_TRANSFER_FAILED`), and that the underlying per-attempt error is still visible via `get_error_log`.
- `circuit_breaker_open_short_circuits_retry_with_its_own_terminal_error` — asserts that a circuit trip mid-loop stops early with `final_error == ERR_CIRCUIT_OPEN`, distinct from `ERR_RETRIES_EXHAUSTED`.
- Also strengthened the existing `circuit_breaker_retry_branches` test with an explicit `assert_eq!(fail.final_error, error_recovery::ERR_RETRIES_EXHAUSTED)`.

```
$ cargo test -p bounty-escrow -- circuit_breaker retry serialization
test test_coverage_boost_small::circuit_breaker_retry_branches ... ok
test test_coverage_boost_small::circuit_breaker_open_short_circuits_retry_with_its_own_terminal_error ... ok
test test_coverage_boost_small::circuit_breaker_retry_exhausted_uses_default_cap_and_distinct_terminal_error ... ok
test test_coverage_comprehensive::fee_with_circuit_breaker_exercise ... ok

test result: ok. 53 passed; 0 failed; 0 ignored; 0 measured; 480 filtered out; finished in 0.55s

$ cargo test -p bounty-escrow
test result: ok. 533 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 40.08s
```

`cargo fmt --check -p bounty-escrow` and `cargo clippy -p bounty-escrow --tests` were run and compared against the pre-change baseline: the only fmt diff touching a line this PR modified does not overlap this PR's actual changes (confirmed via `git diff main-synced -- .../error_recovery.rs`, which shows only the intended additions), and clippy's warning count is unchanged at 209 with no warnings referencing `ERR_RETRIES_EXHAUSTED` or `DEFAULT_MAX_RETRY_ATTEMPTS`. Both tools' remaining output is pre-existing, repo-wide formatting/lint debt unrelated to this change (tracked separately by #388, which proposes adding fmt/clippy CI gates).

## Note

This branch is stacked locally on `docs/error-recovery-167-retry-semantics` (PR #414, itself the docs companion to this fix), since I don't have push access to open a PR against a non-`main` base on the upstream org repo. Both PRs target `main`; #414 documents the retry semantics that existed before this fix, and this PR is what makes the "current limitation" it originally described no longer true. If #414 merges first, this PR's diff against `main` will shrink to just this PR's own changes; if reviewed before that, the diff will show both PRs' changes together — happy to rebase once #414 lands.