### PR TITLE
feat(sdk): extend ProgramEscrowClient with dispute, whitelist, circuit-breaker, and governance methods

### DIFF
--- a/sdk/src/__tests__/program-escrow-client.test.ts
+++ b/sdk/src/__tests__/program-escrow-client.test.ts
@@ -1,0 +1,214 @@
+import { Keypair } from '@stellar/stellar-sdk';
+import { ProgramEscrowClient } from '../index';
+import { ValidationError } from '../errors';
+
+describe('ProgramEscrowClient', () => {
+  const mockConfig = {
+    contractId: 'CBTG2M4XXWNDH7GCHXZT6E2I3J644MFRZQK6CUKL4WJY6WQZXY3P2M6L',
+    rpcUrl: 'http://localhost:8000/rpc',
+    networkPassphrase: 'Test SDF Network ; September 2015',
+  };
+
+  const validAddress = 'GAXN6265B5U2ZIK2QFWIYYXGZ5B47L7Z236L72G66Z3S7MHT7XZQ5WZG';
+
+  let client: ProgramEscrowClient;
+  let sourceKeypair: Keypair;
+
+  beforeEach(() => {
+    client = new ProgramEscrowClient(mockConfig);
+    sourceKeypair = Keypair.random();
+  });
+
+  function mockInvoke(result: unknown = undefined) {
+    return jest.spyOn(client as any, 'invokeContract').mockResolvedValue(result);
+  }
+
+  describe('initialization', () => {
+    it('creates client with valid config', () => {
+      expect(client).toBeDefined();
+    });
+  });
+
+  describe('existing methods (regression)', () => {
+    it('initProgram succeeds and calls init_program', async () => {
+      const invoke = mockInvoke({ program_id: 'p1' });
+      await client.initProgram('p1', validAddress, validAddress, sourceKeypair);
+      expect(invoke).toHaveBeenCalledWith(
+        'init_program',
+        ['p1', validAddress, validAddress],
+        sourceKeypair
+      );
+    });
+
+    it('getRemainingBalance parses a bigint result', async () => {
+      mockInvoke(500n);
+      const result = await client.getRemainingBalance();
+      expect(result).toBe(500n);
+    });
+  });
+
+  describe('dispute resolution', () => {
+    it('openDispute calls open_dispute with the reason', async () => {
+      const invoke = mockInvoke();
+      await client.openDispute('fraud suspected', sourceKeypair);
+      expect(invoke).toHaveBeenCalledWith(
+        'open_dispute',
+        ['fraud suspected'],
+        sourceKeypair
+      );
+    });
+
+    it('resolveDispute calls resolve_dispute', async () => {
+      const invoke = mockInvoke();
+      await client.resolveDispute(sourceKeypair);
+      expect(invoke).toHaveBeenCalledWith('resolve_dispute', [], sourceKeypair);
+    });
+
+    it('isRecipientDisputed rejects an invalid address', async () => {
+      await expect(client.isRecipientDisputed('invalid')).rejects.toThrow(ValidationError);
+    });
+
+    it('isRecipientDisputed returns the contract result', async () => {
+      mockInvoke(true);
+      const result = await client.isRecipientDisputed(validAddress);
+      expect(result).toBe(true);
+    });
+
+    it('isScheduleDisputed returns the contract result', async () => {
+      mockInvoke(false);
+      const result = await client.isScheduleDisputed(1n);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('whitelist management', () => {
+    it('setWhitelist rejects an invalid address', async () => {
+      await expect(
+        client.setWhitelist('invalid', true, sourceKeypair)
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('setWhitelist calls set_whitelist with the flag', async () => {
+      const invoke = mockInvoke();
+      await client.setWhitelist(validAddress, true, sourceKeypair);
+      expect(invoke).toHaveBeenCalledWith(
+        'set_whitelist',
+        [validAddress, true],
+        sourceKeypair
+      );
+    });
+
+    it('isWhitelisted returns the contract result', async () => {
+      mockInvoke(true);
+      const result = await client.isWhitelisted(validAddress);
+      expect(result).toBe(true);
+    });
+
+    it('setWhitelistEnforced calls set_whitelist_enforced', async () => {
+      const invoke = mockInvoke();
+      await client.setWhitelistEnforced(false, sourceKeypair);
+      expect(invoke).toHaveBeenCalledWith(
+        'set_whitelist_enforced',
+        [false],
+        sourceKeypair
+      );
+    });
+  });
+
+  describe('circuit breaker admin controls', () => {
+    it('setCircuitAdmin rejects an invalid new admin address', async () => {
+      await expect(
+        client.setCircuitAdmin('invalid', null, sourceKeypair)
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('resetCircuitBreaker rejects an invalid caller address', async () => {
+      await expect(
+        client.resetCircuitBreaker('invalid', sourceKeypair)
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('configureCircuitBreaker calls configure_circuit_breaker with thresholds', async () => {
+      const invoke = mockInvoke();
+      await client.configureCircuitBreaker(3, 1, 10, validAddress, sourceKeypair);
+      expect(invoke).toHaveBeenCalledWith(
+        'configure_circuit_breaker',
+        [validAddress, 3, 1, 10],
+        sourceKeypair
+      );
+    });
+
+    it('emergencyOpenCircuit calls emergency_open_circuit', async () => {
+      const invoke = mockInvoke();
+      await client.emergencyOpenCircuit(validAddress, sourceKeypair);
+      expect(invoke).toHaveBeenCalledWith(
+        'emergency_open_circuit',
+        [validAddress],
+        sourceKeypair
+      );
+    });
+
+    it('getCircuitStatus returns the contract result', async () => {
+      const status = { state: 'Closed', failure_count: 0, success_count: 0, last_failure_timestamp: 0n, opened_at: 0n };
+      mockInvoke(status);
+      const result = await client.getCircuitStatus();
+      expect(result).toEqual(status);
+    });
+  });
+
+  describe('governance integration', () => {
+    it('setGovernanceContract rejects an invalid address', async () => {
+      await expect(
+        client.setGovernanceContract('invalid', sourceKeypair)
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('setGovernanceContract calls set_governance_contract', async () => {
+      const invoke = mockInvoke();
+      await client.setGovernanceContract(validAddress, sourceKeypair);
+      expect(invoke).toHaveBeenCalledWith(
+        'set_governance_contract',
+        [validAddress],
+        sourceKeypair
+      );
+    });
+
+    it('getGovernanceContract returns the contract result', async () => {
+      mockInvoke(validAddress);
+      const result = await client.getGovernanceContract();
+      expect(result).toBe(validAddress);
+    });
+
+    it('setMinGovernanceVersion calls set_min_governance_version', async () => {
+      const invoke = mockInvoke();
+      await client.setMinGovernanceVersion(2, sourceKeypair);
+      expect(invoke).toHaveBeenCalledWith(
+        'set_min_governance_version',
+        [2],
+        sourceKeypair
+      );
+    });
+
+    it('getMinGovernanceVersion parses a numeric result', async () => {
+      mockInvoke(2);
+      const result = await client.getMinGovernanceVersion();
+      expect(result).toBe(2);
+    });
+  });
+
+  describe('monitoring / analytics', () => {
+    it('healthCheck returns the contract result', async () => {
+      const health = { is_healthy: true, last_operation: 0n, total_operations: 0n, contract_version: '1.0.0' };
+      mockInvoke(health);
+      const result = await client.healthCheck();
+      expect(result).toEqual(health);
+    });
+
+    it('getMonitoringAnalytics returns the contract result', async () => {
+      const analytics = { total_locked: 0n, total_released: 0n, total_payouts: 0, active_programs: 0, operation_count: 0 };
+      mockInvoke(analytics);
+      const result = await client.getMonitoringAnalytics();
+      expect(result).toEqual(analytics);
+    });
+  });
+});

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,9 +1,14 @@
 export { ProgramEscrowClient } from './program-escrow-client';
-export type { 
-  ProgramEscrowConfig, 
-  ProgramData, 
+export type {
+  ProgramEscrowConfig,
+  ProgramData,
   PayoutRecord,
-  ProgramReleaseSchedule 
+  ProgramReleaseSchedule,
+  CircuitBreakerConfig as ProgramCircuitBreakerConfig,
+  CircuitState as ProgramCircuitState,
+  CircuitBreakerStatus as ProgramCircuitBreakerStatus,
+  HealthStatus as ProgramHealthStatus,
+  ProgramAnalytics
 } from './program-escrow-client';
 
 export { BountyEscrowClient } from './bounty-escrow-client';

--- a/sdk/src/program-escrow-client.ts
+++ b/sdk/src/program-escrow-client.ts
@@ -51,6 +51,50 @@ export interface ProgramReleaseSchedule {
   released: boolean;
 }
 
+/** Configuration for the circuit breaker. */
+export interface CircuitBreakerConfig {
+  /** Count of consecutive errors required to open the circuit. */
+  failure_threshold: number;
+  /** Count of consecutive successes required to close the circuit in half-open state. */
+  success_threshold: number;
+  /** Maximum number of records in the error log. */
+  max_error_log: number;
+}
+
+/** Possible states for the circuit breaker. */
+export type CircuitState = 'Closed' | 'Open' | 'HalfOpen';
+
+/** Current status snapshot of the circuit breaker. */
+export interface CircuitBreakerStatus {
+  /** The state of the circuit breaker. */
+  state: CircuitState;
+  /** Number of consecutive failures in closed state. */
+  failure_count: number;
+  /** Number of consecutive successes in half-open state. */
+  success_count: number;
+  /** Timestamp of the last recorded failure. */
+  last_failure_timestamp: bigint;
+  /** Timestamp of when the circuit was opened. */
+  opened_at: bigint;
+}
+
+/** Contract-wide health snapshot returned by health_check(). */
+export interface HealthStatus {
+  is_healthy: boolean;
+  last_operation: bigint;
+  total_operations: bigint;
+  contract_version: string;
+}
+
+/** Aggregated monitoring analytics returned by get_monitoring_analytics(). */
+export interface ProgramAnalytics {
+  total_locked: bigint;
+  total_released: bigint;
+  total_payouts: number;
+  active_programs: number;
+  operation_count: number;
+}
+
 /**
  * Client for interacting with the ProgramEscrow Soroban contract
  */
@@ -269,6 +313,219 @@ export class ProgramEscrowClient {
         sourceKeypair
       );
       return Number(result);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  // ==========================================================================
+  // Dispute resolution
+  // ==========================================================================
+
+  /** Open a program-wide dispute, blocking all payouts and releases. Admin-only. */
+  async openDispute(reason: string, sourceKeypair: Keypair): Promise<void> {
+    try {
+      await this.invokeContract('open_dispute', [reason], sourceKeypair);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /** Resolve the currently open program-wide dispute, re-enabling payouts. Admin-only. */
+  async resolveDispute(sourceKeypair: Keypair): Promise<void> {
+    try {
+      await this.invokeContract('resolve_dispute', [], sourceKeypair);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /** Whether a global or recipient-scoped dispute currently blocks this recipient. */
+  async isRecipientDisputed(recipient: string): Promise<boolean> {
+    this.validateAddress(recipient, 'recipient');
+    try {
+      return await this.invokeContract('is_recipient_disputed', [recipient]);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /** Whether a global or schedule-scoped dispute currently blocks this release schedule. */
+  async isScheduleDisputed(scheduleId: bigint): Promise<boolean> {
+    try {
+      return await this.invokeContract('is_schedule_disputed', [scheduleId]);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  // ==========================================================================
+  // Whitelist management
+  // ==========================================================================
+
+  /** Add or remove an address from the anti-abuse whitelist. Admin-only. */
+  async setWhitelist(
+    address: string,
+    whitelisted: boolean,
+    sourceKeypair: Keypair
+  ): Promise<void> {
+    this.validateAddress(address, 'address');
+    try {
+      await this.invokeContract('set_whitelist', [address, whitelisted], sourceKeypair);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /** Whether an address is currently whitelisted. */
+  async isWhitelisted(address: string): Promise<boolean> {
+    this.validateAddress(address, 'address');
+    try {
+      return await this.invokeContract('is_whitelisted', [address]);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /** Enable or disable whitelist enforcement contract-wide. Admin-only. */
+  async setWhitelistEnforced(enabled: boolean, sourceKeypair: Keypair): Promise<void> {
+    try {
+      await this.invokeContract('set_whitelist_enforced', [enabled], sourceKeypair);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  // ==========================================================================
+  // Circuit breaker admin controls
+  // ==========================================================================
+
+  /** Register or rotate the circuit breaker admin address. */
+  async setCircuitAdmin(
+    newAdmin: string,
+    caller: string | null,
+    sourceKeypair: Keypair
+  ): Promise<void> {
+    this.validateAddress(newAdmin, 'newAdmin');
+    try {
+      await this.invokeContract('set_circuitadmin', [newAdmin, caller], sourceKeypair);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /** Reset the circuit breaker (Open -> HalfOpen -> Closed). Circuit-admin only. */
+  async resetCircuitBreaker(caller: string, sourceKeypair: Keypair): Promise<void> {
+    this.validateAddress(caller, 'caller');
+    try {
+      await this.invokeContract('reset_circuit_breaker', [caller], sourceKeypair);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /** Update circuit breaker thresholds. Circuit-admin only. */
+  async configureCircuitBreaker(
+    failureThreshold: number,
+    successThreshold: number,
+    maxErrorLog: number,
+    caller: string,
+    sourceKeypair: Keypair
+  ): Promise<void> {
+    this.validateAddress(caller, 'caller');
+    try {
+      await this.invokeContract(
+        'configure_circuit_breaker',
+        [caller, failureThreshold, successThreshold, maxErrorLog],
+        sourceKeypair
+      );
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /** Immediately open the circuit, blocking all payout/release operations. Circuit-admin only. */
+  async emergencyOpenCircuit(caller: string, sourceKeypair: Keypair): Promise<void> {
+    this.validateAddress(caller, 'caller');
+    try {
+      await this.invokeContract('emergency_open_circuit', [caller], sourceKeypair);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /** Get the current circuit breaker status snapshot. */
+  async getCircuitStatus(): Promise<CircuitBreakerStatus> {
+    try {
+      const result = await this.invokeContract('get_circuit_status', []);
+      return result as CircuitBreakerStatus;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  // ==========================================================================
+  // Governance integration
+  // ==========================================================================
+
+  /** Set the governance contract address used for version-gated admin operations. Admin-only. */
+  async setGovernanceContract(governanceAddress: string, sourceKeypair: Keypair): Promise<void> {
+    this.validateAddress(governanceAddress, 'governanceAddress');
+    try {
+      await this.invokeContract('set_governance_contract', [governanceAddress], sourceKeypair);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /** Get the configured governance contract address, if any. */
+  async getGovernanceContract(): Promise<string | null> {
+    try {
+      const result = await this.invokeContract('get_governance_contract', []);
+      return result as string | null;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /** Set the minimum governance contract version required for gated admin operations. Admin-only. */
+  async setMinGovernanceVersion(minVersion: number, sourceKeypair: Keypair): Promise<void> {
+    try {
+      await this.invokeContract('set_min_governance_version', [minVersion], sourceKeypair);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /** Get the configured minimum governance version (0 if unset). */
+  async getMinGovernanceVersion(): Promise<number> {
+    try {
+      const result = await this.invokeContract('get_min_governance_version', []);
+      return Number(result);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  // ==========================================================================
+  // Monitoring / analytics
+  // ==========================================================================
+
+  /** Get the current contract health snapshot. */
+  async healthCheck(): Promise<HealthStatus> {
+    try {
+      const result = await this.invokeContract('health_check', []);
+      return result as HealthStatus;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /** Get aggregated monitoring analytics across all programs. */
+  async getMonitoringAnalytics(): Promise<ProgramAnalytics> {
+    try {
+      const result = await this.invokeContract('get_monitoring_analytics', []);
+      return result as ProgramAnalytics;
     } catch (error) {
       throw this.handleError(error);
     }


### PR DESCRIPTION
## Summary

Closes #389

`ProgramEscrowClient` exposed only 8 methods (init/lock/payout/query surface) while `program-escrow/src/lib.rs` (3,800+ lines) has dozens more contract entrypoints with no SDK equivalent — pushing integrators toward hand-rolled, unaudited contract-invocation code for exactly the surface area that moves real value and controls real safety mechanisms (dispute resolution, circuit-breaker admin).

## Changes

Adds 18 new methods across the five groups the issue calls for, following the exact conventions already established in `bounty-escrow-client.ts` (`validateAddress`, `invokeContract`, `handleError`):

- **Dispute resolution**: `openDispute`, `resolveDispute`, `isRecipientDisputed`, `isScheduleDisputed`.
- **Whitelist management**: `setWhitelist`, `isWhitelisted`, `setWhitelistEnforced`.
- **Circuit breaker admin**: `setCircuitAdmin`, `resetCircuitBreaker`, `configureCircuitBreaker`, `emergencyOpenCircuit`, `getCircuitStatus`.
- **Governance integration**: `setGovernanceContract`, `getGovernanceContract`, `setMinGovernanceVersion`, `getMinGovernanceVersion`.
- **Monitoring/analytics**: `healthCheck`, `getMonitoringAnalytics`.

Adds `CircuitBreakerConfig`/`CircuitState`/`CircuitBreakerStatus`/`HealthStatus`/`ProgramAnalytics` interfaces (program-escrow's own, matching its actual Rust struct fields — kept separate from `bounty-escrow-client.ts`'s identically-named types, per the existing per-client duplication convention already in this codebase) and exports them from `index.ts` under a `Program`-prefixed alias to avoid a barrel-export name collision.

Adds `sdk/src/__tests__/program-escrow-client.test.ts` (24 tests: one success and one validation-failure path per new method group, plus two regression tests for pre-existing methods), following the existing `jest.spyOn(invokeContract)` mocking convention from `bounty-escrow-client.test.ts`.

## Scope note

This covers a representative, compact subset of `program-escrow`'s entrypoints per the issue's "at least" list (dispute/whitelist/circuit-breaker/governance/monitoring), not full 1:1 parity with every `lib.rs` function — full parity would be a much larger, separate effort. `check_proposal_vetoed` is not included since it has no `#[contractimpl]` wrapper on the contract itself (internal-only, used within upgrade execution paths).

## What's covered

- [x] `ProgramEscrowClient` exposes methods for dispute resolution, whitelist, circuit breaker admin, governance integration, and monitoring.
- [x] A dedicated `program-escrow-client.test.ts` exists and passes.
- [x] New methods follow the same error-mapping and typing conventions as `bounty-escrow-client.ts`.

## Test plan

```
$ npm run build
> tsc
(clean, no errors)

$ npm test -- --runInBand
Test Suites: 9 passed, 9 total
Tests:       296 passed, 296 total
```

296 = 272 pre-existing + 24 new, all passing.