### PR TITLE
fix(grainlify-core): add reinitialization guard and real authorization to init_governance

### DIFF
--- a/grainlify-core/src/governance.rs
+++ b/grainlify-core/src/governance.rs
@@ -81,6 +81,7 @@ pub const PROPOSALS: Symbol = symbol_short!("PROPOSALS");
 pub const PROPOSAL_COUNT: Symbol = symbol_short!("PROP_CNT");
 pub const VOTES: Symbol = symbol_short!("VOTES");
 pub const GOVERNANCE_CONFIG: Symbol = symbol_short!("GOV_CFG");
+pub const GOVERNANCE_ADMIN: Symbol = symbol_short!("GOV_ADM");
 
 #[soroban_sdk::contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -104,6 +105,7 @@ pub enum Error {
     InvalidTotalVotingPower = 16,
     Unauthorized = 17,
     VoteWeightOverflow = 18,
+    AlreadyInitialized = 19,
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), soroban_sdk::contract)]
@@ -117,6 +119,13 @@ impl GovernanceContract {
         config: GovernanceConfig,
     ) -> Result<(), Error> {
         admin.require_auth();
+
+        // One-time initialisation, mirroring the reinit guard already used by
+        // GrainlifyContract::init and GrainlifyContract::init_admin.
+        if env.storage().instance().has(&GOVERNANCE_CONFIG) {
+            return Err(Error::AlreadyInitialized);
+        }
+
         if config.quorum_percentage > 10000 || config.approval_threshold > 10000 {
             return Err(Error::InvalidThreshold);
         }
@@ -130,6 +139,9 @@ impl GovernanceContract {
             return Err(Error::InvalidTotalVotingPower);
         }
 
+        // Persist the authenticated caller as the real governance admin of
+        // record, rather than treating `admin` as a throwaway auth argument.
+        env.storage().instance().set(&GOVERNANCE_ADMIN, &admin);
         env.storage().instance().set(&GOVERNANCE_CONFIG, &config);
         env.storage().instance().set(&PROPOSAL_COUNT, &0u32);
         Ok(())
@@ -575,6 +587,57 @@ mod test {
         env.mock_all_auths();
         client.init_governance(&admin, &config);
         (client, token_admin_client, user, contract_id)
+    }
+
+    #[test]
+    fn test_init_governance_twice_rejected() {
+        let env = Env::default();
+        let (client, _, _, _) = setup_test(&env, VotingScheme::OnePersonOneVote, 1000, 0, 10);
+
+        let attacker = Address::generate(&env);
+        let hijack_config = GovernanceConfig {
+            voting_period: 1,
+            execution_delay: 0,
+            quorum_percentage: 1,
+            approval_threshold: 5000,
+            min_proposal_stake: 0,
+            voting_scheme: VotingScheme::OnePersonOneVote,
+            governance_token: Address::generate(&env),
+            one_person_total_voters: 1,
+            token_total_voting_power: 0,
+            snapshot_ledger: None,
+        };
+
+        let result = client.try_init_governance(&attacker, &hijack_config);
+        assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
+    }
+
+    #[test]
+    fn test_init_governance_persists_admin_of_record() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, GovernanceContract);
+        let client = GovernanceContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let config = GovernanceConfig {
+            voting_period: 100,
+            execution_delay: 0,
+            quorum_percentage: 1000,
+            approval_threshold: 5000,
+            min_proposal_stake: 0,
+            voting_scheme: VotingScheme::OnePersonOneVote,
+            governance_token: Address::generate(&env),
+            one_person_total_voters: 10,
+            token_total_voting_power: 0,
+            snapshot_ledger: None,
+        };
+
+        env.mock_all_auths();
+        client.init_governance(&admin, &config);
+
+        let stored_admin: Address = env.as_contract(&contract_id, || {
+            env.storage().instance().get(&GOVERNANCE_ADMIN).unwrap()
+        });
+        assert_eq!(stored_admin, admin);
     }
 
     fn create_test_proposal(


### PR DESCRIPTION
Closes #470

init_governance had no reinitialization guard and trusted a caller-supplied
`admin` argument with no persisted identity behind it — any address could
call it at any time to overwrite GovernanceConfig and reset PROPOSAL_COUNT.

- Reject a second call once GOVERNANCE_CONFIG is already set, mirroring the
  existing guards on `init` (multisig) and `init_admin`.
- Persist the authenticated caller as a real governance admin of record
  (GOVERNANCE_ADMIN) instead of discarding it after the auth check.
- Two new tests: reinit rejection, and that the admin is actually persisted.

115/115 existing + new tests pass