### PR TITLE
Fix demo upgrade script path and scheduled upgrade flow

### DIFF
--- a/scripts/demo_upgrade.sh
+++ b/scripts/demo_upgrade.sh
@@ -3,69 +3,77 @@ set -e
 
 # Configuration
 NETWORK="testnet"
-CONTRACT_DIR="contracts/grainlify-core"
+CONTRACT_DIR="grainlify-core"
 SRC_FILE="$CONTRACT_DIR/src/lib.rs"
 SOURCE="demo_user"
+WASM_FILE="target/wasm32-unknown-unknown/release/grainlify_core.wasm"
+MIN_UPGRADE_WAIT_SECONDS=${MIN_UPGRADE_WAIT_SECONDS:-310}
 
 echo "=== Grainlify Contract Upgrade Demo ==="
 
 # 1. Build V1
-echo "[1/9] Building V1..."
+echo "[1/10] Building V1..."
 cargo build --target wasm32-unknown-unknown --release --manifest-path "$CONTRACT_DIR/Cargo.toml"
-WASM_V1="$CONTRACT_DIR/target/wasm32-unknown-unknown/release/grainlify_core.wasm"
+WASM_V1="$WASM_FILE"
 
 # 2. Setup Identity
-echo "[2/9] Setting up Identity..."
+echo "[2/10] Setting up Identity..."
 soroban keys generate "$SOURCE" --network "$NETWORK" --overwrite || true
 soroban keys fund "$SOURCE" --network "$NETWORK"
 
 # 3. Deploy V1
-echo "[3/9] Deploying V1..."
+echo "[3/10] Deploying V1..."
 ID=$(soroban contract deploy --wasm "$WASM_V1" --source "$SOURCE" --network "$NETWORK")
 echo "Contract Deployed: $ID"
 
 # 4. Initialize V1
-echo "[4/9] Initializing V1..."
+echo "[4/10] Initializing V1..."
 ADMIN_ADDR=$(soroban keys address "$SOURCE")
-soroban contract invoke --id "$ID" --source "$SOURCE" --network "$NETWORK" --send=yes -- init --admin "$ADMIN_ADDR"
+soroban contract invoke --id "$ID" --source "$SOURCE" --network "$NETWORK" --send=yes -- init_admin --admin "$ADMIN_ADDR"
 
-# 5. Check Version
-echo "[5/9] Checking Version (Expect: 1)..."
-VER=$(soroban contract invoke --id "$ID" --source "$SOURCE" --network "$NETWORK" -- get_version)
-echo "Current Version: $VER"
+# Use the minimum supported delay so the demo is runnable without waiting 24 hours.
+echo "[5/10] Setting minimum upgrade delay..."
+soroban contract invoke --id "$ID" --source "$SOURCE" --network "$NETWORK" --send=yes -- set_upgrade_delay --delay_seconds 300
 
-if [[ "$VER" != *"1"* ]]; then
-    echo "Error: Expected version 1, got $VER"
-    exit 1
-fi
-
-# 6. Modify Code to V2
-echo "[6/9] Modifying code to Version 2..."
-# Change get_version to return hardcoded 2
-sed -i 's/env.storage().instance().get(&DataKey::Version).unwrap_or(0)/2/' "$SRC_FILE"
-
-# 7. Build V2
-echo "[7/9] Building V2..."
-cargo build --target wasm32-unknown-unknown --release --manifest-path "$CONTRACT_DIR/Cargo.toml"
-WASM_V2="$CONTRACT_DIR/target/wasm32-unknown-unknown/release/grainlify_core.wasm"
-
-# 8. Upgrade
-echo "[8/9] Upgrading Contract..."
-./scripts/upgrade_contract.sh "$ID" "$WASM_V2" "$NETWORK" "$SOURCE"
-
-# 9. Check Version
-echo "[9/9] Checking Version (Expect: 2)..."
+# 6. Check Version
+echo "[6/10] Checking Version (Expect: 2)..."
 VER=$(soroban contract invoke --id "$ID" --source "$SOURCE" --network "$NETWORK" -- get_version)
 echo "Current Version: $VER"
 
 if [[ "$VER" != *"2"* ]]; then
     echo "Error: Expected version 2, got $VER"
-    # Cleanup before exit
-    sed -i 's/2/env.storage().instance().get(\&DataKey::Version).unwrap_or(0)/' "$SRC_FILE"
     exit 1
 fi
 
