### PR TITLE
fix SDK program-escrow InvalidThresholdBps mapping

### DIFF
--- a/sdk/src/__tests__/error-mapping.test.ts
+++ b/sdk/src/__tests__/error-mapping.test.ts
@@ -24,7 +24,7 @@ import {
 // -----------------------------------------------------------------------
 
 /** contracts/program-escrow/src/lib.rs — Error enum */
-const PROGRAM_ESCROW_DISCRIMINANTS: number[] = [4];
+const PROGRAM_ESCROW_DISCRIMINANTS: number[] = [4, 5];
 
 /** contracts/bounty_escrow/contracts/escrow/src/lib.rs — Error enum */
 const BOUNTY_ESCROW_DISCRIMINANTS: number[] = [
@@ -181,6 +181,8 @@ describe('parseContractError string matching', () => {
     ['Amount exceeds maximum allowed',                 ContractErrorCode.AMOUNT_ABOVE_MAX],
     ['AmountAboveMaximum',                             ContractErrorCode.AMOUNT_ABOVE_MAX],
     ['GovernanceVersionTooLow',                       ContractErrorCode.GOVERNANCE_VERSION_TOO_LOW],
+    ['InvalidThresholdBps',                            ContractErrorCode.INVALID_THRESHOLD_BPS],
+    ['threshold_bps exceeds 10_000',                   ContractErrorCode.INVALID_THRESHOLD_BPS],
   ];
 
   it.each(programEscrowCases)(
@@ -292,6 +294,14 @@ describe('parseContractError string matching', () => {
 // 4. Cross-layer consistency: numeric ↔ string resolution agrees
 // =======================================================================
 describe('Cross-layer consistency', () => {
+  it('program-escrow numeric and string parsers yield the same code', () => {
+    const fromNumeric = parseContractErrorByCode(5, 'program_escrow');
+    const fromString = parseContractError(new Error('InvalidThresholdBps'));
+
+    expect(fromNumeric.code).toBe(ContractErrorCode.INVALID_THRESHOLD_BPS);
+    expect(fromNumeric.code).toBe(fromString.code);
+  });
+
   it('bounty-escrow numeric and string parsers yield the same code', () => {
     const numericToString: [number, string][] = [
       [3,  'BountyExists'],
@@ -335,12 +345,12 @@ describe('Cross-layer consistency', () => {
 describe('Enum size regression guards', () => {
   it('ContractErrorCode has the expected number of values', () => {
     const count = Object.keys(ContractErrorCode).length;
-    // 11 program-escrow + 23 bounty-escrow + 15 governance + 3 circuit-breaker = 52
-    expect(count).toBe(52);
+    // 12 program-escrow + 23 bounty-escrow + 15 governance + 3 circuit-breaker = 53
+    expect(count).toBe(53);
   });
 
-  it('PROGRAM_ESCROW_ERROR_MAP has 1 entry', () => {
-    expect(Object.keys(PROGRAM_ESCROW_ERROR_MAP).length).toBe(1);
+  it('PROGRAM_ESCROW_ERROR_MAP has 2 entries', () => {
+    expect(Object.keys(PROGRAM_ESCROW_ERROR_MAP).length).toBe(2);
   });
 
   it('BOUNTY_ESCROW_ERROR_MAP has 23 entries', () => {

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -74,6 +74,7 @@ export enum ContractErrorCode {
   AMOUNT_BELOW_MIN         = 'AMOUNT_BELOW_MIN',
   AMOUNT_ABOVE_MAX         = 'AMOUNT_ABOVE_MAX',
   GOVERNANCE_VERSION_TOO_LOW = 'GOVERNANCE_VERSION_TOO_LOW',
+  INVALID_THRESHOLD_BPS    = 'INVALID_THRESHOLD_BPS',
 
   // ── Bounty-Escrow (contracts/bounty_escrow) ────────────────────────────
   BOUNTY_ALREADY_INITIALIZED = 'BOUNTY_ALREADY_INITIALIZED',   // 1
@@ -140,6 +141,7 @@ const CONTRACT_ERROR_MESSAGES: Record<ContractErrorCode, string> = {
   [ContractErrorCode.AMOUNT_BELOW_MIN]:          'Amount is below the minimum allowed by policy',
   [ContractErrorCode.AMOUNT_ABOVE_MAX]:          'Amount exceeds the maximum allowed by policy',
   [ContractErrorCode.GOVERNANCE_VERSION_TOO_LOW]: 'Linked governance contract version is below the required minimum',
+  [ContractErrorCode.INVALID_THRESHOLD_BPS]:     'Large-payout threshold must not exceed 10,000 basis points',
 
   // Bounty-Escrow
   [ContractErrorCode.BOUNTY_ALREADY_INITIALIZED]: 'Bounty escrow contract is already initialized',
@@ -196,6 +198,7 @@ const CONTRACT_ERROR_MESSAGES: Record<ContractErrorCode, string> = {
 /** Program-escrow #[contracterror] discriminants → SDK code */
 export const PROGRAM_ESCROW_ERROR_MAP: Record<number, ContractErrorCode> = {
   4: ContractErrorCode.GOVERNANCE_VERSION_TOO_LOW,
+  5: ContractErrorCode.INVALID_THRESHOLD_BPS,
 };
 
 /** Bounty-escrow #[contracterror] discriminants → SDK code */
@@ -340,6 +343,15 @@ export function parseContractError(error: any): ContractError {
   }
   if (!hasBountyContext && (errorMessage.includes('GovernanceVersionTooLow') || errorMessage.includes('Governance version requirement not met'))) {
     return createContractError(ContractErrorCode.GOVERNANCE_VERSION_TOO_LOW);
+  }
+  if (
+    !hasBountyContext
+    && (
+      errorMessage.includes('InvalidThresholdBps')
+      || /threshold_bps.*(?:exceeds|greater than).*10_?000/i.test(errorMessage)
+    )
+  ) {
+    return createContractError(ContractErrorCode.INVALID_THRESHOLD_BPS);
   }
 
   // ── Bounty-escrow patterns ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add the missing program-escrow error code `5` mapping for `InvalidThresholdBps`
- expose a typed `INVALID_THRESHOLD_BPS` SDK error and human-readable message
- keep the string parser from misclassifying `InvalidThresholdBps` as the governance contract's `GOV_INVALID_THRESHOLD`
- extend numeric, string, cross-layer, enum-size, and map-size regression coverage

## Root cause and impact

The on-chain program-escrow contract defines `InvalidThresholdBps = 5`, but the SDK's program-escrow lookup table only mapped code `4`. Numeric failures from `set_large_payout_threshold` therefore fell back to a generic error. The string parser also matched the `InvalidThresholdBps` variant through its broader `InvalidThreshold` governance pattern, reporting the wrong contract-specific error.

This change makes both numeric and string error paths resolve to the same program-escrow SDK code.

## Validation

- `npm test -- --runInBand` — 302 tests passed
- `npm run build` — passed
- `npm run test:coverage -- --runInBand` — `errors.ts` has 100% statements, functions, and lines; 99.34% branches

Closes #485
