### PR TITLE
Fix EscrowQueryFilter documentation examples

### DIFF
--- a/bounty_escrow/contracts/escrow/src/test_query_filters.rs
+++ b/bounty_escrow/contracts/escrow/src/test_query_filters.rs
@@ -57,6 +57,29 @@ impl Setup {
     }
 }
 
+#[test]
+fn test_documented_escrow_query_filter_shape_compiles() {
+    let s = Setup::new();
+    let ignored_depositor = Address::generate(&s.env);
+    let filter = EscrowQueryFilter {
+        has_status_filter: true,
+        status: EscrowStatus::Locked,
+        has_depositor_filter: false,
+        depositor: ignored_depositor,
+        min_amount: 1000,
+        max_amount: i128::MAX,
+        min_deadline: 0,
+        max_deadline: u64::MAX,
+    };
+
+    assert!(filter.has_status_filter);
+    assert_eq!(filter.status, EscrowStatus::Locked);
+    assert!(!filter.has_depositor_filter);
+    assert_eq!(filter.min_amount, 1000);
+    assert_eq!(filter.max_amount, i128::MAX);
+    assert_eq!(filter.min_deadline, 0);
+    assert_eq!(filter.max_deadline, u64::MAX);
+}
 //  status filter tests
 
 #[test]

