### PR TITLE
fix: require contract admin auth for first-time circuit breaker admin assignment

### DIFF
--- a/program-escrow/src/lib.rs
+++ b/program-escrow/src/lib.rs
@@ -1383,7 +1383,24 @@ impl ProgramEscrowContract {
 
     // --- Circuit Breaker & Rate Limit ---
 
+    /// Register (or rotate) the circuit breaker admin.
+    ///
+    /// Bootstrap case (no circuit breaker admin registered yet): requires the
+    /// main contract admin's (`DataKey::Admin`) authorization, so the very
+    /// first caller against a freshly deployed contract cannot claim circuit
+    /// breaker admin unauthenticated -- `initialize_contract` never sets one
+    /// automatically. Once a circuit breaker admin exists, rotation continues
+    /// through `error_recovery::set_circuitadmin`'s existing current-admin
+    /// handoff path (`caller == current` + `require_auth`), unchanged.
     pub fn set_circuitadmin(env: Env, newadmin: Address, caller: Option<Address>) {
+        if error_recovery::get_circuitadmin(&env).is_none() {
+            let admin: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::Admin)
+                .unwrap_or_else(|| panic!("Admin not set"));
+            admin.require_auth();
+        }
         error_recovery::set_circuitadmin(&env, newadmin, caller);
         Self::bump_instance_ttl(&env);
     }

--- a/program-escrow/src/rbac_tests.rs
+++ b/program-escrow/src/rbac_tests.rs
@@ -1,7 +1,10 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal, String,
+};
 
 struct RbacSetup<'a> {
     env: Env,
