### PR TITLE
fix(grainlify-core): require caller to be a current signer in multisig remove_signer

### DIFF
--- a/grainlify-core/src/governance.rs
+++ b/grainlify-core/src/governance.rs
@@ -858,7 +858,8 @@ mod test {
     #[test]
     fn test_sweep_expired_proposal_strictly_before_voting_end_rejected() {
         let env = Env::default();
-        let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+        let (client, _, proposer, _) =
+            setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
         let prop_id = create_test_proposal(&env, &client, &proposer);
 
         // Proposal voting_end is created_at (0) + voting_period (100) = 100.
@@ -876,7 +877,8 @@ mod test {
     #[test]
     fn test_sweep_expired_proposal_exact_voting_end_boundary_rejected() {
         let env = Env::default();
-        let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+        let (client, _, proposer, _) =
+            setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
         let prop_id = create_test_proposal(&env, &client, &proposer);
 
         // Proposal voting_end is created_at (0) + voting_period (100) = 100.
@@ -894,7 +896,8 @@ mod test {
     #[test]
     fn test_sweep_expired_proposal_one_second_past_voting_end_succeeds() {
         let env = Env::default();
-        let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+        let (client, _, proposer, _) =
+            setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
         let prop_id = create_test_proposal(&env, &client, &proposer);
 
         // Proposal voting_end is created_at (0) + voting_period (100) = 100.
@@ -912,7 +915,7 @@ mod test {
 #[test]
 fn test_sweep_expired_proposal_nonexistent_fails() {
     let env = Env::default();
-    let (client, _, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, _, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let non_existent_id = 999;
 
     let result = client.try_sweep_expired_proposal(&non_existent_id, &150);
@@ -922,7 +925,7 @@ fn test_sweep_expired_proposal_nonexistent_fails() {
 #[test]
 fn test_sweep_expired_proposal_already_expired_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     // First sweep after expiry
@@ -942,7 +945,7 @@ fn test_sweep_expired_proposal_already_expired_fails() {
 #[test]
 fn test_sweep_expired_proposal_already_finalized_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 2);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 2);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     // Vote and finalize the proposal
@@ -962,7 +965,7 @@ fn test_sweep_expired_proposal_already_finalized_fails() {
 #[test]
 fn test_cancel_proposal_success() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     let result = client.try_cancel_proposal(&proposer, &prop_id);
@@ -993,7 +996,7 @@ fn test_cancel_proposal_success() {
 #[test]
 fn test_cancel_proposal_unauthorized() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
     let unauthorized = Address::generate(&env);
 
@@ -1009,7 +1012,7 @@ fn test_cancel_proposal_unauthorized() {
 #[test]
 fn test_cancel_proposal_after_passing_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     client.cast_vote(&proposer, &prop_id, &VoteType::For);
@@ -1024,7 +1027,7 @@ fn test_cancel_proposal_after_passing_fails() {
 #[test]
 fn test_cancel_proposal_already_cancelled_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     client.cancel_proposal(&proposer, &prop_id);
@@ -1036,7 +1039,7 @@ fn test_cancel_proposal_already_cancelled_fails() {
 #[test]
 fn test_cancel_proposal_wrong_proposal_id_returns_unauthorized() {
     let env = Env::default();
-    let (client, _, proposer1) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer1, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let proposer2 = Address::generate(&env);
     let _prop1 = create_test_proposal(&env, &client, &proposer1);
     let prop2 = create_test_proposal(&env, &client, &proposer2);
@@ -1051,7 +1054,7 @@ fn test_cancel_proposal_wrong_proposal_id_returns_unauthorized() {
 #[test]
 fn test_cancel_proposal_after_rejection_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 3);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 3);
     let voter2 = Address::generate(&env);
     let voter3 = Address::generate(&env);
     let prop_id = create_test_proposal(&env, &client, &proposer);
@@ -1071,7 +1074,7 @@ fn test_cancel_proposal_after_rejection_fails() {
 #[test]
 fn test_cancel_proposal_after_sweep_expired_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     let current_time = 150;
@@ -1088,7 +1091,7 @@ fn test_cancel_proposal_after_sweep_expired_fails() {
 #[test]
 fn test_cross_contract_auth_scope_minimal() {
     let env = Env::default();
-    let (client, token_admin_client, proposer) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
+    let (client, token_admin_client, proposer, _) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
     let token_admin_client = token_admin_client.unwrap();
 
     token_admin_client.mint(&proposer, &50);
@@ -1131,7 +1134,7 @@ fn test_cross_contract_auth_scope_minimal() {
 #[test]
 fn test_edge_case_vote_weight_overflow() {
     let env = Env::default();
-    let (client, token_admin_client, proposer) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
+    let (client, token_admin_client, proposer, _) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
     let token_admin_client = token_admin_client.unwrap();
 
     let voter1 = Address::generate(&env);

--- a/grainlify-core/src/lib.rs
+++ b/grainlify-core/src/lib.rs
@@ -98,7 +98,7 @@
 //! | `MultiSig::nonce(env)` | Returns the next expected execution nonce (replay protection). |
 //! | `MultiSig::execute(env, proposal_id, expected_action, expected_nonce, closure)` | Atomically verifies threshold, payload, and nonce, runs the provided closure (the WASM update), marks the proposal executed, and increments the nonce. |
 //! | `MultiSig::get_action(env, proposal_id)` | Returns the `ProposalAction` bound to a proposal. |
-//! | `MultiSig::remove_signer(env, caller, signer_to_remove)` | Removes a signer; rejected if `(signer_count - 1) < threshold` to prevent permanent lockout. |
+//! | `MultiSig::remove_signer(env, caller, signer_to_remove)` | Removes a signer; `caller` must itself be a current signer (self-governing set, same rule as `propose`/`approve`), and the removal is rejected if `(signer_count - 1) < threshold` to prevent permanent lockout. |
 //!
 //! ### Key properties
 //!
@@ -947,7 +947,9 @@ impl GrainlifyContract {
     ///
     /// # Arguments
     /// * `env` - The contract environment
-    /// * `caller` - Address authorising the removal (must sign the transaction)
+    /// * `caller` - Address authorising the removal. Must both sign the
+    ///   transaction *and* be a current member of the signer set — this is a
+    ///   self-governing multisig, not admin-gated.
     /// * `signer_to_remove` - The signer address to remove from the set
     pub fn remove_signer(env: Env, caller: Address, signer_to_remove: Address) {
         MultiSig::remove_signer(&env, caller, signer_to_remove);

--- a/grainlify-core/src/multisig.rs
+++ b/grainlify-core/src/multisig.rs
@@ -249,6 +249,13 @@ impl MultiSig {
 
     /// Remove a signer from the multisig configuration.
     ///
+    /// # Access model
+    /// `MultiSigConfig` has no separate "admin" concept — it is a
+    /// self-governing signer set, the same as `propose`/`approve`. Any
+    /// *current signer* may remove any other signer (including, if they
+    /// choose, themself); `caller` must be a member of `config.signers`, not
+    /// merely an address that can authorize its own transaction.
+    ///
     /// # Pre-condition: threshold viability guard
     /// The removal is rejected with [`MultiSigError::RemovalWouldBreakThreshold`]
     /// if `(current_signer_count - 1) < threshold`.  This prevents an admin
@@ -257,14 +264,20 @@ impl MultiSig {
     /// permanently lock any funds or actions protected by the multisig.
     ///
     /// # Errors
-    /// - Panics with `NotSigner` if `signer_to_remove` is not in the current
-    ///   signer set.
+    /// - Panics with `NotSigner` if `caller` is not a current signer, or if
+    ///   `signer_to_remove` is not in the current signer set.
     /// - Panics with `RemovalWouldBreakThreshold` if the removal would leave
     ///   fewer signers than the configured threshold.
     pub fn remove_signer(env: &Env, caller: Address, signer_to_remove: Address) {
         caller.require_auth();
 
         let mut config = Self::get_config(env);
+
+        // `require_auth()` above only proves `caller` authorized this specific
+        // invocation as itself — it does not prove `caller` is a configured
+        // signer. Without this check, any outside address could evict a
+        // legitimate signer by simply calling this with itself as `caller`.
+        Self::assert_signer(&config, &caller);
 
         // Verify the address to be removed is actually a current signer.
         if !config.signers.contains(&signer_to_remove) {
@@ -1272,6 +1285,67 @@ mod test {
 
             // Removing signer_b would leave 1 signer < threshold=2 → must panic.
             MultiSig::remove_signer(&setup.env, setup.signer_a.clone(), setup.signer_b.clone());
+        });
+    }
+
+    /// A caller who is not a configured signer must not be able to remove a
+    /// signer, even though `mock_all_auths` lets it trivially authorize its
+    /// own transaction — `require_auth()` alone must not be mistaken for a
+    /// signer-membership check.
+    #[test]
+    #[should_panic(expected = "NotSigner")]
+    fn remove_signer_rejects_non_signer_caller_even_when_self_authorized() {
+        let setup = setup();
+        let attacker = Address::generate(&setup.env);
+
+        setup.env.as_contract(&setup.contract_id, || {
+            let three_signers = addr_vec(
+                &setup.env,
+                &[&setup.signer_a, &setup.signer_b, &setup.signer_c],
+            );
+            MultiSig::init(&setup.env, three_signers, 2);
+
+            // `attacker` is not in the signer set, but mock_all_auths lets it
+            // sign for itself trivially — the call must still be rejected.
+            MultiSig::remove_signer(&setup.env, attacker, setup.signer_c.clone());
+        });
+    }
+
+    /// Complementary positive case: a legitimate signer's removal call is
+    /// unaffected by the new signer-membership check, and the config is
+    /// unchanged after the non-signer attack above was rejected.
+    #[test]
+    fn remove_signer_rejects_non_signer_then_succeeds_for_legitimate_signer() {
+        let setup = setup();
+        let attacker = Address::generate(&setup.env);
+
+        setup.env.as_contract(&setup.contract_id, || {
+            let three_signers = addr_vec(
+                &setup.env,
+                &[&setup.signer_a, &setup.signer_b, &setup.signer_c],
+            );
+            MultiSig::init(&setup.env, three_signers, 2);
+
+            let attacker_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                MultiSig::remove_signer(&setup.env, attacker.clone(), setup.signer_c.clone());
+            }));
+            assert!(
+                attacker_result.is_err(),
+                "non-signer caller must be rejected"
+            );
+
+            let config = MultiSig::get_config(&setup.env);
+            assert_eq!(
+                config.signers.len(),
+                3,
+                "rejected attacker call must not mutate the signer set"
+            );
+
+            // A legitimate signer performs the same removal successfully.
+            MultiSig::remove_signer(&setup.env, setup.signer_a.clone(), setup.signer_c.clone());
+            let config = MultiSig::get_config(&setup.env);
+            assert_eq!(config.signers.len(), 2);
+            assert!(!config.signers.contains(&setup.signer_c));
         });
     }
 


### PR DESCRIPTION
## Summary

Closes #383

`MultiSig::remove_signer` only called `caller.require_auth()`, which proves `caller` authorized this specific invocation as itself — it does **not** prove `caller` is one of the configured `config.signers`. Unlike `propose`/`approve` (which both call `Self::assert_signer` before doing anything), `remove_signer` had no signer-membership check at all.

Any outside address could call `remove_signer(caller: <its own address>, signer_to_remove: <any real signer>)`, trivially self-authorize (it's the attacker's own key), and evict a legitimate signer, so long as the remaining count stayed `>= threshold`. Repeated calls let a non-signer grief the multisig down toward its threshold, eventually freezing all future quorum.

## Fix

- Adds `Self::assert_signer(&config, &caller)` right after `require_auth()` in `remove_signer`, matching the pattern already used by `propose`/`approve`.
- `MultiSigConfig` has no separate admin concept, so per the issue's request to "audit whether the intended access model is... and document the decision," the chosen (and now documented) model is: **any current signer may remove any other signer** — the same self-governing rule as `propose`/`approve`, not admin-gated.
- Updates the doc comments on both `MultiSig::remove_signer` and `GrainlifyContract::remove_signer` (in `lib.rs`), plus the module-level public-interface table, to state this explicitly.

## What's covered

- [x] A caller who is not in `config.signers` cannot remove any signer, even though they can authorize their own transaction — `remove_signer_rejects_non_signer_caller_even_when_self_authorized` (new).
- [x] A legitimate signer can still remove another signer when the post-removal count stays `>= threshold` — `remove_signer_rejects_non_signer_then_succeeds_for_legitimate_signer` (new) plus the pre-existing `remove_signer_normal_above_threshold_succeeds` and `remove_signer_boundary_exactly_at_threshold_is_allowed`, unaffected by this change.
- [x] The `RemovalWouldBreakThreshold` guard continues to function for authorized callers — pre-existing `remove_signer_below_threshold_is_rejected` still passes unmodified.

## Test plan

```
$ cargo test -p grainlify-core -- remove_signer
test multisig::test::remove_signer_below_threshold_is_rejected - should panic ... ok
test multisig::test::remove_signer_rejects_non_signer_caller_even_when_self_authorized - should panic ... ok
test multisig::test::remove_signer_normal_above_threshold_succeeds ... ok
test multisig::test::remove_signer_boundary_exactly_at_threshold_is_allowed ... ok
test multisig::test::remove_signer_rejects_non_signer_then_succeeds_for_legitimate_signer ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 95 filtered out; finished in 0.03s

$ cargo test -p grainlify-core
test result: FAILED. 99 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.21s
```

99/100 pass (97 pre-existing + 2 new). The one failure, `test_upgrade_replay_guard_and_rescheduling`, is pre-existing and unrelated (see the base PR below).

`cargo fmt --check -p grainlify-core`: diff count across the whole crate unchanged from baseline (46), verified via a worktree checkout of the base branch.
`cargo clippy -p grainlify-core --tests`: warning count unchanged from baseline (28).

## Note

This branch is stacked on #418 (`fix/governance-rs-setup-test-arity-mismatch`), a required prerequisite — `cargo test -p grainlify-core` doesn't compile on `main` without it. Both PRs target `main` since I don't have push access to open a PR against a non-`main` base on the upstream org repo. #384 (exposing `add_signer`/`rotate_signers` as entrypoints) will stack on top of this one, applying the same `assert_signer` check to those two functions as they're newly exposed.