### PR TITLE
test(grainlify-core): add end-to-end proposal lifecycle tests to governance.rs

### DIFF
--- a/grainlify-core/src/governance.rs
+++ b/grainlify-core/src/governance.rs
@@ -1159,4 +1159,140 @@ fn test_edge_case_vote_weight_overflow() {
     let res2 = client.try_cast_vote(&voter2, &prop_id, &VoteType::For);
     assert_eq!(res2, Err(Ok(Error::VoteWeightOverflow)));
 }
+
+// =============================================================================
+// Proposal lifecycle (Issue #179)
+// =============================================================================
+// A single end-to-end happy-path test plus one dedicated test per rejection
+// branch: double-voting and voting-after-expiry are already covered above by
+// test_edge_case_double_voting and test_edge_case_voting_after_expiration
+// respectively; the two tests below cover the remaining gap — execution
+// attempted before quorum/approval, and execution of an already-executed
+// proposal — which nothing in this file previously exercised (ProposalStatus
+// never reached Executed in any existing test's assertions).
+
+/// Full propose -> vote to quorum -> finalize -> execute lifecycle, asserting
+/// the proposal's status transitions at every step (Active -> Approved ->
+/// Executed), not just that each call returns Ok.
+#[test]
+fn test_proposal_lifecycle_happy_path_create_vote_execute() {
+    let env = Env::default();
+    // quorum 50%, 3 total one-person-one-vote voters, approval_threshold fixed
+    // at 5000 (50%) by setup_test, execution_delay fixed at 0.
+    let (client, _, proposer, _) =
+        setup_test(&env, VotingScheme::OnePersonOneVote, 5000, 0, 3);
+    let voter_a = Address::generate(&env);
+    let voter_b = Address::generate(&env);
+
+    let prop_id = create_test_proposal(&env, &client, &proposer);
+    assert_eq!(
+        client.get_proposal_status(&prop_id),
+        ProposalStatus::Active
+    );
+
+    // 2 of 3 voters vote For: total_cast/total_power = 2/3 (~66%) clears the
+    // 50% quorum, and 2/2 approval votes clears the 50% approval threshold.
+    client.cast_vote(&voter_a, &prop_id, &VoteType::For);
+    client.cast_vote(&voter_b, &prop_id, &VoteType::For);
+    assert_eq!(
+        client.get_proposal_status(&prop_id),
+        ProposalStatus::Active,
+        "status must not change until finalize_proposal runs"
+    );
+
+    // voting_period is fixed at 100 by setup_test.
+    env.ledger().with_mut(|li| li.timestamp = 101);
+    assert_eq!(
+        client.finalize_proposal(&prop_id),
+        ProposalStatus::Approved
+    );
+    assert_eq!(
+        client.get_proposal_status(&prop_id),
+        ProposalStatus::Approved
+    );
+
+    // execution_delay is fixed at 0 by setup_test, so executable_at == voting_end (100).
+    client.execute_proposal(&prop_id);
+    assert_eq!(
+        client.get_proposal_status(&prop_id),
+        ProposalStatus::Executed
+    );
+}
+
+/// Execution attempted before the proposal has quorum/approval must be
+/// rejected with ProposalNotApproved — both while voting is freshly open
+/// (Active, no votes) and after votes are in but before finalize_proposal
+/// has run (still Active, not yet Approved).
+#[test]
+fn test_proposal_lifecycle_rejects_execute_before_quorum() {
+    let env = Env::default();
+    let (client, _, proposer, _) =
+        setup_test(&env, VotingScheme::OnePersonOneVote, 5000, 0, 3);
+    let voter_a = Address::generate(&env);
+    let voter_b = Address::generate(&env);
+
+    let prop_id = create_test_proposal(&env, &client, &proposer);
+
+    // Freshly created, no votes at all.
+    assert_eq!(
+        client.try_execute_proposal(&prop_id),
+        Err(Ok(Error::ProposalNotApproved))
+    );
+    assert_eq!(
+        client.get_proposal_status(&prop_id),
+        ProposalStatus::Active
+    );
+
+    // Quorum-worthy votes are in, but finalize_proposal hasn't run yet, so
+    // status is still Active rather than Approved.
+    client.cast_vote(&voter_a, &prop_id, &VoteType::For);
+    client.cast_vote(&voter_b, &prop_id, &VoteType::For);
+    assert_eq!(
+        client.try_execute_proposal(&prop_id),
+        Err(Ok(Error::ProposalNotApproved))
+    );
+    assert_eq!(
+        client.get_proposal_status(&prop_id),
+        ProposalStatus::Active
+    );
+}
+
+/// Once a proposal has been executed, a second execute_proposal call must be
+/// rejected — the proposal's status has already moved past Approved to
+/// Executed, so it fails the same ProposalNotApproved check as an
+/// unapproved proposal, not some separate "already executed" error.
+#[test]
+fn test_proposal_lifecycle_rejects_executing_already_executed_proposal() {
+    let env = Env::default();
+    let (client, _, proposer, _) =
+        setup_test(&env, VotingScheme::OnePersonOneVote, 5000, 0, 3);
+    let voter_a = Address::generate(&env);
+    let voter_b = Address::generate(&env);
+
+    let prop_id = create_test_proposal(&env, &client, &proposer);
+    client.cast_vote(&voter_a, &prop_id, &VoteType::For);
+    client.cast_vote(&voter_b, &prop_id, &VoteType::For);
+
+    env.ledger().with_mut(|li| li.timestamp = 101);
+    assert_eq!(
+        client.finalize_proposal(&prop_id),
+        ProposalStatus::Approved
+    );
+
+    client.execute_proposal(&prop_id);
+    assert_eq!(
+        client.get_proposal_status(&prop_id),
+        ProposalStatus::Executed
+    );
+
+    assert_eq!(
+        client.try_execute_proposal(&prop_id),
+        Err(Ok(Error::ProposalNotApproved))
+    );
+    // Still Executed, not reverted or otherwise mutated by the rejected retry.
+    assert_eq!(
+        client.get_proposal_status(&prop_id),
+        ProposalStatus::Executed
+    );
+}
 }