@@ -39,8 +42,19 @@ impl<'a> RbacSetup<'a> {
         // Note: Currently init_program doesn't have auth, so we can just call it
         client.init_program(&program_id, &operator, &token_id);
 
-        // Initialize circuit breaker with pauser
-        // caller is None for first setting
+        // Initialize circuit breaker with pauser (first-ever assignment now
+        // requires the contract admin's auth — scope-mock just this one call
+        // so the rest of this fixture, and every individual test built on
+        // top of it, keeps its existing strict/unmocked auth behavior).
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "set_circuitadmin",
+                args: (pauser.clone(), Option::<Address>::None).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
         client.set_circuitadmin(&pauser, &None);
 
         Self {
@@ -456,4 +470,130 @@ fn test_circuit_admin_cannot_trigger_program_releases() {
     // Without mock_all_auths the authorized_payout_key.require_auth() fires.
     let setup = RbacSetup::new();
     setup.client.trigger_program_releases();
+}
+
+// ─────────────────────────────────────────────────────────
+// §10  Circuit-breaker-admin bootstrap authorization (issue #382)
+//
+// set_circuitadmin's *first-ever* call (no circuit admin registered yet)
+// must require the contract admin's auth, so an unauthenticated caller
+// can't claim circuit-breaker admin on a freshly deployed contract. These
+// tests build a minimal fixture themselves (contract initialized, no
+// circuit admin yet) rather than RbacSetup::new(), since that fixture's
+// constructor already bootstraps `pauser` as circuit admin.
+// ─────────────────────────────────────────────────────────
+
+/// A contract with an admin initialized, but no circuit breaker admin yet.
+struct BootstrapFixture<'a> {
+    env: Env,
+    contract_id: Address,
+    admin: Address,
+    client: ProgramEscrowContractClient<'a>,
+}
+
+impl<'a> BootstrapFixture<'a> {
+    fn new() -> Self {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, ProgramEscrowContract);
+        let client = ProgramEscrowContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize_contract(&admin);
+        Self {
+            env,
+            contract_id,
+            admin,
+            client,
+        }
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_set_circuitadmin_bootstrap_by_non_admin_rejected() {
+    let fx = BootstrapFixture::new();
+    let attacker = Address::generate(&fx.env);
+    // No mock_all_auths, no mock_auths for the contract admin: the very
+    // first set_circuitadmin call must be rejected without the contract
+    // admin's authorization, regardless of who the attacker claims to be.
+    fx.client.set_circuitadmin(&attacker, &None);
+}
+
+#[test]
+fn test_set_circuitadmin_bootstrap_by_admin_succeeds() {
+    let fx = BootstrapFixture::new();
+    let new_circuit_admin = Address::generate(&fx.env);
+
+    fx.env.mock_auths(&[MockAuth {
+        address: &fx.admin,
+        invoke: &MockAuthInvoke {
+            contract: &fx.contract_id,
+            fn_name: "set_circuitadmin",
+            args: (new_circuit_admin.clone(), Option::<Address>::None).into_val(&fx.env),
+            sub_invokes: &[],
+        },
+    }]);
+    fx.client.set_circuitadmin(&new_circuit_admin, &None);
+
+    assert_eq!(fx.client.get_circuitadmin(), Some(new_circuit_admin));
+}
+
+#[test]
+fn test_set_circuitadmin_rotation_by_current_circuit_admin_succeeds() {
+    let fx = BootstrapFixture::new();
+    let circuit_admin = Address::generate(&fx.env);
+    let successor = Address::generate(&fx.env);
+
+    fx.env.mock_auths(&[MockAuth {
+        address: &fx.admin,
+        invoke: &MockAuthInvoke {
+            contract: &fx.contract_id,
+            fn_name: "set_circuitadmin",
+            args: (circuit_admin.clone(), Option::<Address>::None).into_val(&fx.env),
+            sub_invokes: &[],
+        },
+    }]);
+    fx.client.set_circuitadmin(&circuit_admin, &None);
+
+    // Rotation: existing circuit admin is already set, so the bootstrap gate
+    // is skipped and the existing current-admin handoff path applies —
+    // authorize the current circuit admin, not the contract admin, for this
+    // second call.
+    fx.env.mock_auths(&[MockAuth {
+        address: &circuit_admin,
+        invoke: &MockAuthInvoke {
+            contract: &fx.contract_id,
+            fn_name: "set_circuitadmin",
+            args: (successor.clone(), Some(circuit_admin.clone())).into_val(&fx.env),
+            sub_invokes: &[],
+        },
+    }]);
+    fx.client.set_circuitadmin(&successor, &Some(circuit_admin));
+
+    assert_eq!(fx.client.get_circuitadmin(), Some(successor));
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized: only current admin can change circuit breaker admin")]
+fn test_set_circuitadmin_rotation_by_stale_circuit_admin_rejected() {
+    let fx = BootstrapFixture::new();
+    let circuit_admin = Address::generate(&fx.env);
+    let successor = Address::generate(&fx.env);
+    let stale_admin = Address::generate(&fx.env);
+
+    fx.env.mock_auths(&[MockAuth {
+        address: &fx.admin,
+        invoke: &MockAuthInvoke {
+            contract: &fx.contract_id,
+            fn_name: "set_circuitadmin",
+            args: (circuit_admin.clone(), Option::<Address>::None).into_val(&fx.env),
+            sub_invokes: &[],
+        },
+    }]);
+    fx.client.set_circuitadmin(&circuit_admin, &None);
+
+    // A stale/removed circuit admin (never actually the current one) tries
+    // to hand off to a successor. A circuit admin already exists, so this
+    // hits error_recovery::set_circuitadmin's existing rejection path.
+    fx.env.mock_all_auths();
+    fx.client.set_circuitadmin(&successor, &Some(stale_admin));
 }

--- a/program-escrow/src/test_circuit_breaker_integration.rs
+++ b/program-escrow/src/test_circuit_breaker_integration.rs
@@ -52,6 +52,12 @@ fn setup() -> (Env, Address, Address, Address, Address) {
 
     let client = ProgramEscrowContractClient::new(&env, &contract_id);
 
+    // The very first set_circuitadmin call now requires the contract admin's
+    // auth (see issue #382), so this fixture needs one registered; all auths
+    // are mocked above so this doesn't require a real signature.
+    let contract_admin = Address::generate(&env);
+    client.initialize_contract(&contract_admin);
+
     // Initialize and fund the program
     client.initialize_program(&program_id, &authorized_key, &token_address);
     client.lock_program_funds(&authorized_key, &200_000i128);


### PR DESCRIPTION
## Summary
`program-escrow/src/error_recovery.rs::set_circuitadmin` is the only gate protecting `reset_circuit_breaker`, `configure_circuit_breaker`, and `emergency_open_circuit`. When no circuit breaker admin has ever been set — the state of every freshly deployed `program-escrow` contract, since `initialize_contract` never calls `set_circuitadmin` — the entire `if let Some(ref current) = existing` auth check is skipped, and `newadmin` is stored unconditionally with **no `require_auth()` at all**. Unlike `bounty_escrow`'s equivalent `set_circuit_breaker_admin`, whose `lib.rs` wrapper requires the main contract admin's auth before ever touching the inner handoff helper, `program-escrow` had no such outer gate — any address could call `set_circuitadmin(attacker, None)` against a fresh deploy and become the permanent circuit-breaker admin, then force the breaker open (DoS on all payouts) or manipulate its thresholds.

Closes #382

## Changes
- **`program-escrow/src/lib.rs::set_circuitadmin`**: when no circuit breaker admin is registered yet (`error_recovery::get_circuitadmin(&env).is_none()`), require the main contract admin's (`DataKey::Admin`) `require_auth()` before delegating to `error_recovery::set_circuitadmin`. Once a circuit admin exists, this bootstrap gate is skipped and the existing current-admin handoff path (`caller == current` + `require_auth`) applies unchanged — no signature change, no behavior change for the rotation case.
- **`program-escrow/src/rbac_tests.rs`**: `RbacSetup::new()`'s shared fixture bootstraps a circuit admin (`pauser`) as part of setup; scope-mocked just that one call's auth (`env.mock_auths([...])`, not `mock_all_auths()`) so every other test built on this fixture — including the ~8 tests that specifically rely on auths *not* being mocked to prove unauthorized calls panic — keeps its exact existing behavior.
- **`program-escrow/src/test_circuit_breaker_integration.rs`**: its `setup()` bootstraps a circuit admin but never registered a contract admin at all; added `client.initialize_contract(&contract_admin)` (auths are already globally mocked in this fixture via `mock_all_auths()`, so this needed no further scoping).
- New regression tests in `rbac_tests.rs` (`BootstrapFixture`, a minimal admin-only fixture distinct from `RbacSetup` since that one already bootstraps a circuit admin): first-ever call by a non-admin panics; first-ever call by the contract admin succeeds; rotation by the current circuit admin still succeeds; rotation attempt by a stale/removed circuit admin still fails.

## Test plan
```
cargo test -p program-escrow --lib set_circuitadmin
```
```
running 4 tests
test rbac_tests::test_set_circuitadmin_bootstrap_by_admin_succeeds ... ok
test rbac_tests::test_set_circuitadmin_rotation_by_current_circuit_admin_succeeds ... ok
test rbac_tests::test_set_circuitadmin_bootstrap_by_non_admin_rejected - should panic ... ok
test rbac_tests::test_set_circuitadmin_rotation_by_stale_circuit_admin_rejected - should panic ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 458 filtered out
```
- Full `cargo test -p program-escrow --lib`: **460 passed**, 1 pre-existing failure (`reentrancy_tests::test_token_callback_reentrancy_batch_payout`, confirmed identical on unmodified `main` via `git stash` comparison — unrelated to this change), 1 ignored.
- `cargo build -p program-escrow` — clean (this is the only gate the current `program-escrow-tests` CI job runs; `cargo test`/`fmt`/`clippy` aren't wired into CI for this crate yet — that gap is tracked separately as #388).
- `cargo clippy -p program-escrow --lib --tests -- -D warnings`: 34 errors, but **identical count on unmodified `main`** via the same comparison — zero new warnings introduced by this change.
- `cargo fmt -p program-escrow -- --check`: flags pre-existing formatting debt scattered across many unrelated lines/files (125 diffs on unmodified `main`); the two touched-and-clean spots in my own new code were verified formatted correctly and fixed where rustfmt would have reflowed them.