-# Cleanup
+# 7. Modify Code to V3
+echo "[7/10] Modifying code to Version 3..."
+cp "$SRC_FILE" "$SRC_FILE.bak"
+restore_source() {
+    if [ -f "$SRC_FILE.bak" ]; then
+        mv "$SRC_FILE.bak" "$SRC_FILE"
+    fi
+}
+trap restore_source EXIT
+# Change get_version to return hardcoded 3.
+sed -i 's/env.storage().instance().get(&DataKey::Version).unwrap_or(0)/3/' "$SRC_FILE"
+
+# 8. Build V3
+echo "[8/10] Building V3..."
+cargo build --target wasm32-unknown-unknown --release --manifest-path "$CONTRACT_DIR/Cargo.toml"
+WASM_V2="$WASM_FILE"
+
+# 9. Schedule and execute upgrade
+echo "[9/10] Scheduling and executing Contract Upgrade..."
+./scripts/upgrade_contract.sh "$ID" "$WASM_V2" "$NETWORK" "$SOURCE" "$MIN_UPGRADE_WAIT_SECONDS"
+
+# 10. Check Version
+echo "[10/10] Checking Version (Expect: 3)..."
+VER=$(soroban contract invoke --id "$ID" --source "$SOURCE" --network "$NETWORK" -- get_version)
+echo "Current Version: $VER"
+
+if [[ "$VER" != *"3"* ]]; then
+    echo "Error: Expected version 3, got $VER"
+    exit 1
+fi
+
 echo "=== Demo Successful ==="
-echo "Restoring source code..."
-sed -i 's/2/env.storage().instance().get(\&DataKey::Version).unwrap_or(0)/' "$SRC_FILE"

--- a/scripts/upgrade_contract.sh
+++ b/scripts/upgrade_contract.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 set -e
 
-# Usage: ./upgrade_contract.sh <CONTRACT_ID> <WASM_FILE> <NETWORK> <SOURCE_IDENTITY>
-# Example: ./upgrade_contract.sh C... contracts/grainlify-core/target/wasm32-unknown-unknown/release/grainlify_core.wasm testnet demo_user
+# Usage: ./upgrade_contract.sh <CONTRACT_ID> <WASM_FILE> <NETWORK> <SOURCE_IDENTITY> [WAIT_SECONDS]
+# Example: ./upgrade_contract.sh C... target/wasm32-unknown-unknown/release/grainlify_core.wasm testnet demo_user 310
+# If WAIT_SECONDS is omitted, the script uploads and schedules the upgrade, then exits
+# before execution so callers can wait for the configured timelock themselves.
 
 CONTRACT_ID=$1
 WASM_FILE=$2
 NETWORK=${3:-testnet}
 SOURCE=${4:-default}
+WAIT_SECONDS=${5:-}
 
 if [ -z "$CONTRACT_ID" ] || [ -z "$WASM_FILE" ]; then
-    echo "Usage: $0 <CONTRACT_ID> <WASM_FILE> [NETWORK] [SOURCE_IDENTITY]"
+    echo "Usage: $0 <CONTRACT_ID> <WASM_FILE> [NETWORK] [SOURCE_IDENTITY] [WAIT_SECONDS]"
     exit 1
 fi
 
@@ -19,7 +22,26 @@ echo "Uploading WASM..."
 WASM_HASH=$(soroban contract upload --wasm "$WASM_FILE" --network "$NETWORK" --source "$SOURCE")
 echo "WASM Hash: $WASM_HASH"
 
-echo "Upgrading contract..."
+echo "Scheduling contract upgrade..."
+soroban contract invoke \
+    --id "$CONTRACT_ID" \
+    --network "$NETWORK" \
+    --source "$SOURCE" \
+    --send=yes \
+    -- \
+    schedule_upgrade \
+    --wasm_hash "$WASM_HASH"
+
+if [ -z "$WAIT_SECONDS" ]; then
+    echo "Upgrade scheduled. Wait until the scheduled executable_at timestamp, then run:"
+    echo "soroban contract invoke --id $CONTRACT_ID --network $NETWORK --source $SOURCE --send=yes -- upgrade --new_wasm_hash $WASM_HASH"
+    exit 0
+fi
+
+echo "Waiting $WAIT_SECONDS seconds for the upgrade timelock..."
+sleep "$WAIT_SECONDS"
+
+echo "Executing contract upgrade..."
 soroban contract invoke \
     --id "$CONTRACT_ID" \
     --network "$NETWORK" \


### PR DESCRIPTION
Fixes #481.\n\nUpdates the demo and upgrade helper to match the current repository layout and contract API:\n\n- points the demo at the root-level grainlify-core package and workspace 	arget output\n- initializes the single-admin path with init_admin instead of passing --admin to the multisig init entrypoint\n- schedules the uploaded WASM with schedule_upgrade before calling upgrade\n- lets the helper stop after scheduling unless an explicit wait period is supplied, while the demo uses the minimum configured delay\n\nValidation: static script/API review only; I did not run testnet Soroban commands from this environment.