--- a/docs/QUERY_DOCUMENTATION.md
+++ b/docs/QUERY_DOCUMENTATION.md
@@ -13,26 +13,31 @@ pub fn query_escrows(env: Env, filter: EscrowQueryFilter, offset: u32, limit: u3
 **Purpose**: Retrieve escrows with comprehensive filtering and pagination support.
 
 **Parameters**:
-- `filter`: EscrowQueryFilter with optional fields:
-  - `status`: Filter by EscrowStatus (Locked, Released, Refunded)
-  - `depositor`: Filter by depositor address
-  - `min_amount`: Minimum escrow amount
-  - `max_amount`: Maximum escrow amount
-  - `min_deadline`: Minimum deadline timestamp
-  - `max_deadline`: Maximum deadline timestamp
+- `filter`: `EscrowQueryFilter` with explicit enable flags and sentinel values:
+  - `has_status_filter`: Set `true` to apply `status`; `false` ignores `status`
+  - `status`: Filter by `EscrowStatus` when `has_status_filter` is `true`
+  - `has_depositor_filter`: Set `true` to apply `depositor`; `false` ignores `depositor`
+  - `depositor`: Filter by depositor address when `has_depositor_filter` is `true`
+  - `min_amount`: Minimum escrow amount; `0` means no minimum
+  - `max_amount`: Maximum escrow amount; `i128::MAX` means no maximum
+  - `min_deadline`: Minimum deadline timestamp; `0` means no minimum
+  - `max_deadline`: Maximum deadline timestamp; `u64::MAX` means no maximum
 - `offset`: Number of records to skip (for pagination)
 - `limit`: Maximum number of records to return
 
 **Example Usage**:
 ```rust
 // Query all locked escrows with amount >= 1000
+let ignored_depositor = Address::generate(&env);
 let filter = EscrowQueryFilter {
-    status: Some(EscrowStatus::Locked),
-    depositor: None,
-    min_amount: Some(1000),
-    max_amount: None,
-    min_deadline: None,
-    max_deadline: None,
+    has_status_filter: true,
+    status: EscrowStatus::Locked,
+    has_depositor_filter: false,
+    depositor: ignored_depositor,
+    min_amount: 1000,
+    max_amount: i128::MAX,
+    min_deadline: 0,
+    max_deadline: u64::MAX,
 };
 let results = contract.query_escrows(env, filter, 0, 50);
 ```
@@ -187,8 +192,14 @@ pub fn get_total_scheduled_amount(env: Env) -> i128
    
    // Less efficient: Filter all escrows by depositor
    let filter = EscrowQueryFilter {
-       depositor: Some(depositor),
-       ..Default::default()
+       has_status_filter: false,
+       status: EscrowStatus::Locked,
+       has_depositor_filter: true,
+       depositor,
+       min_amount: 0,
+       max_amount: i128::MAX,
+       min_deadline: 0,
+       max_deadline: u64::MAX,
    };
    let results = contract.query_escrows(env, filter, 0, 50);
    ```
@@ -196,11 +207,16 @@ pub fn get_total_scheduled_amount(env: Env) -> i128
 3. **Combine Filters**:
    ```rust
    // Efficient: Apply multiple filters in single query
+   let ignored_depositor = Address::generate(&env);
    let filter = EscrowQueryFilter {
-       status: Some(EscrowStatus::Locked),
-       min_amount: Some(1000),
-       max_deadline: Some(current_time + 86400),
-       ..Default::default()
+       has_status_filter: true,
+       status: EscrowStatus::Locked,
+       has_depositor_filter: false,
+       depositor: ignored_depositor,
+       min_amount: 1000,
+       max_amount: i128::MAX,
+       min_deadline: 0,
+       max_deadline: current_time + 86400,
    };
    ```
 

--- a/docs/QUERY_QUICK_REFERENCE.md
+++ b/docs/QUERY_QUICK_REFERENCE.md
@@ -17,13 +17,16 @@ let balance = contract.get_balance(env)?;
 ### Filtered Queries
 ```rust
 // All locked escrows
+let ignored_depositor = Address::generate(&env);
 let filter = EscrowQueryFilter {
-    status: Some(EscrowStatus::Locked),
-    depositor: None,
-    min_amount: None,
-    max_amount: None,
-    min_deadline: None,
-    max_deadline: None,
+    has_status_filter: true,
+    status: EscrowStatus::Locked,
+    has_depositor_filter: false,
+    depositor: ignored_depositor,
+    min_amount: 0,
+    max_amount: i128::MAX,
+    min_deadline: 0,
+    max_deadline: u64::MAX,
 };
 let results = contract.query_escrows(env, filter, 0, 50);
 
@@ -31,13 +34,16 @@ let results = contract.query_escrows(env, filter, 0, 50);
 let results = contract.query_escrows_by_depositor(env, depositor_addr, 0, 50);
 
 // High-value escrows expiring soon
+let ignored_depositor = Address::generate(&env);
 let filter = EscrowQueryFilter {
-    status: Some(EscrowStatus::Locked),
-    depositor: None,
-    min_amount: Some(10000),
-    max_amount: None,
-    min_deadline: None,
-    max_deadline: Some(current_time + 86400), // 24 hours
+    has_status_filter: true,
+    status: EscrowStatus::Locked,
+    has_depositor_filter: false,
+    depositor: ignored_depositor,
+    min_amount: 10000,
+    max_amount: i128::MAX,
+    min_deadline: 0,
+    max_deadline: current_time + 86400, // 24 hours
 };
 let results = contract.query_escrows(env, filter, 0, 50);
 ```
@@ -184,10 +190,16 @@ let due = contract.get_due_schedules(env);
 ```rust
 // Check for expiring escrows
 let soon = current_time + 3600; // 1 hour
+let ignored_depositor = Address::generate(&env);
 let filter = EscrowQueryFilter {
-    status: Some(EscrowStatus::Locked),
-    max_deadline: Some(soon),
-    ..Default::default()
+    has_status_filter: true,
+    status: EscrowStatus::Locked,
+    has_depositor_filter: false,
+    depositor: ignored_depositor,
+    min_amount: 0,
+    max_amount: i128::MAX,
+    min_deadline: 0,
+    max_deadline: soon,
 };
 let expiring = contract.query_escrows(env, filter, 0, 100);
 
@@ -219,26 +231,42 @@ let daily_total: i128 = daily_payouts.iter().map(|p| p.amount).sum();
 
 ```rust
 // Empty filter (no filtering)
+let ignored_depositor = Address::generate(&env);
 let filter = EscrowQueryFilter {
-    status: None,
-    depositor: None,
-    min_amount: None,
-    max_amount: None,
-    min_deadline: None,
-    max_deadline: None,
+    has_status_filter: false,
+    status: EscrowStatus::Locked,
+    has_depositor_filter: false,
+    depositor: ignored_depositor,
+    min_amount: 0,
+    max_amount: i128::MAX,
+    min_deadline: 0,
+    max_deadline: u64::MAX,
 };
 
 // Status only
+let ignored_depositor = Address::generate(&env);
 let filter = EscrowQueryFilter {
-    status: Some(EscrowStatus::Locked),
-    ..Default::default()
+    has_status_filter: true,
+    status: EscrowStatus::Locked,
+    has_depositor_filter: false,
+    depositor: ignored_depositor,
+    min_amount: 0,
+    max_amount: i128::MAX,
+    min_deadline: 0,
+    max_deadline: u64::MAX,
 };
 
 // Amount range
+let ignored_depositor = Address::generate(&env);
 let filter = EscrowQueryFilter {
-    min_amount: Some(1000),
-    max_amount: Some(10000),
-    ..Default::default()
+    has_status_filter: false,
+    status: EscrowStatus::Locked,
+    has_depositor_filter: false,
+    depositor: ignored_depositor,
+    min_amount: 1000,
+    max_amount: 10000,
+    min_deadline: 0,
+    max_deadline: u64::MAX,
 };
 
 // Time range


### PR DESCRIPTION
Closes #486

## Summary
- update every `EscrowQueryFilter` example in `docs/QUERY_DOCUMENTATION.md` and `docs/QUERY_QUICK_REFERENCE.md` to use the real struct fields (`has_status_filter`, `has_depositor_filter`, direct `status`/`depositor`, and sentinel values)
- replace the old `Option`/`Default::default()` examples that would not compile against the actual contract type
- add a focused test that constructs the documented filter shape so future drift is caught by the existing escrow query test module

## Validation
- Verified the real `EscrowQueryFilter` definition in `bounty_escrow/contracts/escrow/src/lib.rs` through the GitHub contents API.
- Checked the changed docs no longer contain `status: Some(...)`, `depositor: None`, `min_amount: Some(...)`, `max_amount: Some(...)`, or `..Default::default()` in `EscrowQueryFilter` examples.
- No project dependencies or Cargo toolchains were installed or executed locally.