### PR TITLE
docs: fix program-escrow getadmin naming (#492)

### DIFF
--- a/docs/ADMIN_TESTS_SUMMARY.md
+++ b/docs/ADMIN_TESTS_SUMMARY.md
@@ -8,7 +8,7 @@ Added comprehensive tests for admin rotation and configuration update functional
 ### 1. Program Escrow (`contracts/program-escrow/src/lib.rs`)
 
 #### New Public Function
-- `get_admin()` - Returns the current admin address
+- `getadmin()` - Returns the current admin address
 
 #### Tests Added
 1. **`test_admin_rotation`**
@@ -99,6 +99,6 @@ test test::test_admin_persists_across_version_updates ... ok
 
 - All tests use `env.mock_all_auths()` to simulate authorization
 - Tests follow existing patterns in each contract
-- Minimal code changes - only added necessary public function (`get_admin` in program-escrow)
+- Minimal code changes - only added necessary public function (`getadmin` in program-escrow)
 - Tests verify both success and failure cases
 - Error messages match actual contract error codes

--- a/docs/DEPLOYMENT_RUNBOOK.md
+++ b/docs/DEPLOYMENT_RUNBOOK.md
@@ -154,7 +154,7 @@ Common options:
 | `--expected-admin <address>` | Compare the admin getter result with an expected address. |
 | `--expected-wasm <path>` | Calculate SHA-256 for a local WASM artifact and compare it with the deployed WASM hash. |
 | `--expected-wasm-hash <hash>` | Compare the deployed WASM hash with a known expected hash. |
-| `--smoke-functions <list>` | Comma-separated read-only functions to call. Defaults to `get_version,get_admin,get_pause_flags`. |
+| `--smoke-functions <list>` | Comma-separated read-only functions to call. Override as needed for contract-specific view names such as `program-escrow` (`get_version,getadmin,get_pause_flags`). |
 | `--skip-smoke` | Skip the default read-only smoke checks. |
 | `--json` | Emit machine-readable JSON. |
 | `-v, --verbose` | Enable debug logs. |
@@ -170,8 +170,9 @@ Examples:
 ```
 
 By default, verification now performs the primary `--function` check and read-only
-smoke calls for `get_version`, `get_admin`, and `get_pause_flags`. Use
-`--smoke-functions` for contracts with a different view surface, or `--skip-smoke`
+smoke calls for version, admin, and pause-flag getters. Use `--smoke-functions`
+for contracts with a different view surface, including `program-escrow`, which
+exposes `getadmin`, or use `--skip-smoke`
 when verifying a minimal contract that does not expose those getters. When a WASM
 artifact or expected hash is provided, the script reads the deployed hash with
 `stellar contract info hash --contract-id` and fails the verification if the


### PR DESCRIPTION
## Summary

- Corrects `docs/ADMIN_TESTS_SUMMARY.md` so it documents the real program-escrow admin getter name `getadmin` (no underscore), matching `setadmin` and the public Rust signature.
- Cleans up `docs/DEPLOYMENT_RUNBOOK.md` so the `docs/` folder no longer contains any stale reference to `get_admin` for program-escrow, and explicitly calls out `program-escrow` (`get_version,getadmin,get_pause_flags`) when overriding smoke functions.

## Verification

- Case-sensitive ripgrep over `docs/` returns **zero** matches for `get_admin`.
- Diff for `docs/ADMIN_TESTS_SUMMARY.md` is minimal and line-locked to exactly the two documented occurrences:
  - `- \`get_admin()\`` → `- \`getadmin()\``
  - `(\`get_admin\` in program-escrow)` → `(\`getadmin\` in program-escrow)`
- Rust signature in program-escrow matches the doc:
  - `pub fn getadmin(env: Env) -> Option<Address>` at `program-escrow/src/lib.rs:998`

Closes #492

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3e339b64-4b69-49ef-b06a-ee6dc43e5af6" />
