### PR TITLE
feat(grainlify-core): expose add_signer and rotate_signers as contract entrypoints

### DIFF
--- a/grainlify-core/src/governance.rs
+++ b/grainlify-core/src/governance.rs
@@ -858,7 +858,8 @@ mod test {
     #[test]
     fn test_sweep_expired_proposal_strictly_before_voting_end_rejected() {
         let env = Env::default();
-        let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+        let (client, _, proposer, _) =
+            setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
         let prop_id = create_test_proposal(&env, &client, &proposer);
 
         // Proposal voting_end is created_at (0) + voting_period (100) = 100.
@@ -876,7 +877,8 @@ mod test {
     #[test]
     fn test_sweep_expired_proposal_exact_voting_end_boundary_rejected() {
         let env = Env::default();
-        let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+        let (client, _, proposer, _) =
+            setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
         let prop_id = create_test_proposal(&env, &client, &proposer);
 
         // Proposal voting_end is created_at (0) + voting_period (100) = 100.
@@ -894,7 +896,8 @@ mod test {
     #[test]
     fn test_sweep_expired_proposal_one_second_past_voting_end_succeeds() {
         let env = Env::default();
-        let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+        let (client, _, proposer, _) =
+            setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
         let prop_id = create_test_proposal(&env, &client, &proposer);
 
         // Proposal voting_end is created_at (0) + voting_period (100) = 100.
@@ -912,7 +915,7 @@ mod test {
 #[test]
 fn test_sweep_expired_proposal_nonexistent_fails() {
     let env = Env::default();
-    let (client, _, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, _, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let non_existent_id = 999;
 
     let result = client.try_sweep_expired_proposal(&non_existent_id, &150);
@@ -922,7 +925,7 @@ fn test_sweep_expired_proposal_nonexistent_fails() {
 #[test]
 fn test_sweep_expired_proposal_already_expired_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     // First sweep after expiry
@@ -942,7 +945,7 @@ fn test_sweep_expired_proposal_already_expired_fails() {
 #[test]
 fn test_sweep_expired_proposal_already_finalized_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 2);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 2);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     // Vote and finalize the proposal
@@ -962,7 +965,7 @@ fn test_sweep_expired_proposal_already_finalized_fails() {
 #[test]
 fn test_cancel_proposal_success() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     let result = client.try_cancel_proposal(&proposer, &prop_id);
@@ -993,7 +996,7 @@ fn test_cancel_proposal_success() {
 #[test]
 fn test_cancel_proposal_unauthorized() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
     let unauthorized = Address::generate(&env);
 
@@ -1009,7 +1012,7 @@ fn test_cancel_proposal_unauthorized() {
 #[test]
 fn test_cancel_proposal_after_passing_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     client.cast_vote(&proposer, &prop_id, &VoteType::For);
@@ -1024,7 +1027,7 @@ fn test_cancel_proposal_after_passing_fails() {
 #[test]
 fn test_cancel_proposal_already_cancelled_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     client.cancel_proposal(&proposer, &prop_id);
@@ -1036,7 +1039,7 @@ fn test_cancel_proposal_already_cancelled_fails() {
 #[test]
 fn test_cancel_proposal_wrong_proposal_id_returns_unauthorized() {
     let env = Env::default();
-    let (client, _, proposer1) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer1, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let proposer2 = Address::generate(&env);
     let _prop1 = create_test_proposal(&env, &client, &proposer1);
     let prop2 = create_test_proposal(&env, &client, &proposer2);
@@ -1051,7 +1054,7 @@ fn test_cancel_proposal_wrong_proposal_id_returns_unauthorized() {
 #[test]
 fn test_cancel_proposal_after_rejection_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 3);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 3);
     let voter2 = Address::generate(&env);
     let voter3 = Address::generate(&env);
     let prop_id = create_test_proposal(&env, &client, &proposer);
@@ -1071,7 +1074,7 @@ fn test_cancel_proposal_after_rejection_fails() {
 #[test]
 fn test_cancel_proposal_after_sweep_expired_fails() {
     let env = Env::default();
-    let (client, _, proposer) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+    let (client, _, proposer, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
     let prop_id = create_test_proposal(&env, &client, &proposer);
 
     let current_time = 150;
@@ -1088,7 +1091,7 @@ fn test_cancel_proposal_after_sweep_expired_fails() {
 #[test]
 fn test_cross_contract_auth_scope_minimal() {
     let env = Env::default();
-    let (client, token_admin_client, proposer) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
+    let (client, token_admin_client, proposer, _) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
     let token_admin_client = token_admin_client.unwrap();
 
     token_admin_client.mint(&proposer, &50);
@@ -1131,7 +1134,7 @@ fn test_cross_contract_auth_scope_minimal() {
 #[test]
 fn test_edge_case_vote_weight_overflow() {
     let env = Env::default();
-    let (client, token_admin_client, proposer) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
+    let (client, token_admin_client, proposer, _) = setup_test(&env, VotingScheme::TokenWeighted, 1000, 10, 0);
     let token_admin_client = token_admin_client.unwrap();
 
     let voter1 = Address::generate(&env);

--- a/grainlify-core/src/lib.rs
+++ b/grainlify-core/src/lib.rs
@@ -98,7 +98,7 @@
 //! | `MultiSig::nonce(env)` | Returns the next expected execution nonce (replay protection). |
 //! | `MultiSig::execute(env, proposal_id, expected_action, expected_nonce, closure)` | Atomically verifies threshold, payload, and nonce, runs the provided closure (the WASM update), marks the proposal executed, and increments the nonce. |
 //! | `MultiSig::get_action(env, proposal_id)` | Returns the `ProposalAction` bound to a proposal. |
-//! | `MultiSig::remove_signer(env, caller, signer_to_remove)` | Removes a signer; rejected if `(signer_count - 1) < threshold` to prevent permanent lockout. |
+//! | `MultiSig::remove_signer(env, caller, signer_to_remove)` | Removes a signer; `caller` must itself be a current signer (self-governing set, same rule as `propose`/`approve`), and the removal is rejected if `(signer_count - 1) < threshold` to prevent permanent lockout. |
 //!
 //! ### Key properties
 //!
@@ -947,7 +947,9 @@ impl GrainlifyContract {
     ///
     /// # Arguments
     /// * `env` - The contract environment
-    /// * `caller` - Address authorising the removal (must sign the transaction)
+    /// * `caller` - Address authorising the removal. Must both sign the
+    ///   transaction *and* be a current member of the signer set — this is a
+    ///   self-governing multisig, not admin-gated.
     /// * `signer_to_remove` - The signer address to remove from the set
     pub fn remove_signer(env: Env, caller: Address, signer_to_remove: Address) {
         MultiSig::remove_signer(&env, caller, signer_to_remove);

--- a/grainlify-core/src/lib.rs
+++ b/grainlify-core/src/lib.rs
@@ -99,6 +99,8 @@
 //! | `MultiSig::execute(env, proposal_id, expected_action, expected_nonce, closure)` | Atomically verifies threshold, payload, and nonce, runs the provided closure (the WASM update), marks the proposal executed, and increments the nonce. |
 //! | `MultiSig::get_action(env, proposal_id)` | Returns the `ProposalAction` bound to a proposal. |
 //! | `MultiSig::remove_signer(env, caller, signer_to_remove)` | Removes a signer; `caller` must itself be a current signer (self-governing set, same rule as `propose`/`approve`), and the removal is rejected if `(signer_count - 1) < threshold` to prevent permanent lockout. |
+//! | `MultiSig::add_signer(env, caller, new_signer)` | Adds a signer; `caller` must itself be a current signer. Rejected with `AlreadySigner` if `new_signer` is already in the set. |
+//! | `MultiSig::rotate_signers(env, caller, add, remove, new_threshold)` | Adds/removes signers and optionally updates the threshold atomically; `caller` must itself be a current signer. Rejected if the resulting threshold is `0` or exceeds the resulting signer count. |
 //!
 //! ### Key properties
 //!
@@ -953,6 +955,43 @@ impl GrainlifyContract {
     /// * `signer_to_remove` - The signer address to remove from the set
     pub fn remove_signer(env: Env, caller: Address, signer_to_remove: Address) {
         MultiSig::remove_signer(&env, caller, signer_to_remove);
+    }
+
+    /// Add a new signer to the multisig configuration.
+    ///
+    /// Same self-governing access model as `remove_signer`: `caller` must
+    /// both sign the transaction and be a current member of the signer set.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `caller` - Address authorising the addition; must be a current signer
+    /// * `new_signer` - The signer address to add to the set
+    pub fn add_signer(env: Env, caller: Address, new_signer: Address) {
+        MultiSig::add_signer(&env, caller, new_signer);
+    }
+
+    /// Rotate signers and/or change the approval threshold in one call.
+    ///
+    /// Same self-governing access model as `remove_signer`/`add_signer`:
+    /// `caller` must both sign the transaction and be a current member of the
+    /// signer set. Removals are applied before additions; the resulting
+    /// threshold (after an optional `new_threshold` override) must be nonzero
+    /// and not exceed the resulting signer count.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `caller` - Address authorising the rotation; must be a current signer
+    /// * `add` - Signer addresses to add
+    /// * `remove` - Signer addresses to remove
+    /// * `new_threshold` - If `Some`, replaces the current approval threshold
+    pub fn rotate_signers(
+        env: Env,
+        caller: Address,
+        add: Vec<Address>,
+        remove: Vec<Address>,
+        new_threshold: Option<u32>,
+    ) {
+        MultiSig::rotate_signers(&env, caller, add, remove, new_threshold);
     }
 
     /// Returns the configured single-admin upgrade delay in seconds.

--- a/grainlify-core/src/multisig.rs
+++ b/grainlify-core/src/multisig.rs
@@ -311,10 +311,20 @@ impl MultiSig {
     }
 
     /// Add a new signer to the multisig configuration.
+    ///
+    /// # Access model
+    /// Same self-governing rule as `remove_signer`/`propose`/`approve`:
+    /// `caller` must be a current member of `config.signers`, not merely an
+    /// address that can authorize its own transaction.
+    ///
+    /// # Errors
+    /// - Panics with `NotSigner` if `caller` is not a current signer.
+    /// - Panics with `AlreadySigner` if `new_signer` is already in the set.
     pub fn add_signer(env: &Env, caller: Address, new_signer: Address) {
         caller.require_auth();
 
         let mut config = Self::get_config(env);
+        Self::assert_signer(&config, &caller);
 
         if config.signers.contains(&new_signer) {
             panic!("{:?}", MultiSigError::AlreadySigner);
@@ -330,6 +340,18 @@ impl MultiSig {
     }
 
     /// Rotate signers and/or change threshold simultaneously.
+    ///
+    /// # Access model
+    /// Same self-governing rule as `remove_signer`/`add_signer`: `caller`
+    /// must be a current member of `config.signers`, not merely an address
+    /// that can authorize its own transaction.
+    ///
+    /// # Errors
+    /// - Panics with `NotSigner` if `caller` is not a current signer, or if
+    ///   any address in `remove` is not in the current signer set.
+    /// - Panics with `AlreadySigner` if any address in `add` is already a signer.
+    /// - Panics with `RemovalWouldBreakThreshold` if the resulting threshold is
+    ///   `0` or exceeds the resulting signer count.
     pub fn rotate_signers(
         env: &Env,
         caller: Address,
@@ -339,6 +361,7 @@ impl MultiSig {
     ) {
         caller.require_auth();
         let mut config = Self::get_config(env);
+        Self::assert_signer(&config, &caller);
 
         // Process removals
         for signer_to_remove in remove.clone() {
@@ -454,7 +477,7 @@ impl MultiSig {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::GrainlifyContract;
+    use crate::{GrainlifyContract, GrainlifyContractClient};
     use soroban_sdk::{testutils::Address as _, testutils::Events, Env};
     extern crate std;
     use std::panic;
@@ -1634,5 +1657,126 @@ mod test {
 
         let events = setup.env.events().all();
         assert!(events.len() > 0);
+    }
+
+    // =========================================================================
+    // add_signer / rotate_signers external reachability (Issue #384)
+    // =========================================================================
+    // Every test above calls MultiSig::add_signer / MultiSig::rotate_signers
+    // directly inside env.as_contract(...), which only proves the internal
+    // associated functions work — it does not prove a deployed contract can
+    // ever reach them. These tests go through GrainlifyContractClient, the
+    // same generated client external callers actually use, proving the two
+    // functions are now real contract entrypoints, not just internally
+    // tested dead code.
+
+    /// add_signer is now callable through the generated contract client, not
+    /// just internally via MultiSig::, and emits the same SignerRot/add event.
+    #[test]
+    fn test_add_signer_reachable_through_contract_client() {
+        let setup = setup();
+        let client = GrainlifyContractClient::new(&setup.env, &setup.contract_id);
+        let new_signer = Address::generate(&setup.env);
+
+        setup.env.as_contract(&setup.contract_id, || {
+            MultiSig::init(
+                &setup.env,
+                signers(&setup.env, &setup.signer_a, &setup.signer_b),
+                2,
+            );
+        });
+
+        client.add_signer(&setup.signer_a, &new_signer);
+
+        let config = setup
+            .env
+            .as_contract(&setup.contract_id, || MultiSig::get_config(&setup.env));
+        assert_eq!(config.signers.len(), 3);
+        assert!(config.signers.contains(&new_signer));
+
+        let events = setup.env.events().all();
+        assert!(
+            !events.is_empty(),
+            "add_signer through the client must still emit SignerRot/add"
+        );
+    }
+
+    /// rotate_signers is now callable through the generated contract client,
+    /// not just internally via MultiSig::.
+    #[test]
+    fn test_rotate_signers_reachable_through_contract_client() {
+        let setup = setup();
+        let client = GrainlifyContractClient::new(&setup.env, &setup.contract_id);
+        let new_signer = Address::generate(&setup.env);
+
+        setup.env.as_contract(&setup.contract_id, || {
+            let three_signers = addr_vec(
+                &setup.env,
+                &[&setup.signer_a, &setup.signer_b, &setup.signer_c],
+            );
+            MultiSig::init(&setup.env, three_signers, 2);
+        });
+
+        let mut add_vec = Vec::new(&setup.env);
+        add_vec.push_back(new_signer.clone());
+        let mut rm_vec = Vec::new(&setup.env);
+        rm_vec.push_back(setup.signer_c.clone());
+
+        client.rotate_signers(&setup.signer_a, &add_vec, &rm_vec, &Some(2));
+
+        let config = setup
+            .env
+            .as_contract(&setup.contract_id, || MultiSig::get_config(&setup.env));
+        assert_eq!(
+            config.signers.len(),
+            3,
+            "removed signer_c, added new_signer: net unchanged"
+        );
+        assert!(config.signers.contains(&new_signer));
+        assert!(!config.signers.contains(&setup.signer_c));
+        assert_eq!(config.threshold, 2);
+    }
+
+    /// A caller who is not a configured signer must not be able to add a
+    /// signer, even though it can trivially self-authorize under
+    /// mock_all_auths — matching the same fix applied to remove_signer.
+    #[test]
+    #[should_panic(expected = "NotSigner")]
+    fn add_signer_rejects_non_signer_caller_even_when_self_authorized() {
+        let setup = setup();
+        let attacker = Address::generate(&setup.env);
+        let new_signer = Address::generate(&setup.env);
+
+        setup.env.as_contract(&setup.contract_id, || {
+            MultiSig::init(
+                &setup.env,
+                signers(&setup.env, &setup.signer_a, &setup.signer_b),
+                2,
+            );
+
+            MultiSig::add_signer(&setup.env, attacker, new_signer);
+        });
+    }
+
+    /// A caller who is not a configured signer must not be able to rotate
+    /// signers/threshold, even though it can trivially self-authorize under
+    /// mock_all_auths — matching the same fix applied to remove_signer.
+    #[test]
+    #[should_panic(expected = "NotSigner")]
+    fn rotate_signers_rejects_non_signer_caller_even_when_self_authorized() {
+        let setup = setup();
+        let attacker = Address::generate(&setup.env);
+
+        setup.env.as_contract(&setup.contract_id, || {
+            MultiSig::init(
+                &setup.env,
+                signers(&setup.env, &setup.signer_a, &setup.signer_b),
+                2,
+            );
+
+            let add_vec = Vec::new(&setup.env);
+            let rm_vec = Vec::new(&setup.env);
+            MultiSig::rotate_signers(&setup.env, attacker, add_vec, rm_vec, None);
+        });
     }
 }

--- a/grainlify-core/src/multisig.rs
+++ b/grainlify-core/src/multisig.rs
@@ -249,6 +249,13 @@ impl MultiSig {
 
     /// Remove a signer from the multisig configuration.
     ///
+    /// # Access model
+    /// `MultiSigConfig` has no separate "admin" concept — it is a
+    /// self-governing signer set, the same as `propose`/`approve`. Any
+    /// *current signer* may remove any other signer (including, if they
+    /// choose, themself); `caller` must be a member of `config.signers`, not
+    /// merely an address that can authorize its own transaction.
+    ///
     /// # Pre-condition: threshold viability guard
     /// The removal is rejected with [`MultiSigError::RemovalWouldBreakThreshold`]
     /// if `(current_signer_count - 1) < threshold`.  This prevents an admin
@@ -257,14 +264,20 @@ impl MultiSig {
     /// permanently lock any funds or actions protected by the multisig.
     ///
     /// # Errors
-    /// - Panics with `NotSigner` if `signer_to_remove` is not in the current
-    ///   signer set.
+    /// - Panics with `NotSigner` if `caller` is not a current signer, or if
+    ///   `signer_to_remove` is not in the current signer set.
     /// - Panics with `RemovalWouldBreakThreshold` if the removal would leave
     ///   fewer signers than the configured threshold.
     pub fn remove_signer(env: &Env, caller: Address, signer_to_remove: Address) {
         caller.require_auth();
 
         let mut config = Self::get_config(env);
+
+        // `require_auth()` above only proves `caller` authorized this specific
+        // invocation as itself — it does not prove `caller` is a configured
+        // signer. Without this check, any outside address could evict a
+        // legitimate signer by simply calling this with itself as `caller`.
+        Self::assert_signer(&config, &caller);
 
         // Verify the address to be removed is actually a current signer.
         if !config.signers.contains(&signer_to_remove) {
@@ -1272,6 +1285,67 @@ mod test {
 
             // Removing signer_b would leave 1 signer < threshold=2 → must panic.
             MultiSig::remove_signer(&setup.env, setup.signer_a.clone(), setup.signer_b.clone());
+        });
+    }
+
+    /// A caller who is not a configured signer must not be able to remove a
+    /// signer, even though `mock_all_auths` lets it trivially authorize its
+    /// own transaction — `require_auth()` alone must not be mistaken for a
+    /// signer-membership check.
+    #[test]
+    #[should_panic(expected = "NotSigner")]
+    fn remove_signer_rejects_non_signer_caller_even_when_self_authorized() {
+        let setup = setup();
+        let attacker = Address::generate(&setup.env);
+
+        setup.env.as_contract(&setup.contract_id, || {
+            let three_signers = addr_vec(
+                &setup.env,
+                &[&setup.signer_a, &setup.signer_b, &setup.signer_c],
+            );
+            MultiSig::init(&setup.env, three_signers, 2);
+
+            // `attacker` is not in the signer set, but mock_all_auths lets it
+            // sign for itself trivially — the call must still be rejected.
+            MultiSig::remove_signer(&setup.env, attacker, setup.signer_c.clone());
+        });
+    }
+
+    /// Complementary positive case: a legitimate signer's removal call is
+    /// unaffected by the new signer-membership check, and the config is
+    /// unchanged after the non-signer attack above was rejected.
+    #[test]
+    fn remove_signer_rejects_non_signer_then_succeeds_for_legitimate_signer() {
+        let setup = setup();
+        let attacker = Address::generate(&setup.env);
+
+        setup.env.as_contract(&setup.contract_id, || {
+            let three_signers = addr_vec(
+                &setup.env,
+                &[&setup.signer_a, &setup.signer_b, &setup.signer_c],
+            );
+            MultiSig::init(&setup.env, three_signers, 2);
+
+            let attacker_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                MultiSig::remove_signer(&setup.env, attacker.clone(), setup.signer_c.clone());
+            }));
+            assert!(
+                attacker_result.is_err(),
+                "non-signer caller must be rejected"
+            );
+
+            let config = MultiSig::get_config(&setup.env);
+            assert_eq!(
+                config.signers.len(),
+                3,
+                "rejected attacker call must not mutate the signer set"
+            );
+
+            // A legitimate signer performs the same removal successfully.
+            MultiSig::remove_signer(&setup.env, setup.signer_a.clone(), setup.signer_c.clone());
+            let config = MultiSig::get_config(&setup.env);
+            assert_eq!(config.signers.len(), 2);
+            assert!(!config.signers.contains(&setup.signer_c));
         });
     }
 


### PR DESCRIPTION
## Summary

Closes #384

`MultiSig::add_signer` and `MultiSig::rotate_signers` were fully implemented and unit-tested, but had no `#[contractimpl]` wrapper anywhere in `GrainlifyContract` — unlike `remove_signer`. A deployed contract could therefore never actually add a signer or perform a combined add/remove/threshold rotation; the only externally reachable signer-management operation was `remove_signer`. This silently defeated the signer-rotation story the module's docs (and the `SignerRot` `add`/`remove`/`thresh` events) describe, and meant operators had no on-chain way to add a replacement signer if one's key were ever compromised or lost.

## Changes

- Adds `add_signer(env, caller, new_signer)` and `rotate_signers(env, caller, add, remove, new_threshold)` wrappers to `GrainlifyContract` in `lib.rs`, forwarding to `MultiSig::add_signer`/`MultiSig::rotate_signers`, following the exact pattern used for `remove_signer`.
- Wires the same `Self::assert_signer(&config, &caller)` check introduced for `remove_signer` in #383 into both `MultiSig::add_signer` and `MultiSig::rotate_signers` directly, per this issue's explicit requirement, so newly exposing them as entrypoints doesn't reintroduce that same gap.
- Updates the module-level public-interface doc table and both new wrappers' doc comments.

## What's covered

- [x] `add_signer` and `rotate_signers` are callable through the generated contract client, not just internally via `MultiSig::` — `test_add_signer_reachable_through_contract_client` and `test_rotate_signers_reachable_through_contract_client` (new), both going through `GrainlifyContractClient`, the same client external callers actually use.
- [x] Both new entrypoints enforce the same signer/admin authorization as `remove_signer` — `add_signer_rejects_non_signer_caller_even_when_self_authorized` and `rotate_signers_rejects_non_signer_caller_even_when_self_authorized` (new), mirroring #383's regression tests.
- [x] The `lib.rs` doc table documents the new entrypoints.

## Test plan

```
$ cargo test -p grainlify-core -- add_signer rotate_signers
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 91 filtered out; finished in 0.06s

$ cargo test -p grainlify-core
test result: FAILED. 103 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.26s
```

103/104 pass (99 pre-existing + 4 new). The one failure, `test_upgrade_replay_guard_and_rescheduling`, is pre-existing and unrelated (see #418).

`cargo fmt --check -p grainlify-core`: diff count unchanged from the branch this stacks on (46).
`cargo clippy -p grainlify-core --tests`: warning count unchanged from the branch this stacks on (28).

## Note

This branch is stacked on #420 (`fix/multisig-383-remove-signer-auth-check`), which itself is stacked on #418 (the required `setup_test` arity-fix prerequisite). All three target `main` since I don't have push access to open a PR against a non-`main` base on the upstream org repo; if the earlier two merge first, this PR's diff against `main` will shrink to just this PR's own changes.