### PR TITLE
docs(bounty-escrow): document authorization, params, and cross-contract calls on lib.rs public interface

### DIFF
--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -965,6 +965,10 @@ impl BountyEscrowContract {
     }
 
     /// Get current pause flags
+    /// Get current pause flags
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_pause_flags(env: &Env) -> PauseFlags {
         env.storage()
             .instance()
@@ -1012,6 +1016,10 @@ impl BountyEscrowContract {
     }
 
     /// Get current fee configuration (view function)
+    /// Get current fee configuration (view function)
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_fee_config(env: Env) -> FeeConfig {
         Self::get_fee_config_internal(&env)
     }
@@ -1048,6 +1056,10 @@ impl BountyEscrowContract {
     }
 
     /// Get multisig configuration
+    /// Get multisig configuration
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_multisig_config(env: Env) -> MultisigConfig {
         env.storage()
             .instance()
@@ -1144,6 +1156,11 @@ impl BountyEscrowContract {
     }
 
     /// Approve release for large amount (requires multisig)
+    ///
+    /// # Authorization
+    /// Requires `approver.require_auth()`, and `approver` must be one of the
+    /// addresses configured in `MultisigConfig::signers` (`Unauthorized` otherwise).
+    /// This only records one signer's approval; it does not itself transfer funds.
     pub fn approve_large_release(
         env: Env,
         bounty_id: u64,
@@ -1205,6 +1222,26 @@ impl BountyEscrowContract {
     }
 
     /// Lock funds for a specific bounty.
+    ///
+    /// # Authorization
+    /// Requires `depositor.require_auth()` — only the depositor themself can
+    /// lock their own funds.
+    ///
+    /// # Arguments
+    /// * `depositor` - Address whose token balance is debited.
+    /// * `bounty_id` - Caller-chosen unique identifier; fails with `BountyExists` if reused.
+    /// * `amount` - Token amount to lock, in the token contract's own smallest unit
+    ///   (e.g. stroops for the native asset); must satisfy any configured min/max
+    ///   amount policy.
+    /// * `deadline` - Unix timestamp (seconds) after which the bounty becomes refundable.
+    ///
+    /// # Cross-contract call
+    /// Transfers `amount` from `depositor` to this contract via the configured
+    /// token contract's `transfer` (see `execute_token_transfer`).
+    ///
+    /// # Errors
+    /// `NotInitialized`, `BountyExists`, `AmountBelowMinimum`/`AmountAboveMaximum`
+    /// (if an amount policy is set), `FundsPaused`, `CircuitBreakerOpen`.
     pub fn lock_funds(
         env: Env,
         depositor: Address,
@@ -1350,6 +1387,13 @@ impl BountyEscrowContract {
     /// Only the admin (backend) can authorize this.
     /// If governance is configured, the linked governance version must meet
     /// the configured minimum before this value transfer can proceed.
+    ///
+    /// # Authorization
+    /// Requires `admin.require_auth()`, where `admin` is the contract's configured admin.
+    ///
+    /// # Cross-contract call
+    /// Transfers the escrow's full `remaining_amount` to `contributor` via the
+    /// configured token contract's `transfer` (see `execute_token_transfer`).
     pub fn release_funds(env: Env, bounty_id: u64, contributor: Address) -> Result<(), Error> {
         Self::check_governance_requirements(&env)?;
 
@@ -1559,6 +1603,18 @@ impl BountyEscrowContract {
     }
 
     /// Beneficiary calls this to claim their authorized funds within the window.
+    ///
+    /// # Authorization
+    /// Requires `require_auth()` from the `recipient` address recorded on the
+    /// pending claim by `authorize_claim` — not the escrow's admin or depositor.
+    ///
+    /// # Cross-contract call
+    /// Transfers the claimed amount to the recipient via the configured token
+    /// contract's `transfer` (see `execute_token_transfer`).
+    ///
+    /// # Errors
+    /// `BountyNotFound` (no pending claim), `ClaimExpired`, `FundsNotLocked`
+    /// (already claimed), `FundsPaused`, `CircuitBreakerOpen`.
     pub fn claim(env: Env, bounty_id: u64) -> Result<(), Error> {
         // --- All validation BEFORE the reentrancy guard so early returns never
         //     leak the guard flag. ---
@@ -1767,6 +1823,13 @@ impl BountyEscrowContract {
     /// - The bounty stays Locked while any funds remain unreleased.
     /// - If governance is configured, its version must satisfy the configured
     ///   minimum before any partial payout is transferred.
+    ///
+    /// # Authorization
+    /// Requires `admin.require_auth()`, where `admin` is the contract's configured admin.
+    ///
+    /// # Cross-contract call
+    /// Transfers `payout_amount` to `contributor` via the configured token
+    /// contract's `transfer` (see `execute_token_transfer`).
     pub fn partial_release(
         env: Env,
         bounty_id: u64,
@@ -1929,6 +1992,17 @@ impl BountyEscrowContract {
     /// Refunds the full remaining_amount (accounts for any prior partial releases).
     /// If governance is configured, the linked governance version must meet
     /// the configured minimum before funds can be refunded.
+    ///
+    /// # Authorization
+    /// No caller authorization is required — callable by anyone (a permissionless
+    /// "keeper" pattern). Safety comes from the recipient being fixed by contract
+    /// state (the original depositor, or an admin-approved recipient via
+    /// `approve_refund`), not from caller identity, and from the deadline/approval
+    /// gate above.
+    ///
+    /// # Cross-contract call
+    /// Transfers the refund amount to the recipient via the configured token
+    /// contract's `transfer` (see `execute_token_transfer`).
     pub fn refund(env: Env, bounty_id: u64) -> Result<(), Error> {
 
 
@@ -2099,6 +2173,14 @@ impl BountyEscrowContract {
     /// transfer, so one invalid entry rejects the whole sweep.
     /// If governance is configured, the linked governance version must meet
     /// the configured minimum before any expired bounty is swept.
+    ///
+    /// # Authorization
+    /// No caller authorization is required, matching `refund`'s permissionless
+    /// keeper pattern — recipients are always each bounty's own depositor.
+    ///
+    /// # Cross-contract call
+    /// Transfers each bounty's full remaining amount back to its depositor via
+    /// the configured token contract's `transfer`, once per swept bounty.
     pub fn sweep_expired_refunds(env: Env, bounty_ids: Vec<u64>) -> Result<u32, Error> {
 
 
@@ -2240,6 +2322,10 @@ impl BountyEscrowContract {
     }
 
     /// view function to get escrow info
+    /// view function to get escrow info
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_escrow_info(env: Env, bounty_id: u64) -> Result<Escrow, Error> {
         if !env.storage().persistent().has(&DataKey::Escrow(bounty_id)) {
             return Err(Error::BountyNotFound);
@@ -2254,6 +2340,13 @@ impl BountyEscrowContract {
     }
 
     /// view function to get contract balance of the token
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
+    ///
+    /// # Cross-contract call
+    /// Reads this contract's balance via the configured token contract's
+    /// `balance` query. No funds move.
     pub fn get_balance(env: Env) -> Result<i128, Error> {
         if !env.storage().instance().has(&DataKey::Token) {
             return Err(Error::NotInitialized);
@@ -2265,6 +2358,11 @@ impl BountyEscrowContract {
 
     /// Query escrows with filtering and pagination
     /// Pass 0 for min values and i128::MAX/u64::MAX for max values to disable those filters
+    /// Query escrows with filtering and pagination
+    /// Pass 0 for min values and i128::MAX/u64::MAX for max values to disable those filters
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn query_escrows_by_status(
         env: Env,
         status: EscrowStatus,
@@ -2305,6 +2403,10 @@ impl BountyEscrowContract {
     }
 
     /// Query escrows with amount range filtering
+    /// Query escrows with amount range filtering
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn query_escrows_by_amount(
         env: Env,
         min_amount: i128,
@@ -2346,6 +2448,10 @@ impl BountyEscrowContract {
     }
 
     /// Query escrows with deadline range filtering
+    /// Query escrows with deadline range filtering
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn query_escrows_by_deadline(
         env: Env,
         min_deadline: u64,
@@ -2387,6 +2493,10 @@ impl BountyEscrowContract {
     }
 
     /// Query escrows by depositor
+    /// Query escrows by depositor
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn query_escrows_by_depositor(
         env: Env,
         depositor: Address,
@@ -2533,6 +2643,16 @@ impl BountyEscrowContract {
     ///
     /// For verification purposes, use `get_aggregate_stats_full_scan` to perform a
     /// ground-truth comparison.
+    /// Get aggregate statistics from O(1) incremental counters.
+    ///
+    /// This function reads maintained counters that are updated on every state transition
+    /// (lock, release, refund, partial_release). Provides constant-time aggregate queries.
+    ///
+    /// For verification purposes, use `get_aggregate_stats_full_scan` to perform a
+    /// ground-truth comparison.
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_aggregate_stats(env: Env) -> AggregateStats {
         Self::get_counters(&env)
     }
@@ -2545,6 +2665,17 @@ impl BountyEscrowContract {
     ///
     /// **Performance:** O(N) where N is the number of bounties. Not suitable for
     /// production queries at scale.
+    /// Get aggregate statistics via full O(N) scan for reconciliation and testing.
+    ///
+    /// This function performs a complete scan of all escrows to calculate aggregate
+    /// statistics from scratch. Use this to verify the incremental counters are accurate
+    /// or when counters need to be rebuilt.
+    ///
+    /// **Performance:** O(N) where N is the number of bounties. Not suitable for
+    /// production queries at scale.
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_aggregate_stats_full_scan(env: Env) -> AggregateStats {
         let index: Vec<u64> = env
             .storage()
@@ -2594,6 +2725,10 @@ impl BountyEscrowContract {
     }
 
     /// Get total count of escrows
+    /// Get total count of escrows
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_escrow_count(env: Env) -> u32 {
         let index: Vec<u64> = env
             .storage()
@@ -2641,6 +2776,10 @@ impl BountyEscrowContract {
     }
 
     /// Get escrow IDs by status
+    /// Get escrow IDs by status
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_escrow_ids_by_status(
         env: Env,
         status: EscrowStatus,
@@ -2679,6 +2818,16 @@ impl BountyEscrowContract {
         results
     }
 
+    /// Set (or overwrite) the address recorded as the anti-abuse module's admin.
+    ///
+    /// Note: this stored value is informational only — `set_whitelist` below is
+    /// actually gated by the contract's main `DataKey::Admin`, not by this value.
+    ///
+    /// # Authorization
+    /// Requires `require_auth()` from the contract's main admin (`DataKey::Admin`).
+    ///
+    /// # Errors
+    /// `NotInitialized` if the contract has no admin set yet.
     pub fn set_anti_abuse_admin(env: Env, admin: Address) -> Result<(), Error> {
         let current: Address = env
             .storage()
@@ -2690,10 +2839,26 @@ impl BountyEscrowContract {
         Ok(())
     }
 
+    /// Get the address most recently stored via `set_anti_abuse_admin`, if any.
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_anti_abuse_admin(env: Env) -> Option<Address> {
         anti_abuse::get_admin(&env)
     }
 
+    /// Add or remove `whitelisted_address` from the anti-abuse rate-limit
+    /// whitelist. Whitelisted addresses bypass `check_rate_limit` entirely.
+    ///
+    /// # Authorization
+    /// Requires `require_auth()` from the contract's main admin (`DataKey::Admin`).
+    ///
+    /// # Arguments
+    /// * `whitelisted_address` - Address to add or remove.
+    /// * `whitelisted` - `true` to add, `false` to remove.
+    ///
+    /// # Errors
+    /// `NotInitialized` if the contract has no admin set yet.
     pub fn set_whitelist(
         env: Env,
         whitelisted_address: Address,
@@ -2718,6 +2883,18 @@ impl BountyEscrowContract {
     /// # Returns
     /// * `Ok(Vec<RefundRecord>)` - The refund history
     /// * `Err(Error::BountyNotFound)` - Bounty doesn't exist
+    /// Retrieves the refund history for a specific bounty.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `bounty_id` - The bounty to query
+    ///
+    /// # Returns
+    /// * `Ok(Vec<RefundRecord>)` - The refund history
+    /// * `Err(Error::BountyNotFound)` - Bounty doesn't exist
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_refund_history(env: Env, bounty_id: u64) -> Result<Vec<RefundRecord>, Error> {
         if !env.storage().persistent().has(&DataKey::Escrow(bounty_id)) {
             return Err(Error::BountyNotFound);
@@ -2746,6 +2923,10 @@ impl BountyEscrowContract {
     }
 
     /// Get the governance contract address
+    /// Get the governance contract address
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_governance_contract(env: Env) -> Option<Address> {
         governance_integration::get_governance_contract(&env)
     }
@@ -2762,6 +2943,10 @@ impl BountyEscrowContract {
     }
 
     /// Get minimum required governance version
+    /// Get minimum required governance version
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_min_governance_version(env: Env) -> u32 {
         governance_integration::get_min_governance_version(&env)
     }
@@ -2771,6 +2956,19 @@ impl BountyEscrowContract {
     /// The configured grainlify-core governance contract re-checks quorum and
     /// approval state by executing the proposal itself. Pending, rejected,
     /// delayed, missing, or already-executed proposals are rejected.
+    ///
+    /// # Authorization
+    /// No caller authorization is required — callable by anyone. Safety comes
+    /// from the governance contract re-validating the proposal's own approval
+    /// state on every call, not from caller identity; this function only marks
+    /// an already-legitimately-approved proposal as consumed.
+    ///
+    /// # Cross-contract call
+    /// Invokes `execute_proposal` on the configured governance contract (see
+    /// `governance_integration::execute_governance_proposal`).
+    ///
+    /// # Errors
+    /// `NotInitialized`, `GovernanceVersionTooLow`, `GovernanceProposalNotExecutable`.
     pub fn execute_governance_proposal(env: Env, proposal_id: u32) -> Result<(), Error> {
         if !env.storage().instance().has(&DataKey::Admin) {
             return Err(Error::NotInitialized);
@@ -2806,6 +3004,22 @@ impl BountyEscrowContract {
     ///   - remaining: Remaining amount in escrow
     ///   - approval: Optional refund approval if exists
     /// * `Err(Error::BountyNotFound)` - Bounty doesn't exist
+    /// Gets refund eligibility information for a bounty.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `bounty_id` - The bounty to query
+    ///
+    /// # Returns
+    /// * `Ok((bool, bool, i128, Option<RefundApproval>))` - Tuple containing:
+    ///   - can_refund: Whether refund is possible
+    ///   - deadline_passed: Whether the deadline has passed
+    ///   - remaining: Remaining amount in escrow
+    ///   - approval: Optional refund approval if exists
+    /// * `Err(Error::BountyNotFound)` - Bounty doesn't exist
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_refund_eligibility(
         env: Env,
         bounty_id: u64,
@@ -2868,6 +3082,14 @@ impl BountyEscrowContract {
     ///
     /// # Note
     /// This operation is atomic - if any item fails, the entire transaction reverts.
+    ///
+    /// # Authorization
+    /// Requires `require_auth()` from each item's own `depositor` (same rule as
+    /// `lock_funds`) — there is no single caller identity for the whole batch.
+    ///
+    /// # Cross-contract call
+    /// Transfers each item's `amount` from its `depositor` to this contract via
+    /// the configured token contract's `transfer`, once per batch item.
     pub fn batch_lock_funds(env: Env, items: Vec<LockFundsItem>) -> Result<u32, Error> {
 
 
@@ -3036,6 +3258,10 @@ impl BountyEscrowContract {
     /// This operation is atomic - if any item fails, the entire transaction reverts.
     /// If governance is configured, the linked governance version must meet
     /// the configured minimum before any item is released.
+    ///
+    /// # Cross-contract call
+    /// Transfers each item's escrowed amount to its `contributor` via the
+    /// configured token contract's `transfer`, once per batch item.
     pub fn batch_release_funds(env: Env, items: Vec<ReleaseFundsItem>) -> Result<u32, Error> {
 
 
@@ -3179,6 +3405,17 @@ impl BountyEscrowContract {
     /// # Returns
     /// * `Ok(BountyAnalytics)` - Analytics for the bounty including amounts locked/released/refunded
     /// * `Err(Error::BountyNotFound)` - If bounty doesn't exist
+    /// Get per-bounty analytics for a specific bounty
+    ///
+    /// # Arguments
+    /// * `bounty_id` - The bounty to query
+    ///
+    /// # Returns
+    /// * `Ok(BountyAnalytics)` - Analytics for the bounty including amounts locked/released/refunded
+    /// * `Err(Error::BountyNotFound)` - If bounty doesn't exist
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_bounty_analytics(env: Env, bounty_id: u64) -> Result<analytics::BountyAnalytics, Error> {
         get_bounty_analytics(&env, bounty_id).ok_or(Error::BountyNotFound)
     }
@@ -3199,6 +3436,25 @@ impl BountyEscrowContract {
     /// - Average bounty size
     ///
     /// This function uses O(1) incremental counters for efficiency.
+    /// Get contract-wide analytics snapshot
+    ///
+    /// Returns aggregated metrics about active bounties, total locked amounts, and released amounts.
+    /// This view is efficient and suitable for regular polling by off-chain indexers.
+    ///
+    /// # Returns
+    /// `ContractAnalytics` containing:
+    /// - Active bounty count (Locked or Partially Refunded)
+    /// - Released bounty count
+    /// - Refunded bounty count
+    /// - Total locked amount
+    /// - Total released amount
+    /// - Total refunded amount
+    /// - Average bounty size
+    ///
+    /// This function uses O(1) incremental counters for efficiency.
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_contract_analytics(env: Env) -> ContractAnalytics {
         let stats = Self::get_counters(&env);
 
@@ -3230,6 +3486,10 @@ impl BountyEscrowContract {
     ///
     /// This can be called periodically to create snapshots for off-chain analytics and indexing.
     /// The event contains a full `ContractAnalytics` structure that can be ingested by indexing services.
+    ///
+    /// # Authorization
+    /// None — callable by anyone. It only publishes an event derived from
+    /// existing on-chain state; it cannot mutate escrow state or move funds.
     pub fn emit_analytics_snapshot_event(env: Env) {
         let analytics = Self::get_contract_analytics(env.clone());
         emit_analytics_snapshot(
@@ -3249,6 +3509,17 @@ impl BountyEscrowContract {
     ///
     /// For Locked status, this includes both Locked and PartiallyRefunded bounties.
     /// For other statuses, only exact matches are counted.
+    /// Count bounties by status
+    ///
+    /// # Returns
+    /// Number of bounties in the specified status
+    /// Count bounties by status using O(1) incremental counters.
+    ///
+    /// For Locked status, this includes both Locked and PartiallyRefunded bounties.
+    /// For other statuses, only exact matches are counted.
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn count_bounties_by_status(env: Env, status: EscrowStatus) -> u32 {
         let stats = Self::get_counters(&env);
         match status {
@@ -3267,6 +3538,13 @@ impl BountyEscrowContract {
     ///
     /// Use this when you need to distinguish between Locked and PartiallyRefunded,
     /// or for verification purposes.
+    /// Count bounties by status via full O(N) scan for exact status matching.
+    ///
+    /// Use this when you need to distinguish between Locked and PartiallyRefunded,
+    /// or for verification purposes.
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn count_by_status_full_scan(env: Env, status: EscrowStatus) -> u32 {
         let index: Vec<u64> = env
             .storage()
@@ -3293,6 +3571,12 @@ impl BountyEscrowContract {
     /// Get total volume of funds by status using O(1) incremental counters.
     ///
     /// Returns the sum of all funds in bounties with the specified status.
+    /// Get total volume of funds by status using O(1) incremental counters.
+    ///
+    /// Returns the sum of all funds in bounties with the specified status.
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_volume_by_status(env: Env, status: EscrowStatus) -> i128 {
         let stats = Self::get_counters(&env);
         match status {
@@ -3310,6 +3594,12 @@ impl BountyEscrowContract {
     /// Get total volume of funds by status via full O(N) scan.
     ///
     /// Use this for exact status matching or verification.
+    /// Get total volume of funds by status via full O(N) scan.
+    ///
+    /// Use this for exact status matching or verification.
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn volume_by_status_full_scan(env: Env, status: EscrowStatus) -> i128 {
         let index: Vec<u64> = env
             .storage()
@@ -3342,6 +3632,12 @@ impl BountyEscrowContract {
     /// Get statistics for a specific depositor
     ///
     /// Returns count and total amount of bounties created by the depositor
+    /// Get statistics for a specific depositor
+    ///
+    /// Returns count and total amount of bounties created by the depositor
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_depositor_stats(
         env: Env,
         depositor: Address,
@@ -3402,6 +3698,18 @@ impl BountyEscrowContract {
     ///
     /// # Returns
     /// Vector of bounties sorted by deadline that match the criteria
+    /// Query bounties by expiration status (approaching or already expired)
+    ///
+    /// # Arguments
+    /// * `max_deadline` - Only return bounties with deadline <= this timestamp
+    /// * `offset` - Pagination offset
+    /// * `limit` - Maximum number of results
+    ///
+    /// # Returns
+    /// Vector of bounties sorted by deadline that match the criteria
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn query_expiring_bounties(env: Env, max_deadline: u64, offset: u32, limit: u32) -> Vec<u64> {
         let index: Vec<u64> = env
             .storage()
@@ -3451,6 +3759,18 @@ impl BountyEscrowContract {
     /// # Arguments
     /// * `min_amount` - Minimum amount to consider "high-value"
     /// * `limit` - Maximum number of results
+    /// Get high-value bounties (above a threshold) for risk monitoring.
+    ///
+    /// **Note:** This function still performs an O(N) scan as it requires filtering
+    /// by amount, which cannot be efficiently maintained in aggregate counters.
+    /// Consider using pagination and caching for large datasets.
+    ///
+    /// # Arguments
+    /// * `min_amount` - Minimum amount to consider "high-value"
+    /// * `limit` - Maximum number of results
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_high_value_bounties(env: Env, min_amount: i128, limit: u32) -> Vec<u64> {
         let index: Vec<u64> = env
             .storage()
@@ -3540,11 +3860,19 @@ impl BountyEscrowContract {
     }
 
     /// Get the current circuit breaker configuration.
+    /// Get the current circuit breaker configuration.
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_circuit_breaker_config(env: Env) -> CircuitBreakerConfig {
         get_config(&env)
     }
 
     /// Get the current circuit breaker status.
+    /// Get the current circuit breaker status.
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_circuit_breaker_status(env: Env) -> CircuitBreakerStatus {
         get_status(&env)
     }
@@ -3565,6 +3893,10 @@ impl BountyEscrowContract {
     }
 
     /// Get the circuit breaker error log.
+    /// Get the circuit breaker error log.
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
     pub fn get_circuit_error_log(env: Env) -> soroban_sdk::Vec<ErrorEntry> {
         error_recovery::get_error_log(&env)
     }


### PR DESCRIPTION
## Summary

Documentation-only pass over `bounty_escrow/contracts/escrow/src/lib.rs`'s public interface — the 62 `pub fn` entrypoints under `impl BountyEscrowContract` (the contract's actual deployed ABI; the file's private `mod monitoring` / `mod anti_abuse` helper submodules are internal and out of scope).

Closes #176

## What changed

- **3 entrypoints with no doc comment at all** now have one: `set_anti_abuse_admin`, `get_anti_abuse_admin`, `set_whitelist`.
- **Every entrypoint that lacked an explicit `# Authorization` note** now has one, stating who can call it. This surfaced three entrypoints that are genuinely permissionless (no `require_auth()` anywhere in the call path) — `refund`, `sweep_expired_refunds`, and `execute_governance_proposal` — which is easy to miss when skimming, since most state-changing calls in this file *do* require a specific caller. All three are documented as intentional keeper-style patterns (safety comes from the fixed recipient / re-validated proposal state, not caller identity), not flagged as bugs — that's existing, working behavior.
- **Every entrypoint that performs a cross-contract call** now has an explicit `# Cross-contract call` note, per the issue's requirement (given the separately-tracked reentrancy concerns): `lock_funds`, `release_funds`, `claim`, `partial_release`, `refund`, `sweep_expired_refunds`, `batch_lock_funds`, `batch_release_funds` (token transfers), `get_balance` (read-only token balance query), and `execute_governance_proposal` (governance contract call).
- `lock_funds`, as the primary value-entry point, also got parameter unit/precision notes (token's smallest unit, deadline as a Unix timestamp) and an explicit error list.
- The ~28 remaining pure read-only query/getter functions (`get_*`, `query_*`, `count_*`) each got a one-line `# Authorization: None — callable by anyone (read-only query).` note for completeness.

No production code paths were touched — this is comments-only, as the issue requires ("this is a documentation pass, not a behavior change").

## Test plan

```
$ cargo build -p bounty-escrow
Finished `dev` profile [unoptimized] target(s) in 1.68s   # same pre-existing dead-code warnings as baseline, no new ones

$ cargo test -p bounty-escrow
test result: ok. 531 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 39.70s   # identical count to baseline — doc-only change

$ cargo doc -p bounty-escrow --no-deps
Finished `dev` profile [unoptimized] target(s) in 8.81s   # 0 warnings, matching the clean baseline (also verified via git stash)
```

## Note

This branch is independent (based directly on `main-synced`), since this issue doesn't overlap the other in-flight PRs (#414, #415, #416).