### PR TITLE
fix: validate lockFunds/batchLockFunds deadline against current time

### DIFF
--- a/sdk/src/__tests__/bounty-escrow-client.test.ts
+++ b/sdk/src/__tests__/bounty-escrow-client.test.ts
@@ -71,6 +71,21 @@ describe('BountyEscrowClient', () => {
         ).rejects.toThrow(ValidationError);
       });
     });
+    describe('deadlines', () => {
+      it('throws on a positive-but-past deadline in lockFunds', async () => {
+        const pastDeadline = Math.floor(Date.now() / 1000) - 3600;
+        await expect(
+          client.lockFunds(validGAddress1, 1n, 100n, pastDeadline, sourceKeypair)
+        ).rejects.toThrow(ValidationError);
+      });
+      it('accepts a valid future deadline in lockFunds', async () => {
+        mockInvoke();
+        const futureDeadline = Math.floor(Date.now() / 1000) + 3600;
+        await expect(
+          client.lockFunds(validGAddress1, 1n, 100n, futureDeadline, sourceKeypair)
+        ).resolves.toBeUndefined();
+      });
+    });
     
     describe('batch operations', () => {
       it('throws on empty items array in batchLockFunds', async () => {
@@ -83,6 +98,17 @@ describe('BountyEscrowClient', () => {
         const items: LockFundsItem[] = [
           { bounty_id: 1n, depositor: validGAddress1, amount: 10n, deadline: 100 },
           { bounty_id: 2n, depositor: validGAddress1, amount: -10n, deadline: 100 },
+        ];
+        await expect(
+          client.batchLockFunds(items, sourceKeypair)
+        ).rejects.toThrow(ValidationError);
+      });
+      it('throws on a batch containing one item with a past deadline', async () => {
+        const futureDeadline = Math.floor(Date.now() / 1000) + 3600;
+        const pastDeadline = Math.floor(Date.now() / 1000) - 3600;
+        const items: LockFundsItem[] = [
+          { bounty_id: 1n, depositor: validGAddress1, amount: 10n, deadline: futureDeadline },
+          { bounty_id: 2n, depositor: validGAddress1, amount: 10n, deadline: pastDeadline },
         ];
         await expect(
           client.batchLockFunds(items, sourceKeypair)
@@ -587,8 +613,9 @@ describe('BountyEscrowClient', () => {
 
     it('routes lockFunds correctly', async () => {
       const invoke = mockInvoke();
-      await client.lockFunds(validGAddress1, 1n, 100n, 1000, sourceKeypair);
-      expect(invoke).toHaveBeenCalledWith('lock_funds', [validGAddress1, 1n, 100n, 1000], sourceKeypair);
+      const futureDeadline = Math.floor(Date.now() / 1000) + 3600;
+      await client.lockFunds(validGAddress1, 1n, 100n, futureDeadline, sourceKeypair);
+      expect(invoke).toHaveBeenCalledWith('lock_funds', [validGAddress1, 1n, 100n, futureDeadline], sourceKeypair);
     });
 
     it('routes releaseFunds correctly', async () => {
@@ -623,7 +650,8 @@ describe('BountyEscrowClient', () => {
 
     it('routes batchLockFunds correctly', async () => {
       const invoke = mockInvoke(5);
-      const items = [{ bounty_id: 1n, depositor: validGAddress1, amount: 100n, deadline: 1000 }];
+      const futureDeadline = Math.floor(Date.now() / 1000) + 3600;
+      const items = [{ bounty_id: 1n, depositor: validGAddress1, amount: 100n, deadline: futureDeadline }];
       const count = await client.batchLockFunds(items, sourceKeypair);
       expect(count).toBe(5);
       expect(invoke).toHaveBeenCalledWith('batch_lock_funds', [items], sourceKeypair);

--- a/sdk/src/bounty-escrow-client.ts
+++ b/sdk/src/bounty-escrow-client.ts
@@ -304,7 +304,7 @@ export class BountyEscrowClient {
     if (amount <= 0n) {
       throw new ValidationError('Amount must be greater than zero', 'amount');
     }
-    if (deadline <= 0) {
+    if (deadline <= Math.floor(Date.now() / 1000)) {
       throw new ValidationError('Deadline must be in the future', 'deadline');
     }
 
@@ -468,6 +468,9 @@ export class BountyEscrowClient {
       this.validateAddress(items[i].depositor, `items[${i}].depositor`);
       if (items[i].amount <= 0n) {
         throw new ValidationError(`Amount at index ${i} must be greater than zero`, 'amount');
+      }
+      if (items[i].deadline <= Math.floor(Date.now() / 1000)) {
+        throw new ValidationError(`Deadline at index ${i} must be in the future`, 'deadline');
       }
     }
 


### PR DESCRIPTION
## Summary
`lockFunds` validated `deadline <= 0` but its error message claimed "must be
in the future" — a positive-but-past timestamp (e.g. `1`, decades ago)
silently passed the check. `batchLockFunds` had no deadline validation at all.

## Changes
- `lockFunds`: replaced `deadline <= 0` with `deadline <= Math.floor(Date.now() / 1000)`
- `batchLockFunds`: added the same per-item deadline check inside the
  existing validation loop
- Updated two existing routing tests (`routes lockFunds correctly`,
  `routes batchLockFunds correctly`) that used a hardcoded past timestamp
  (`1000`) as their input, since they now correctly fail that check

## Tests
Added 3 new tests:
- `throws on a positive-but-past deadline in lockFunds`
- `accepts a valid future deadline in lockFunds`
- `throws on a batch containing one item with a past deadline`

Full SDK test suite result:
\`\`\`
Test Suites: 9 passed, 9 total
Tests:       299 passed, 299 total
\`\`\`

Fixes #489