### PR TITLE
fix(grainlify-core): fix setup_test tuple-arity mismatch breaking test compilation

### DIFF
--- a/grainlify-core/src/governance.rs
+++ b/grainlify-core/src/governance.rs
@@ -858,7 +858,8 @@ mod test {
     #[test]
     fn test_sweep_expired_proposal_strictly_before_voting_end_rejected() {
         let env = Env::default();
-        let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+        let (client, _, proposer, _) =
+            setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
         let prop_id = create_test_proposal(&env, &client, &proposer);
 
         // Proposal voting_end is created_at (0) + voting_period (100) = 100.
@@ -876,7 +877,8 @@ mod test {
     #[test]
     fn test_sweep_expired_proposal_exact_voting_end_boundary_rejected() {
         let env = Env::default();
-        let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+        let (client, _, proposer, _) =
+            setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
         let prop_id = create_test_proposal(&env, &client, &proposer);
 
         // Proposal voting_end is created_at (0) + voting_period (100) = 100.
@@ -894,7 +896,8 @@ mod test {
     #[test]
     fn test_sweep_expired_proposal_one_second_past_voting_end_succeeds() {
         let env = Env::default();
-        let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+        let (client, _, proposer, _) =
+            setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
         let prop_id = create_test_proposal(&env, &client, &proposer);
 
         // Proposal voting_end is created_at (0) + voting_period (100) = 100.
@@ -912,7 +915,7 @@ mod test {
 #[test]
 fn test_sweep_expired_proposal_nonexistent_fails() {
     let env = Env::default();
-    let (client, _, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, _, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let non_existent_id = 999;
 
     let result = client.try_sweep_expired_proposal(&non_existent_id, &150);
@@ -922,7 +925,7 @@ fn test_sweep_expired_proposal_nonexistent_fails() {
 #[test]
 fn test_sweep_expired_proposal_already_expired_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     // First sweep after expiry
@@ -942,7 +945,7 @@ fn test_sweep_expired_proposal_already_expired_fails() {
 #[test]
 fn test_sweep_expired_proposal_already_finalized_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 2);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 2);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     // Vote and finalize the proposal
@@ -962,7 +965,7 @@ fn test_sweep_expired_proposal_already_finalized_fails() {
 #[test]
 fn test_cancel_proposal_success() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     let result = client.try_cancel_proposal(&proposer, &prop_id);
@@ -993,7 +996,7 @@ fn test_cancel_proposal_success() {
 #[test]
 fn test_cancel_proposal_unauthorized() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
     let unauthorized = Address::generate(&env);
 
@@ -1009,7 +1012,7 @@ fn test_cancel_proposal_unauthorized() {
 #[test]
 fn test_cancel_proposal_after_passing_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     client.cast_vote(&proposer, &prop_id, &VoteType::For);
@@ -1024,7 +1027,7 @@ fn test_cancel_proposal_after_passing_fails() {
 #[test]
 fn test_cancel_proposal_already_cancelled_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     client.cancel_proposal(&proposer, &prop_id);
@@ -1036,7 +1039,7 @@ fn test_cancel_proposal_already_cancelled_fails() {
 #[test]
 fn test_cancel_proposal_wrong_proposal_id_returns_unauthorized() {
     let env = Env::default();
-    let (client, _, proposer1) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer1, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let proposer2 = Address::generate(&env);
     let _prop1 = create_test_proposal(&env, &client, &proposer1);
     let prop2 = create_test_proposal(&env, &client, &proposer2);
@@ -1051,7 +1054,7 @@ fn test_cancel_proposal_wrong_proposal_id_returns_unauthorized() {
 #[test]
 fn test_cancel_proposal_after_rejection_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 3);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 3);
     let voter2 = Address::generate(&env);
     let voter3 = Address::generate(&env);
     let prop_id = create_test_proposal(&env, &client, &proposer);
@@ -1071,7 +1074,7 @@ fn test_cancel_proposal_after_rejection_fails() {
 #[test]
 fn test_cancel_proposal_after_sweep_expired_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     let current_time = 150;
@@ -1088,7 +1091,7 @@ fn test_cancel_proposal_after_sweep_expired_fails() {
 #[test]
 fn test_cross_contract_auth_scope_minimal() {
     let env = Env::default();
-    let (client, token_admin_client, proposer) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
+    let (client, token_admin_client, proposer, _) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
     let token_admin_client = token_admin_client.unwrap();
 
     token_admin_client.mint(&proposer, &50);
@@ -1131,7 +1134,7 @@ fn test_cross_contract_auth_scope_minimal() {
 #[test]
 fn test_edge_case_vote_weight_overflow() {
     let env = Env::default();
-    let (client, token_admin_client, proposer) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
+    let (client, token_admin_client, proposer, _) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
     let token_admin_client = token_admin_client.unwrap();
 
     let voter1 = Address::generate(&env);


### PR DESCRIPTION
## Summary

Not tied to a specific issue number — discovered while working on #179 (adding proposal lifecycle tests to `grainlify-core/src/governance.rs`), which requires running `cargo test -p grainlify-core` to verify new tests.

`grainlify-core/src/governance.rs`'s `setup_test()` test helper returns a 4-element tuple `(GovernanceContractClient, Option<StellarAssetClient>, Address, Address)` — `(client, token_admin_client, user, contract_id)`. 15 tests (apparently added after a later refactor added the 4th `contract_id` element) still destructure only 3 elements, e.g.:

```rust
let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
```

This is a hard compile error (`E0308: mismatched types ... expected a tuple with 4 elements, found one with 3 elements`), not a runtime bug — `cargo test -p grainlify-core` currently fails to even **compile** on `main`, so the crate's entire test suite is unrunnable.

## Fix

Adds the missing `_` for the 4th (`contract_id`) tuple element at all 15 call sites, matching the destructuring style already used by the other tests in the same file that do compile (e.g. `let (client, _, user, _) = setup_test(...)`).

Also applied `cargo fmt`'s expected line-wrap to the 3 call sites where adding the extra `_,` pushed the line past the wrap width, so `cargo fmt --check` doesn't gain any new diffs from this fix (verified against baseline via a worktree checkout — diff count is unchanged at 12, all pre-existing/unrelated).

## Test plan

```
$ cargo test -p grainlify-core
test result: FAILED. 97 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.23s
```

97/98 tests now compile and pass. The one remaining failure, `test::test_upgrade_replay_guard_and_rescheduling` in `grainlify-core/src/lib.rs`, is unrelated to this fix — it lives in a completely different file, calls `env.deployer().upload_contract_wasm([].as_slice())` with an empty/invalid WASM byte slice, and fails for that reason regardless of this change. Left alone as out of scope here; flagging it in case it's worth its own follow-up.

`cargo fmt --check -p grainlify-core`: diff count in `governance.rs` unchanged from baseline (12), confirmed via a `main`-based worktree checkout.