### PR TITLE
fix SDK governance error mappings

### DIFF
--- a/sdk/src/__tests__/error-mapping.test.ts
+++ b/sdk/src/__tests__/error-mapping.test.ts
@@ -34,7 +34,7 @@ const BOUNTY_ESCROW_DISCRIMINANTS: number[] = [
 
 /** contracts/grainlify-core/src/governance.rs — Error enum */
 const GOVERNANCE_DISCRIMINANTS: number[] = [
-  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
 ];
 
 /** contracts/program-escrow/src/error_recovery.rs — u32 constants */
@@ -117,7 +117,7 @@ describe('Numeric error code tables', () => {
   });
 
   describe('Governance', () => {
-    it('maps every contract discriminant (1-14)', () => {
+    it('maps every contract discriminant (1-19)', () => {
       for (const code of GOVERNANCE_DISCRIMINANTS) {
         expect(GOVERNANCE_ERROR_MAP[code]).toBeDefined();
       }
@@ -130,6 +130,15 @@ describe('Numeric error code tables', () => {
         expect(err.code).not.toBe('CONTRACT_ERROR');
         expect(err.contractErrorCode).toBe(code);
       }
+    });
+
+    it('resolves voting-power and authorization errors to distinct codes', () => {
+      expect(parseContractErrorByCode(15, 'governance').code)
+        .toBe(ContractErrorCode.GOV_ZERO_VOTING_POWER);
+      expect(parseContractErrorByCode(16, 'governance').code)
+        .toBe(ContractErrorCode.GOV_INVALID_TOTAL_VOTING_POWER);
+      expect(parseContractErrorByCode(17, 'governance').code)
+        .toBe(ContractErrorCode.GOV_UNAUTHORIZED);
     });
 
     it('returns generic error for unmapped code', () => {
@@ -335,8 +344,8 @@ describe('Cross-layer consistency', () => {
 describe('Enum size regression guards', () => {
   it('ContractErrorCode has the expected number of values', () => {
     const count = Object.keys(ContractErrorCode).length;
-    // 11 program-escrow + 23 bounty-escrow + 15 governance + 3 circuit-breaker = 52
-    expect(count).toBe(52);
+    // 11 program-escrow + 23 bounty-escrow + 19 governance + 3 circuit-breaker = 56
+    expect(count).toBe(56);
   });
 
   it('PROGRAM_ESCROW_ERROR_MAP has 1 entry', () => {
@@ -347,8 +356,8 @@ describe('Enum size regression guards', () => {
     expect(Object.keys(BOUNTY_ESCROW_ERROR_MAP).length).toBe(23);
   });
 
-  it('GOVERNANCE_ERROR_MAP has 15 entries', () => {
-    expect(Object.keys(GOVERNANCE_ERROR_MAP).length).toBe(15);
+  it('GOVERNANCE_ERROR_MAP has 19 entries', () => {
+    expect(Object.keys(GOVERNANCE_ERROR_MAP).length).toBe(19);
   });
 
   it('CIRCUIT_BREAKER_ERROR_MAP has 3 entries', () => {

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -115,7 +115,11 @@ export enum ContractErrorCode {
   GOV_PROPOSAL_NOT_APPROVED  = 'GOV_PROPOSAL_NOT_APPROVED',    // 12
   GOV_EXECUTION_DELAY_NOT_MET = 'GOV_EXECUTION_DELAY_NOT_MET', // 13
   GOV_PROPOSAL_EXPIRED       = 'GOV_PROPOSAL_EXPIRED',         // 14
+  GOV_ZERO_VOTING_POWER      = 'GOV_ZERO_VOTING_POWER',        // 15
+  GOV_INVALID_TOTAL_VOTING_POWER = 'GOV_INVALID_TOTAL_VOTING_POWER', // 16
+  GOV_UNAUTHORIZED           = 'GOV_UNAUTHORIZED',              // 17
   GOV_VOTE_WEIGHT_OVERFLOW   = 'GOV_VOTE_WEIGHT_OVERFLOW',     // 18
+  GOV_ALREADY_INITIALIZED    = 'GOV_ALREADY_INITIALIZED',      // 19
 
   // ── Circuit-Breaker / Error-Recovery ────────────────────────────────────
   CIRCUIT_OPEN               = 'CIRCUIT_OPEN',                 // 1001
@@ -181,7 +185,11 @@ const CONTRACT_ERROR_MESSAGES: Record<ContractErrorCode, string> = {
   [ContractErrorCode.GOV_PROPOSAL_NOT_APPROVED]:  'Proposal has not been approved',
   [ContractErrorCode.GOV_EXECUTION_DELAY_NOT_MET]: 'Execution delay period has not elapsed yet',
   [ContractErrorCode.GOV_PROPOSAL_EXPIRED]:       'Proposal has expired',
+  [ContractErrorCode.GOV_ZERO_VOTING_POWER]:      'Voter has zero voting power',
+  [ContractErrorCode.GOV_INVALID_TOTAL_VOTING_POWER]: 'Total voting power must be greater than zero',
+  [ContractErrorCode.GOV_UNAUTHORIZED]:           'Unauthorized: caller cannot perform this governance action',
   [ContractErrorCode.GOV_VOTE_WEIGHT_OVERFLOW]:   'Vote weight overflow',
+  [ContractErrorCode.GOV_ALREADY_INITIALIZED]:    'Governance has already been initialized',
 
   // Circuit-Breaker
   [ContractErrorCode.CIRCUIT_OPEN]:               'Circuit breaker is open; operation rejected without attempting',
@@ -241,7 +249,11 @@ export const GOVERNANCE_ERROR_MAP: Record<number, ContractErrorCode> = {
   12: ContractErrorCode.GOV_PROPOSAL_NOT_APPROVED,
   13: ContractErrorCode.GOV_EXECUTION_DELAY_NOT_MET,
   14: ContractErrorCode.GOV_PROPOSAL_EXPIRED,
+  15: ContractErrorCode.GOV_ZERO_VOTING_POWER,
+  16: ContractErrorCode.GOV_INVALID_TOTAL_VOTING_POWER,
+  17: ContractErrorCode.GOV_UNAUTHORIZED,
   18: ContractErrorCode.GOV_VOTE_WEIGHT_OVERFLOW,
+  19: ContractErrorCode.GOV_ALREADY_INITIALIZED,
 };
 
 /** Circuit-breaker u32 error constants → SDK code */


### PR DESCRIPTION
## Summary

- add distinct SDK error codes and messages for governance errors 15, 16, and 17
- map every current `grainlify-core` governance discriminant, including code 19 added by the recent reinitialization-guard merge
- extend numeric parsing, completeness, and regression tests

## Why

`parseContractErrorByCode` could not identify `ZeroVotingPower`,
`InvalidTotalVotingPower`, or governance `Unauthorized` failures. While this
fix was being prepared, current `main` also added `AlreadyInitialized = 19`;
mapping it here keeps the SDK table complete against the contract source.

## Validation

- `npm test -- --runInBand` — 300 tests passed
- `npm run build` — passed
- `npm run test:coverage -- --runInBand` — `errors.ts` at 100% statements, functions, and lines (99.32% branches)

Closes #478