--- a/grainlify-core/src/governance.rs
+++ b/grainlify-core/src/governance.rs
@@ -858,7 +858,8 @@ mod test {
     #[test]
     fn test_sweep_expired_proposal_strictly_before_voting_end_rejected() {
         let env = Env::default();
-        let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+        let (client, _, proposer, _) =
+            setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
         let prop_id = create_test_proposal(&env, &client, &proposer);
 
         // Proposal voting_end is created_at (0) + voting_period (100) = 100.
@@ -876,7 +877,8 @@ mod test {
     #[test]
     fn test_sweep_expired_proposal_exact_voting_end_boundary_rejected() {
         let env = Env::default();
-        let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+        let (client, _, proposer, _) =
+            setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
         let prop_id = create_test_proposal(&env, &client, &proposer);
 
         // Proposal voting_end is created_at (0) + voting_period (100) = 100.
@@ -894,7 +896,8 @@ mod test {
     #[test]
     fn test_sweep_expired_proposal_one_second_past_voting_end_succeeds() {
         let env = Env::default();
-        let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+        let (client, _, proposer, _) =
+            setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
         let prop_id = create_test_proposal(&env, &client, &proposer);
 
         // Proposal voting_end is created_at (0) + voting_period (100) = 100.
@@ -912,7 +915,7 @@ mod test {
 #[test]
 fn test_sweep_expired_proposal_nonexistent_fails() {
     let env = Env::default();
-    let (client, _, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, _, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let non_existent_id = 999;
 
     let result = client.try_sweep_expired_proposal(&non_existent_id, &150);
@@ -922,7 +925,7 @@ fn test_sweep_expired_proposal_nonexistent_fails() {
 #[test]
 fn test_sweep_expired_proposal_already_expired_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     // First sweep after expiry
@@ -942,7 +945,7 @@ fn test_sweep_expired_proposal_already_expired_fails() {
 #[test]
 fn test_sweep_expired_proposal_already_finalized_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 2);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 2);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     // Vote and finalize the proposal
@@ -962,7 +965,7 @@ fn test_sweep_expired_proposal_already_finalized_fails() {
 #[test]
 fn test_cancel_proposal_success() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     let result = client.try_cancel_proposal(&proposer, &prop_id);
@@ -993,7 +996,7 @@ fn test_cancel_proposal_success() {
 #[test]
 fn test_cancel_proposal_unauthorized() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
     let unauthorized = Address::generate(&env);
 
@@ -1009,7 +1012,7 @@ fn test_cancel_proposal_unauthorized() {
 #[test]
 fn test_cancel_proposal_after_passing_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     client.cast_vote(&proposer, &prop_id, &VoteType::For);
@@ -1024,7 +1027,7 @@ fn test_cancel_proposal_after_passing_fails() {
 #[test]
 fn test_cancel_proposal_already_cancelled_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     client.cancel_proposal(&proposer, &prop_id);
@@ -1036,7 +1039,7 @@ fn test_cancel_proposal_already_cancelled_fails() {
 #[test]
 fn test_cancel_proposal_wrong_proposal_id_returns_unauthorized() {
     let env = Env::default();
-    let (client, _, proposer1) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer1, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let proposer2 = Address::generate(&env);
     let _prop1 = create_test_proposal(&env, &client, &proposer1);
     let prop2 = create_test_proposal(&env, &client, &proposer2);
@@ -1051,7 +1054,7 @@ fn test_cancel_proposal_wrong_proposal_id_returns_unauthorized() {
 #[test]
 fn test_cancel_proposal_after_rejection_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 3);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 3);
     let voter2 = Address::generate(&env);
     let voter3 = Address::generate(&env);
     let prop_id = create_test_proposal(&env, &client, &proposer);
@@ -1071,7 +1074,7 @@ fn test_cancel_proposal_after_rejection_fails() {
 #[test]
 fn test_cancel_proposal_after_sweep_expired_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     let current_time = 150;
@@ -1088,7 +1091,7 @@ fn test_cancel_proposal_after_sweep_expired_fails() {
 #[test]
 fn test_cross_contract_auth_scope_minimal() {
     let env = Env::default();
-    let (client, token_admin_client, proposer) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
+    let (client, token_admin_client, proposer, _) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
     let token_admin_client = token_admin_client.unwrap();
 
     token_admin_client.mint(&proposer, &50);
@@ -1131,7 +1134,7 @@ fn test_cross_contract_auth_scope_minimal() {
 #[test]
 fn test_edge_case_vote_weight_overflow() {
     let env = Env::default();
-    let (client, token_admin_client, proposer) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
+    let (client, token_admin_client, proposer, _) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
     let token_admin_client = token_admin_client.unwrap();
 
     let voter1 = Address::generate(&env);


### PR DESCRIPTION
## Summary

Closes #179

Adds `test_proposal_lifecycle_happy_path_create_vote_execute`: a single test covering the full create → vote to quorum → finalize → execute path, asserting `ProposalStatus` transitions (`Active` → `Approved` → `Executed`) via `get_proposal_status` at every step, not just that each call returns `Ok`.

Adds the two rejection-branch tests that were genuinely missing — nothing in this file previously drove a proposal all the way to `Executed`, or asserted `Error::ProposalNotApproved` at all:
- `test_proposal_lifecycle_rejects_execute_before_quorum` — execution attempted both on a freshly-created proposal (no votes) and after quorum-worthy votes are cast but before `finalize_proposal` has run.
- `test_proposal_lifecycle_rejects_executing_already_executed_proposal` — execution attempted a second time after the first succeeded, confirming the retry is rejected and the proposal stays `Executed` rather than being mutated.

## What's covered vs. what already existed

- [x] Full happy-path lifecycle, one test.
- [x] Execute-before-quorum rejection — new.
- [x] Execute-an-already-executed-proposal rejection — new.
- [x] Double-voting rejection — already covered by the pre-existing `test_edge_case_double_voting`; no new test added to avoid redundant coverage.
- [x] Voting-after-expiry rejection — already covered by the pre-existing `test_edge_case_voting_after_expiration`; no new test added to avoid redundant coverage.

## Test plan

```
$ cargo test -p grainlify-core -- proposal_lifecycle
test governance::test::test_proposal_lifecycle_rejects_execute_before_quorum ... ok
test governance::test::test_proposal_lifecycle_happy_path_create_vote_execute ... ok
test governance::test::test_proposal_lifecycle_rejects_executing_already_executed_proposal ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 98 filtered out; finished in 0.08s

$ cargo test -p grainlify-core
test result: FAILED. 100 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.49s
```

100/101 pass (97 pre-existing + 3 new). The one failure, `test_upgrade_replay_guard_and_rescheduling`, is pre-existing and unrelated (lives in `lib.rs`, fails on an invalid empty-byte-slice WASM upload) — see the base PR below.

`cargo fmt --check -p grainlify-core`: diff count in `governance.rs` unchanged from the branch this stacks on (12).
`cargo clippy -p grainlify-core --tests`: warning count unchanged from the branch this stacks on (28), no new warnings in the added tests.

## Note

This branch is stacked on #418 (`fix/governance-rs-setup-test-arity-mismatch`), which is a required prerequisite: `cargo test -p grainlify-core` does not even **compile** on `main` today due to an unrelated pre-existing tuple-arity bug in this same file's test helper usage. Both PRs target `main` since I don't have push access to open a PR against a non-`main` base on the upstream org repo; if #418 merges first, this PR's diff against `main` will shrink to just this PR's own changes.