### PR TITLE
fix(escrow): require admin auth in bootstrap entrypoints (#491)

### DIFF
--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -7,6 +7,8 @@ mod error_recovery;
 #[cfg(test)]
 mod test_rbac;
 mod test_admin_authz;
+#[cfg(test)]
+mod test_admin_bootstrap;
 mod test_coverage_boost;
 mod test_coverage_boost_small;
 mod test_coverage_comprehensive;
@@ -767,10 +769,28 @@ impl BountyEscrowContract {
     // ==================== END INCREMENTAL AGGREGATE COUNTERS ====================
 
     /// Initialize the contract with the admin address and the token address (XLM).
+    ///
+    /// # Authorization
+    /// Requires `require_auth()` from `admin` — the address being installed as
+    /// the permanent contract admin must authorize its own installation. The
+    /// check runs *after* the already-initialized guard so a second call still
+    /// reports `AlreadyInitialized` rather than an authorization failure.
+    ///
+    /// Note this does not fully close the deploy-then-initialize race: an
+    /// attacker who front-runs the legitimate deployer can still self-authorize
+    /// a bootstrap call naming an address they control. It raises the bar so a
+    /// front-runner can no longer install an arbitrary third-party address, and
+    /// it is the mitigation available without deploy-time (constructor)
+    /// initialization. See `docs/DEPLOYMENT_RUNBOOK.md` for the operational
+    /// guidance that covers the remaining window.
+    ///
+    /// # Errors
+    /// `AlreadyInitialized` if an admin has already been set.
     pub fn init(env: Env, admin: Address, token: Address) -> Result<(), Error> {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(Error::AlreadyInitialized);
         }
+        admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Token, &token);
 

--- a/bounty_escrow/contracts/escrow/src/test_admin_authz.rs
+++ b/bounty_escrow/contracts/escrow/src/test_admin_authz.rs
@@ -29,8 +29,6 @@ struct AuthzSetup<'a> {
 impl<'a> AuthzSetup<'a> {
     fn new() -> Self {
         let env = Env::default();
-        // NOTE: no mock_all_auths(). `init` performs no require_auth, so it
-        // works without any mocked authorization.
         let contract_id = env.register_contract(None, BountyEscrowContract);
         let client = BountyEscrowContractClient::new(&env, &contract_id);
 
@@ -41,7 +39,15 @@ impl<'a> AuthzSetup<'a> {
             .register_stellar_asset_contract_v2(token_admin.clone())
             .address();
 
+        // NOTE: as of #491 `init` requires the incoming admin's own auth, so
+        // the bootstrap has to be authorized. Scope it to this one call and
+        // clear immediately with `mock_auths(&[])` — the negative tests below
+        // depend on the env being unauthenticated, and a lingering
+        // `mock_all_auths()` would make every `require_auth()` succeed and
+        // silently void them (see the module note above).
+        env.mock_all_auths();
         client.init(&admin, &token_id);
+        env.mock_auths(&[]);
 
         Self {
             env,

--- a/bounty_escrow/contracts/escrow/src/test_admin_bootstrap.rs
+++ b/bounty_escrow/contracts/escrow/src/test_admin_bootstrap.rs
@@ -1,0 +1,179 @@
+#![cfg(test)]
+
+//! Issue #491 — admin bootstrap authorization and the deploy-then-initialize
+//! race window.
+//!
+//! `init` is the only writer of `DataKey::Admin` in this contract, and there is
+//! no rotation entrypoint at all: whoever wins the bootstrap holds the admin
+//! role permanently and irrecoverably. #491 adds `admin.require_auth()` as the
+//! hardening available without deploy-time initialization.
+//!
+//! These tests pin down BOTH sides of that mitigation — what it buys, and what
+//! it explicitly does NOT close — so a later constructor-style fix can be
+//! validated against them.
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal,
+};
+
+fn create_escrow<'a>(e: &Env) -> BountyEscrowContractClient<'a> {
+    let contract_id = e.register_contract(None, BountyEscrowContract);
+    BountyEscrowContractClient::new(e, &contract_id)
+}
+
+fn create_token(e: &Env) -> Address {
+    let token_admin = Address::generate(e);
+    e.register_stellar_asset_contract_v2(token_admin).address()
+}
+
+/// Baseline: the legitimate flow still works when the incoming admin signs.
+#[test]
+fn admin_bootstrap_succeeds_when_incoming_admin_authorizes() {
+    let env = Env::default();
+    let client = create_escrow(&env);
+    let token = create_token(&env);
+    let admin = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "init",
+            args: (&admin, &token).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.init(&admin, &token);
+
+    assert_eq!(client.get_admin_audit_view().admin, admin);
+}
+
+/// The core of the #491 mitigation: with no authorization at all, the bootstrap
+/// is rejected and no admin is installed.
+#[test]
+fn admin_bootstrap_rejects_call_with_no_authorization() {
+    let env = Env::default();
+    let client = create_escrow(&env);
+    let token = create_token(&env);
+    let admin = Address::generate(&env);
+
+    // Deliberately no mocked auth of any kind.
+    assert!(
+        client.try_init(&admin, &token).is_err(),
+        "unauthorized bootstrap must be rejected"
+    );
+
+    // Nothing was written: a properly authorized bootstrap still succeeds.
+    env.mock_all_auths();
+    client.init(&admin, &token);
+    assert_eq!(client.get_admin_audit_view().admin, admin);
+}
+
+/// What `require_auth()` actually buys: a front-runner can no longer name an
+/// address they do not control. Authorizing themself is not enough — the
+/// *incoming admin* is the address whose signature is checked.
+#[test]
+fn admin_bootstrap_front_runner_cannot_install_unconsenting_admin() {
+    let env = Env::default();
+    let client = create_escrow(&env);
+    let token = create_token(&env);
+    let attacker = Address::generate(&env);
+    let unconsenting = Address::generate(&env);
+
+    // The attacker signs as themself but names a third party as admin.
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "init",
+            args: (&unconsenting, &token).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    assert!(
+        client.try_init(&unconsenting, &token).is_err(),
+        "bootstrap must require the incoming admin's own signature, not the caller's"
+    );
+}
+
+/// The residual race, documented deliberately.
+///
+/// `require_auth()` does NOT close the deploy-then-initialize window: an
+/// attacker who front-runs the legitimate deployer and names an address they
+/// control signs for it themselves and wins permanently. This test is expected
+/// to be rewritten when deploy-time (constructor) initialization lands — it
+/// exists so that change has something concrete to invalidate.
+#[test]
+fn admin_bootstrap_race_self_authorized_front_runner_still_wins() {
+    let env = Env::default();
+    let client = create_escrow(&env);
+    let token = create_token(&env);
+    let attacker = Address::generate(&env);
+    let legitimate_deployer = Address::generate(&env);
+
+    // The attacker front-runs, naming an address they control and signing for it.
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "init",
+            args: (&attacker, &token).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.init(&attacker, &token);
+
+    assert_eq!(
+        client.get_admin_audit_view().admin,
+        attacker,
+        "front-runner wins the bootstrap: require_auth does not close the race"
+    );
+
+    // The legitimate deployer is now permanently locked out, even fully authorized.
+    env.mock_all_auths();
+    assert!(
+        client.try_init(&legitimate_deployer, &token).is_err(),
+        "second bootstrap must be refused"
+    );
+    assert_eq!(
+        client.get_admin_audit_view().admin,
+        attacker,
+        "and there is no path back: the attacker remains admin"
+    );
+}
+
+/// Canary for the premise of this issue in `bounty_escrow`: the loser of the
+/// bootstrap race has no way back. Every entrypoint that can reach the admin
+/// key requires the *current* admin's authorization, so the front-runner must
+/// cooperate — which is what makes a lost race here unrecoverable rather than
+/// merely inconvenient.
+///
+/// If a rotation entrypoint reachable by anyone else is ever added, this test
+/// should fail and the "permanently unrecoverable" framing must be revisited.
+#[test]
+fn admin_bootstrap_lost_race_cannot_be_recovered_by_the_victim() {
+    let env = Env::default();
+    let client = create_escrow(&env);
+    let token = create_token(&env);
+    let attacker = Address::generate(&env);
+    let victim = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.init(&attacker, &token);
+    env.mock_auths(&[]);
+
+    // Re-bootstrapping is closed.
+    assert!(client.try_init(&victim, &token).is_err());
+
+    // And the one entrypoint that can reach the admin key is gated on the
+    // current admin's auth, i.e. on the attacker's cooperation.
+    assert!(
+        client.try_set_anti_abuse_admin(&victim).is_err(),
+        "admin-key mutation must require the current admin's authorization"
+    );
+
+    assert_eq!(client.get_admin_audit_view().admin, attacker);
+}

--- a/bounty_escrow/contracts/escrow/src/test_bounty_escrow.rs
+++ b/bounty_escrow/contracts/escrow/src/test_bounty_escrow.rs
@@ -1688,6 +1688,8 @@ fn test_emit_bounty_initialized_topic_and_payload() {
     let admin = Address::generate(&env);
     let (token, _, _) = create_token_contract(&env, &admin);
 
+    // `init` requires the incoming admin's own auth as of #491.
+    env.mock_all_auths();
     client.init(&admin, &token);
 
     let expected_topics: soroban_sdk::Vec<Val> = (symbol_short!("init"),).into_val(&env);

--- a/bounty_escrow/contracts/escrow/src/test_granular_pause.rs
+++ b/bounty_escrow/contracts/escrow/src/test_granular_pause.rs
@@ -221,7 +221,12 @@ fn test_emergency_pause_requires_admin_auth() {
     let (token_client, _) = create_token(&env, &token_admin);
     let (client, _) = create_escrow(&env);
 
+    // `init` requires the incoming admin's own auth as of #491. Authorize ONLY
+    // the bootstrap, then clear — a blanket `mock_all_auths()` would authorize
+    // `set_emergency_pause` too and turn this test into a no-op.
+    env.mock_all_auths();
     client.init(&admin, &token_client.address);
+    env.mock_auths(&[]);
 
     assert!(client.try_set_emergency_pause(&true).is_err());
     assert!(!client.get_pause_flags().global_paused);

--- a/docs/DEPLOYMENT_RUNBOOK.md
+++ b/docs/DEPLOYMENT_RUNBOOK.md
@@ -82,6 +82,55 @@ Before a live deployment, confirm the exact `.wasm` path and record the commit S
 
 ## Deploy and initialize
 
+> ### ⚠️ Always deploy and initialize in one invocation
+>
+> **Do not deploy first and initialize as a separate step.** The admin
+> bootstrap entrypoints — `bounty_escrow::init`, `program-escrow::initialize_contract`
+> and `program-escrow::setadmin` — are guarded only by "has this already been
+> called". Between the deploy transaction and a later initialization
+> transaction there is a window in which **any observer of the public network
+> can front-run you and claim the admin role permanently**.
+>
+> Each contract requires the incoming admin address to authorize its own
+> installation, so an attacker cannot install an address *you* control. That
+> raises the bar but **does not close the race**: an attacker who names an
+> address *they* control and signs for it still wins.
+>
+> Losing the race is effectively unrecoverable:
+>
+> | Contract | Recovery |
+> | --- | --- |
+> | `bounty_escrow` | **None.** `init` is the only writer of the admin key and there is no rotation entrypoint. |
+> | `program-escrow` | Only `propose_admin` → `accept_admin`, which the **current** admin must initiate. If an attacker holds it, they must cooperate. |
+>
+> The admin gates pausing, fee configuration, rate limits, whitelists and
+> governance linkage — and in `bounty_escrow`, the token address the entire
+> contract's accounting is denominated in.
+>
+> **Do this:**
+>
+> ```bash
+> ./scripts/deploy.sh <wasm_file> -n <network> -N <name> -- --admin G... --token C...
+> ```
+>
+> **Not this:**
+>
+> ```bash
+> ./scripts/deploy.sh <wasm_file>          # deployed, admin unclaimed
+> stellar contract invoke --id <id> -- init --admin G...   # racing an attacker
+> ```
+>
+> If a contract does end up deployed but uninitialized, treat it as
+> compromised until proven otherwise: initialize immediately, then **confirm
+> the stored admin is yours** (`getadmin` on `program-escrow`,
+> `get_admin_audit_view` on `bounty_escrow`) **before funding it**. If it is
+> not yours, abandon the contract and redeploy — there is no way to evict an
+> illegitimate admin.
+>
+> A permanent fix requires deploy-time initialization (constructor arguments
+> passed at deploy rather than a separate `contract invoke -- init`), which is
+> not available on the pinned `soroban-sdk 21.0.0`. Tracked in issue #491.
+
 Preferred script:
 
 ```bash
@@ -133,6 +182,13 @@ What the script does:
 8. Appends the deployment to the configured registry.
 
 If init fails after deploy, the contract id is still printed and the deployment may already be in the registry. Record the failure, verify the deployed contract manually, and either run the correct `init` invocation manually or decide whether a fresh deploy is required.
+
+**This is exactly the race window described above.** From the moment the deploy
+succeeds until an initialization transaction lands, the admin role is unclaimed
+and an attacker can take it. Re-run `init` immediately, then verify the stored
+admin is the address you intended before funding the contract. Because the
+initialization is a separate transaction here, a fresh deploy is the safer
+choice whenever the contract has not yet been funded.
 
 ## Verify a deployment
 
@@ -388,6 +444,8 @@ Before any mainnet deploy, upgrade, or rollback:
 - Confirm `SOROBAN_NETWORK_PASSPHRASE` is `Public Global Stellar Network ; September 2015`.
 - Confirm `DEPLOYER_IDENTITY` is the mainnet identity and has enough XLM.
 - Confirm admin addresses, token addresses, oracle addresses, and fee values.
+- Confirm the init arguments are passed in the **same** `deploy.sh` invocation. Never deploy to mainnet and initialize as a separate step — see the race warning under "Deploy and initialize".
+- Immediately after deploy, confirm the stored admin is yours (`getadmin` / `get_admin_audit_view`) **before funding the contract**.
 - Back up existing registry files.
 - Capture the old WASM hash before upgrade.
 - Confirm rollback hash availability and whether the previous WASM is installed on network.
@@ -420,10 +478,11 @@ Do not use `--force` on mainnet unless an incident commander explicitly approves
 
 1. Build: `cargo build --target wasm32-unknown-unknown --release`
 2. Dry-run deploy: `./scripts/deploy.sh <wasm> -n <network> --dry-run`
-3. Deploy and optionally init: `./scripts/deploy.sh <wasm> -n <network> -N <name> -- [init args]`
-4. Verify: `./scripts/verify-deployment.sh <contract_id> -n <network>`
-5. Save registry files and deployment output.
-6. Dry-run upgrade: `./scripts/upgrade.sh <contract_id> <new_wasm> -n <network> --dry-run`
-7. Upgrade: `./scripts/upgrade.sh <contract_id> <new_wasm> -n <network> -s <admin_identity>`
-8. Verify again with `verify-deployment.sh`.
-9. If rollback is needed, find `old_wasm_hash`, run `rollback.sh --dry-run`, then execute rollback only after confirming state compatibility risk.
+3. Deploy **and init in the same invocation**: `./scripts/deploy.sh <wasm> -n <network> -N <name> -- <init args>` — do not split these into two transactions (see the race warning under "Deploy and initialize").
+4. Confirm the stored admin is the address you intended, before funding: `getadmin` (`program-escrow`) or `get_admin_audit_view` (`bounty_escrow`).
+5. Verify: `./scripts/verify-deployment.sh <contract_id> -n <network>`
+6. Save registry files and deployment output.
+7. Dry-run upgrade: `./scripts/upgrade.sh <contract_id> <new_wasm> -n <network> --dry-run`
+8. Upgrade: `./scripts/upgrade.sh <contract_id> <new_wasm> -n <network> -s <admin_identity>`
+9. Verify again with `verify-deployment.sh`.
+10. If rollback is needed, find `old_wasm_hash`, run `rollback.sh --dry-run`, then execute rollback only after confirming state compatibility risk.

--- a/program-escrow/src/lib.rs
+++ b/program-escrow/src/lib.rs
@@ -153,6 +153,9 @@ mod error_recovery_tests;
 mod reentrancy_tests;
 
 #[cfg(test)]
+mod test_admin_bootstrap;
+
+#[cfg(test)]
 mod test_monitoring;
 
 #[cfg(test)]
@@ -935,11 +938,25 @@ impl ProgramEscrowContract {
 
     /// Initialize the contract with an admin.
     /// This must be called before any admin protected functions (like pause) can be used.
+    ///
+    /// # Authorization
+    /// Requires `require_auth()` from `admin` — the address being installed as
+    /// the contract admin must authorize its own installation. The check runs
+    /// *after* the already-initialized guard, matching the ordering documented
+    /// on `accept_admin` below, so a second call still panics with
+    /// "Already initialized" rather than an authorization failure.
+    ///
+    /// This does not fully close the deploy-then-initialize race: an attacker
+    /// who front-runs the legitimate deployer can still self-authorize a
+    /// bootstrap call naming an address they control. Unlike `bounty_escrow`,
+    /// this contract does retain a recovery path via
+    /// `propose_admin`/`accept_admin`, but only the current admin can start it.
     pub fn initialize_contract(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             Self::bump_instance_ttl(&env);
             panic!("Already initialized");
         }
+        admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         Self::bump_instance_ttl(&env);
     }
@@ -949,11 +966,18 @@ impl ProgramEscrowContract {
     /// This is no longer a rotation path. Once an admin is set, further
     /// rotation must go through `propose_admin`/`accept_admin` so a mistyped
     /// or uncontrolled address can never instantly and irreversibly take over.
+    ///
+    /// # Authorization
+    /// Requires `require_auth()` from `admin`, on the same terms as
+    /// `initialize_contract` above: the address being installed must authorize
+    /// its own installation, and the check runs after the already-set guard so
+    /// a second call still panics with the rotation hint.
     pub fn setadmin(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             Self::bump_instance_ttl(&env);
             panic!("admin already set; use propose_admin/accept_admin to rotate");
         }
+        admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         Self::bump_instance_ttl(&env);
     }

--- a/program-escrow/src/rbac_tests.rs
+++ b/program-escrow/src/rbac_tests.rs
@@ -32,7 +32,14 @@ impl<'a> RbacSetup<'a> {
 
         let program_id = String::from_str(&env, "RBAC-Test");
 
-        // Initialize contract with admin
+        // Initialize contract with admin.
+        // As of #491 `initialize_contract` requires the incoming admin's own
+        // auth, so the bootstrap is authorized here and the mock is cleared
+        // right after with `mock_auths(&[])`. The negative tests below
+        // (`test_random_cannot_pause`, `testadmin_cannot_trigger_releases`)
+        // rely on the env being unauthenticated; leaving `mock_all_auths()`
+        // active would make every `require_auth()` succeed and void them.
+        env.mock_all_auths();
         client.initialize_contract(&admin);
 
         // Initialize program with operator
@@ -42,6 +49,8 @@ impl<'a> RbacSetup<'a> {
         // Initialize circuit breaker with pauser
         // caller is None for first setting
         client.set_circuitadmin(&pauser, &None);
+
+        env.mock_auths(&[]);
 
         Self {
             env,

--- a/program-escrow/src/test_admin_bootstrap.rs
+++ b/program-escrow/src/test_admin_bootstrap.rs
@@ -1,0 +1,215 @@
+#![cfg(test)]
+
+//! Issue #491 — admin bootstrap authorization and the deploy-then-initialize
+//! race window.
+//!
+//! `initialize_contract` and `setadmin` are the two bootstrap paths for
+//! `DataKey::Admin`. #491 adds `admin.require_auth()` to both as the hardening
+//! available without deploy-time initialization.
+//!
+//! Unlike `bounty_escrow`, this contract does keep a recovery path
+//! (`propose_admin`/`accept_admin`), but only the *current* admin can start it
+//! — so a front-runner who wins the bootstrap still cannot be evicted.
+//!
+//! These tests pin down both what the mitigation buys and what it does NOT
+//! close, so a later constructor-style fix can be validated against them.
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal,
+};
+
+fn create_contract<'a>(e: &Env) -> ProgramEscrowContractClient<'a> {
+    let contract_id = e.register_contract(None, ProgramEscrowContract);
+    ProgramEscrowContractClient::new(e, &contract_id)
+}
+
+// ─────────────────────────────────────────────────────────
+// initialize_contract
+// ─────────────────────────────────────────────────────────
+
+#[test]
+fn admin_bootstrap_initialize_contract_succeeds_when_admin_authorizes() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "initialize_contract",
+            args: (&admin,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.initialize_contract(&admin);
+
+    assert_eq!(client.getadmin(), Some(admin));
+}
+
+#[test]
+fn admin_bootstrap_initialize_contract_rejects_unauthorized_call() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+
+    // Deliberately no mocked auth of any kind.
+    assert!(
+        client.try_initialize_contract(&admin).is_err(),
+        "unauthorized bootstrap must be rejected"
+    );
+    assert_eq!(client.getadmin(), None, "no admin may have been installed");
+}
+
+#[test]
+fn admin_bootstrap_initialize_contract_requires_incoming_admins_own_signature() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let attacker = Address::generate(&env);
+    let unconsenting = Address::generate(&env);
+
+    // The attacker signs as themself but names a third party as admin.
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "initialize_contract",
+            args: (&unconsenting,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    assert!(
+        client.try_initialize_contract(&unconsenting).is_err(),
+        "bootstrap must check the incoming admin's signature, not the caller's"
+    );
+    assert_eq!(client.getadmin(), None);
+}
+
+// ─────────────────────────────────────────────────────────
+// setadmin
+// ─────────────────────────────────────────────────────────
+
+#[test]
+fn admin_bootstrap_setadmin_succeeds_when_admin_authorizes() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "setadmin",
+            args: (&admin,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.setadmin(&admin);
+
+    assert_eq!(client.getadmin(), Some(admin));
+}
+
+#[test]
+fn admin_bootstrap_setadmin_rejects_unauthorized_call() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let admin = Address::generate(&env);
+
+    assert!(
+        client.try_setadmin(&admin).is_err(),
+        "unauthorized bootstrap must be rejected"
+    );
+    assert_eq!(client.getadmin(), None, "no admin may have been installed");
+}
+
+#[test]
+fn admin_bootstrap_setadmin_requires_incoming_admins_own_signature() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let attacker = Address::generate(&env);
+    let unconsenting = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "setadmin",
+            args: (&unconsenting,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    assert!(
+        client.try_setadmin(&unconsenting).is_err(),
+        "bootstrap must check the incoming admin's signature, not the caller's"
+    );
+    assert_eq!(client.getadmin(), None);
+}
+
+// ─────────────────────────────────────────────────────────
+// The residual race
+// ─────────────────────────────────────────────────────────
+
+/// `require_auth()` does NOT close the deploy-then-initialize window: an
+/// attacker who front-runs the legitimate deployer with an address they control
+/// signs for it themselves and wins. Expected to be rewritten when deploy-time
+/// (constructor) initialization lands.
+#[test]
+fn admin_bootstrap_race_self_authorized_front_runner_still_wins() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let attacker = Address::generate(&env);
+    let legitimate_deployer = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "initialize_contract",
+            args: (&attacker,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.initialize_contract(&attacker);
+
+    assert_eq!(
+        client.getadmin(),
+        Some(attacker.clone()),
+        "front-runner wins the bootstrap: require_auth does not close the race"
+    );
+
+    // Even fully authorized, the legitimate deployer cannot take over: both
+    // bootstrap paths are now closed by the already-initialized guard.
+    env.mock_all_auths();
+    assert!(client
+        .try_initialize_contract(&legitimate_deployer)
+        .is_err());
+    assert!(client.try_setadmin(&legitimate_deployer).is_err());
+    assert_eq!(client.getadmin(), Some(attacker));
+}
+
+/// The recovery path exists here (unlike `bounty_escrow`) but is controlled by
+/// the current admin, so it does not help the victim of a lost bootstrap race:
+/// only the front-runner can initiate the rotation away from themselves.
+#[test]
+fn admin_bootstrap_race_recovery_requires_the_front_runner_to_cooperate() {
+    let env = Env::default();
+    let client = create_contract(&env);
+    let attacker = Address::generate(&env);
+    let legitimate_deployer = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize_contract(&attacker);
+    env.mock_auths(&[]);
+
+    // The victim cannot propose themselves: `propose_admin` requires the
+    // current admin's auth, and the current admin is the attacker.
+    assert!(
+        client.try_propose_admin(&legitimate_deployer).is_err(),
+        "rotation must not be startable by a non-admin"
+    );
+    assert_eq!(client.getadmin(), Some(attacker));
+}

--- a/program-escrow/src/test_monitoring.rs
+++ b/program-escrow/src/test_monitoring.rs
@@ -143,7 +143,11 @@ fn test_set_large_payout_threshold_rejects_u32_max() {
     assert_eq!(client.get_large_payout_threshold(), 1000);
 }
 #[test]
-#[should_panic]
+// `expected` matches the `.unwrap()` on the `try_` result below, which surfaces
+// the auth abort as `Err(Abort)`. It still discriminates against the bootstrap:
+// an unauthorized `setadmin` would panic on the non-`try_` call above with a
+// host auth error, not with "Abort".
+#[should_panic(expected = "Abort")]
 fn test_non_admin_cannot_update_large_payout_threshold() {
     let env = Env::default();
 
@@ -151,7 +155,15 @@ fn test_non_admin_cannot_update_large_payout_threshold() {
     let client = ProgramEscrowContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
+
+    // As of #491 `setadmin` requires the incoming admin's own auth. Authorize
+    // ONLY the bootstrap and clear immediately, so the threshold update below
+    // is still evaluated unauthenticated. The `expected` string matters here:
+    // with a bare `#[should_panic]` this test would keep passing off the
+    // bootstrap's own auth failure and stop covering the threshold guard.
+    env.mock_all_auths();
     client.setadmin(&admin);
+    env.mock_auths(&[]);
 
     client.try_set_large_payout_threshold(&2000).unwrap();
 }

--- a/program-escrow/src/test_pause.rs
+++ b/program-escrow/src/test_pause.rs
@@ -25,6 +25,8 @@ fn setup_program_withadmin(env: &Env) -> (ProgramEscrowContract, Address, Addres
 #[test]
 fn test_default_pause_flags_are_all_false() {
     let env = Env::default();
+    // `initialize_contract` requires the incoming admin's own auth as of #491.
+    env.mock_all_auths();
     let (contract, admin) = setup_withadmin(&env);
 
     let flags = contract.get_pause_flags(&env);
@@ -156,6 +158,11 @@ fn test_double_initialize_contract() {
     let contract = ProgramEscrowContract;
     let admin = Address::generate(&env);
 
+    // #491 added `admin.require_auth()` to `initialize_contract`, so the first
+    // call needs authorization. The second still panics with "Already
+    // initialized" rather than an auth error because the already-initialized
+    // guard deliberately runs *before* `require_auth()`.
+    env.mock_all_auths();
     contract.initialize_contract(&env, admin.clone());
     contract.initialize_contract(&env, admin); // should panic
 }

--- a/program-escrow/src/test_whitelist.rs
+++ b/program-escrow/src/test_whitelist.rs
@@ -132,13 +132,22 @@ fn test_set_and_unset_whitelist_enforcement() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "Auth")]
 fn test_set_whitelist_enforced_requires_admin_auth() {
     let env = Env::default();
     let contract_id = env.register_contract(None, ProgramEscrowContract);
     let client = ProgramEscrowContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
+
+    // As of #491 `initialize_contract` requires the incoming admin's own auth.
+    // Authorize ONLY the bootstrap and clear immediately: a blanket
+    // `mock_all_auths()` would also authorize `set_whitelist_enforced` and
+    // this test would pass while proving nothing. The `expected` string is
+    // required for the same reason — a bare `#[should_panic]` would happily
+    // absorb an unauthorized-bootstrap panic instead of the one under test.
+    env.mock_all_auths();
     client.initialize_contract(&admin);
+    env.mock_auths(&[]);
 
     // This should panic
     client.set_whitelist_enforced(&true);

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -53,6 +53,35 @@
 #   - Use stored identities (stellar keys generate) or environment variables
 #   - Mainnet deployments require explicit confirmation
 #
+#   - ALWAYS INITIALIZE IN THE SAME INVOCATION AS THE DEPLOY (issue #491).
+#
+#     Deploying without `--init` (or without a `--` passthrough) leaves the
+#     contract deployed but UNINITIALIZED, and the admin role is claimed by
+#     whoever calls init/initialize_contract/setadmin first. Between the deploy
+#     transaction and a later, separate initialization transaction there is a
+#     window in which any observer of the public network can front-run you and
+#     take the admin role.
+#
+#     The contracts require the incoming admin address to authorize its own
+#     installation, so an attacker cannot install an address you control — but
+#     that does NOT close the race: an attacker naming an address THEY control
+#     and signing for it still wins, permanently.
+#
+#     Consequences of losing the race:
+#       * bounty_escrow  - unrecoverable. `init` is the only writer of the admin
+#                          key and there is no rotation entrypoint at all.
+#       * program-escrow - recoverable only via propose_admin/accept_admin,
+#                          which the CURRENT admin must initiate. If an attacker
+#                          holds it, they must cooperate. In practice: gone.
+#
+#     DO:     ./scripts/deploy.sh contract.wasm -- --admin GABC... --token CDEF...
+#     AVOID:  ./scripts/deploy.sh contract.wasm            # then init separately
+#
+#     If a deploy does land uninitialized, treat the contract as compromised
+#     until you have confirmed on-chain that YOUR initialization transaction is
+#     the one that succeeded. Verify with `getadmin` / `get_admin_audit_view`
+#     before funding it. See docs/DEPLOYMENT_RUNBOOK.md.
+#
 # ==============================================================================
 
 set -euo pipefail
@@ -408,9 +437,27 @@ deploy_contract() {
             "${init_args[@]+"${init_args[@]}"}"; then
             log_warn "Initialization failed or not supported"
             log_warn "You may need to initialize the contract manually"
+            log_warn ""
+            log_warn "SECURITY (issue #491): this contract is deployed but NOT"
+            log_warn "initialized. The admin role goes to whoever initializes it"
+            log_warn "first, and anyone watching the network can do that now."
+            log_warn "Initialize immediately, then CONFIRM the stored admin is"
+            log_warn "yours (getadmin / get_admin_audit_view) before funding it."
+            log_warn "If it is not yours, abandon this contract and redeploy —"
+            log_warn "for bounty_escrow the admin can never be changed."
         else
             log_success "Contract initialized"
         fi
+    else
+        log_warn ""
+        log_warn "SECURITY (issue #491): deployed WITHOUT initialization."
+        log_warn "The admin role is unclaimed and goes to whoever calls"
+        log_warn "init/initialize_contract/setadmin first — including an"
+        log_warn "attacker front-running you between now and your init tx."
+        log_warn "Prefer deploying and initializing in ONE invocation:"
+        log_warn "  ./scripts/deploy.sh <wasm> -- --admin <G...> --token <C...>"
+        log_warn "Otherwise initialize now and verify the stored admin is yours"
+        log_warn "before funding the contract. See docs/DEPLOYMENT_RUNBOOK.md."
     fi
 
     # Record deployment


### PR DESCRIPTION
Closes #491

## Summary

`bounty_escrow::init`, `program-escrow::initialize_contract` and
`program-escrow::setadmin` set the permanent contract admin with no
authorization check of any kind. This adds `admin.require_auth()` to all three,
documents the deploy-then-initialize race window in the deployment tooling, and
adds tests that pin down both what the mitigation buys and what it explicitly
does **not** close.

This is the "at minimum" fix the issue asks for, deliberately scoped that way —
see *Why not the constructor fix* below.

## The gap

All three bootstrap functions were guarded only by "has this already been
called". Line numbers below are **as of `42e4d04`** (the base commit), since
this PR shifts them:

- `bounty_escrow/contracts/escrow/src/lib.rs:770` — `init`, the only writer of
  `DataKey::Admin` in the contract.
- `program-escrow/src/lib.rs:938` — `initialize_contract`.
- `program-escrow/src/lib.rs:952` — `setadmin`.

The severity is asymmetric between the two contracts in a way worth stating
explicitly:

| Contract | Recovery after a lost bootstrap race |
| --- | --- |
| `program-escrow` | `propose_admin` → `accept_admin` (`lib.rs:990` and `:1006` on this branch; `:966`/`:982` at `42e4d04`), but only the **current** admin can initiate it. |
| `bounty_escrow` | **None.** No rotation entrypoint exists. |

## Changes

**Contracts** — `admin.require_auth()` in all three bootstrap paths, placed
*after* the already-initialized guard. That ordering is deliberate and follows
the convention this repo already documents on `accept_admin`
(`program-escrow/src/lib.rs:977-981`: *"must match the pending proposal exactly
— this is checked before `require_auth()`"*). It keeps the existing semantics:
a second `init` still returns `Error::AlreadyInitialized`, and a second
`initialize_contract`/`setadmin` still panics with its original message, rather
than turning into an authorization failure.

Each function's doc comment now carries an `# Authorization` section in the
format already used elsewhere in the codebase
(`bounty_escrow/.../lib.rs:2831`, `:2858`).

**Deployment docs** — `scripts/deploy.sh` gained a security block in its usage
header, plus two runtime warnings: one when a deploy completes *without*
initialization (previously it printed "Deployment Complete" and said nothing
about the admin being unclaimed), and a strengthened one when initialization
fails after deploy. `docs/DEPLOYMENT_RUNBOOK.md` gained a prominent warning
under "Deploy and initialize", a line in the mainnet pre-flight checklist, and
a verify-the-stored-admin step in the operator checklist.

## What this does NOT fix

`require_auth()` does not close the race. An attacker who front-runs the
legitimate deployer, names an address **they** control and signs for it still
wins, permanently. What it buys is that a front-runner can no longer install an
address they do not control.

Fully closing the window needs deploy-time initialization (constructor
arguments at deploy rather than a separate `contract invoke -- init`). That is
not available on the pinned `soroban-sdk 21.0.0` (`Cargo.toml:9`,
`program-escrow/Cargo.toml:10`) — it is an SDK major upgrade across both
crates, not a contract-code change. This PR does not attempt it, and the
residual race is covered by tests and by the operational guidance in the
runbook. `test_admin_bootstrap` is written so those tests are the thing a later
constructor fix invalidates.

## Tests

New `test_admin_bootstrap` module in each contract (5 tests in `bounty_escrow`,
8 in `program-escrow`), named so the issue's suggested command selects them:

```
$ cargo test -p bounty-escrow -p program-escrow admin_bootstrap
test result: ok. 5 passed; 0 failed   (bounty-escrow)
test result: ok. 8 passed; 0 failed   (program-escrow)
```

They cover:

- the legitimate bootstrap still works when the incoming admin signs;
- an unauthorized bootstrap is rejected and installs nothing;
- a front-runner cannot name an address they do not control;
- **the residual race**: a self-authorized front-runner still wins (AC #3's
  "documents the current behavior");
- for `program-escrow`, that the `propose_admin` recovery path does not help
  the victim, because only the current admin can start it.

### Existing tests: two would have silently become vacuous

Adding `require_auth()` to a bootstrap path breaks tests that call it without
mocked auth. Most call sites already mock, but three negative-auth tests did
not, and the failure mode differed in a way worth flagging:

| Test | `should_panic` | Effect |
| --- | --- | --- |
| `program-escrow/src/test_whitelist.rs:136` | bare, no `expected` | would keep **passing off the bootstrap's own auth failure** |
| `program-escrow/src/test_monitoring.rs:147` | bare, no `expected` | same |
| `program-escrow/src/test_pause.rs:154` | `expected = "Already initialized"` | fails loudly |

The difference is only whether the attribute carries an `expected` string — a
bare `#[should_panic]` absorbs any panic, including the new one.

These were fixed with auth mocking **scoped to the bootstrap call** and cleared
immediately (`env.mock_auths(&[])`, the idiom this repo already documents at
`bounty_escrow/.../test_admin_authz.rs:57`). A blanket `mock_all_auths()` would
have authorized the very call each test wants to see rejected. The two bare
attributes also gained `expected` strings so they cannot regress this way
again.

`bounty_escrow/.../test_admin_authz.rs` (from #177) needed the same treatment:
its `AuthzSetup::new()` carried the comment *"no mock_all_auths(). `init`
performs no require_auth"*, which this change makes false.

## Backwards compatibility

**Breaking, intentionally.** `init`, `initialize_contract` and `setadmin` now
require the incoming admin address's authorization. Any deployment flow that
invoked them unauthenticated must now sign as the admin address being
installed.

*Migration:* pass init arguments in the same `scripts/deploy.sh` invocation
(`-- --admin G... --token C...`); the script signs with `DEPLOYER_IDENTITY`. If
initializing manually, the transaction must be signed by the address being set
as admin. No storage layout or existing-state changes — already-initialized
contracts are unaffected.

## Verification

Baseline measured on `42e4d04` before any change, via a clean `cargo test` per
crate, then re-measured on this branch:

| Suite | Baseline (`42e4d04`) | With this PR | New failures |
| --- | --- | --- | --- |
| `bounty_escrow` | 545 passed, 0 failed | **550 passed, 0 failed** | 0 |
| `program-escrow` | 456 passed, 1 failed, 1 ignored | **464 passed, 1 failed, 1 ignored** | 0 |

Every new test passes and no existing test regressed. `program-escrow`'s single
failure is the same one present in the baseline.

`program-escrow`'s single pre-existing failure is
`reentrancy_tests::test_token_callback_reentrancy_batch_payout` — a
`#[should_panic(expected = "Reentrancy detected")]` whose actual panic is
`HostError: Error(Context, InvalidAction)`. It comes from the work that closed
#273 and fails at `42e4d04` before this branch touches anything. Not addressed
here.

**Note on CI coverage:** the `program-escrow-tests` job in
`.github/workflows/ci.yml` is named "Program Escrow - Build Only" and runs
`cargo build`, not `cargo test`. The `program-escrow` tests added here are
therefore **not executed by CI**; they were run locally. Enabling `cargo test`
in that job would currently turn CI red because of the pre-existing failure
above, so it is deliberately left alone rather than changed as a side effect of
this PR.

## Scope

Only the issue's three acceptance criteria. Two findings were made while
verifying and are deliberately **not** addressed here:

1. **`AntiAbuseKey::Admin` collides with `DataKey::Admin` in `bounty_escrow`.**
   Both are `#[contracttype]` enums with a unit variant named `Admin`, which
   Soroban serializes by variant name rather than by type, and both write to
   `instance()` storage (`lib.rs:794` and `lib.rs:297`). The practical effect is
   that `set_anti_abuse_admin` transfers the contract admin role, contradicting
   its own doc comment at `lib.rs:2828` (*"this stored value is informational
   only"*). Confirmed by test. This is a distinct bug from #491 and is being
   filed separately. `program-escrow` is not affected — its
   `CircuitBreakerKey::Admin` lives in `persistent()` storage, a different area.

   This does mean one nuance in my application comment needs correcting: I wrote
   that nothing ever rewrites `DataKey::Admin` in `bounty_escrow`. The
   conclusion holds — the loser of a bootstrap race still cannot recover,
   because that path requires the *current* admin's authorization, i.e. the
   attacker's — but the mechanism statement was imprecise, and there is an
   accidental writer.

2. The constructor-based fix, as described above.
