### PR TITLE
feat: emit canonical dispute resolution events

### DIFF
--- a/bounty_escrow/contracts/escrow/src/events.rs
+++ b/bounty_escrow/contracts/escrow/src/events.rs
@@ -224,6 +224,40 @@ pub fn emit_claim_cancelled(env: &Env, event: ClaimCancelled) {
     env.events().publish(topics, event.clone());
 }
 
+/// Final outcome of a pending-claim dispute.
+///
+/// `Claimed` means the authorized recipient completed the claim.
+/// `Cancelled` means the admin cancelled a still-active claim.
+/// `Expired` means the admin cleared a claim after its claim window elapsed.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DisputeOutcome {
+    Claimed,
+    Cancelled,
+    Expired,
+}
+
+/// Emitted exactly once when a pending-claim dispute reaches a terminal outcome.
+///
+/// The `(dispute, resolved)` topic is stable for off-chain indexers. Existing
+/// claim lifecycle events remain emitted for backward compatibility.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisputeResolved {
+    pub version: u32,
+    pub bounty_id: u64,
+    pub outcome: DisputeOutcome,
+    pub resolver: Address,
+    pub recipient: Address,
+    pub amount: i128,
+    pub resolved_at: u64,
+}
+
+pub fn emit_dispute_resolved(env: &Env, event: DisputeResolved) {
+    let topics = (symbol_short!("dispute"), symbol_short!("resolved"));
+    env.events().publish(topics, event);
+}
+
 pub fn emit_pause_state_changed(env: &Env, event: crate::PauseStateChanged) {
     let topics = (symbol_short!("pause"), event.operation.clone());
     env.events().publish(topics, event);

--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -6,6 +6,8 @@ mod error_recovery;
 
 #[cfg(test)]
 mod test_rbac;
+#[cfg(test)]
+mod test_dispute_events;
 mod test_admin_authz;
 mod test_coverage_boost;
 mod test_coverage_boost_small;
@@ -15,9 +17,9 @@ mod test_serialization;
 use events::{
     emit_batch_funds_locked, emit_batch_funds_released, emit_bounty_expired,
     emit_bounty_initialized, emit_funds_locked, emit_funds_refunded, emit_funds_released,
-    emit_claim_created, emit_claim_executed, emit_claim_cancelled,
+    emit_claim_created, emit_claim_executed, emit_claim_cancelled, emit_dispute_resolved,
     BatchFundsLocked, BatchFundsReleased, BountyEscrowInitialized, BountyExpired,
-    ClaimCancelled, ClaimCreated, ClaimExecuted,
+    ClaimCancelled, ClaimCreated, ClaimExecuted, DisputeOutcome, DisputeResolved,
     FundsLocked, FundsRefunded, FundsReleased, EVENT_VERSION_V2,
 };
 use analytics::{
@@ -1699,6 +1701,18 @@ impl BountyEscrowContract {
                 claimed_at: now,
             },
         );
+        emit_dispute_resolved(
+            &env,
+            DisputeResolved {
+                version: EVENT_VERSION_V2,
+                bounty_id,
+                outcome: DisputeOutcome::Claimed,
+                resolver: claim.recipient.clone(),
+                recipient: claim.recipient.clone(),
+                amount: claim_amount,
+                resolved_at: now,
+            },
+        );
         env.storage().instance().remove(&DataKey::ReentrancyGuard);
         Ok(())
     }
@@ -1744,11 +1758,27 @@ impl BountyEscrowContract {
             ClaimCancelled {
                 version: EVENT_VERSION_V2,
                 bounty_id,
-                recipient: claim.recipient,
+                recipient: claim.recipient.clone(),
                 amount: claim.amount,
                 cancelled_at,
-                cancelled_by: admin,
-                reason,
+                cancelled_by: admin.clone(),
+                reason: reason.clone(),
+            },
+        );
+        emit_dispute_resolved(
+            &env,
+            DisputeResolved {
+                version: EVENT_VERSION_V2,
+                bounty_id,
+                outcome: if reason == symbol_short!("expired") {
+                    DisputeOutcome::Expired
+                } else {
+                    DisputeOutcome::Cancelled
+                },
+                resolver: admin,
+                recipient: claim.recipient,
+                amount: claim.amount,
+                resolved_at: cancelled_at,
             },
         );
         Ok(())

--- a/bounty_escrow/contracts/escrow/src/test_dispute_events.rs
+++ b/bounty_escrow/contracts/escrow/src/test_dispute_events.rs
@@ -1,0 +1,139 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Events as _, Ledger},
+    token, Address, Env, IntoVal, TryFromVal, Val, Vec,
+};
+
+struct Fixture<'a> {
+    env: Env,
+    contract_id: Address,
+    admin: Address,
+    depositor: Address,
+    recipient: Address,
+    token_id: Address,
+    client: BountyEscrowContractClient<'a>,
+}
+
+impl<'a> Fixture<'a> {
+    fn new(claim_window: u64) -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(100);
+
+        let contract_id = env.register_contract(None, BountyEscrowContract);
+        let client = BountyEscrowContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let depositor = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+
+        client.init(&admin, &token_id);
+        client.set_claim_window(&claim_window);
+
+        Self {
+            env,
+            contract_id,
+            admin,
+            depositor,
+            recipient,
+            token_id,
+            client,
+        }
+    }
+
+    fn authorize(&self, bounty_id: u64, amount: i128) {
+        token::StellarAssetClient::new(&self.env, &self.token_id).mint(&self.depositor, &amount);
+        self.client.lock_funds(
+            &self.depositor,
+            &bounty_id,
+            &amount,
+            &(self.env.ledger().timestamp() + 3_600),
+        );
+        self.client.authorize_claim(&bounty_id, &self.recipient);
+    }
+
+    fn last_dispute_event(&self) -> DisputeResolved {
+        let events = self.env.events().all();
+        assert!(events.len() > 0, "expected at least one contract event");
+
+        let (contract_id, topics, data) = events.get(events.len() - 1).unwrap();
+        let expected_topics: Vec<Val> =
+            (symbol_short!("dispute"), symbol_short!("resolved")).into_val(&self.env);
+
+        assert_eq!(contract_id, self.contract_id);
+        assert_eq!(topics, expected_topics);
+
+        DisputeResolved::try_from_val(&self.env, &data)
+            .expect("dispute event payload should decode")
+    }
+}
+
+#[test]
+fn claim_emits_claimed_dispute_resolution() {
+    let fixture = Fixture::new(60);
+    fixture.authorize(11, 1_000);
+
+    fixture.client.claim(&11);
+
+    assert_eq!(
+        fixture.last_dispute_event(),
+        DisputeResolved {
+            version: EVENT_VERSION_V2,
+            bounty_id: 11,
+            outcome: DisputeOutcome::Claimed,
+            resolver: fixture.recipient.clone(),
+            recipient: fixture.recipient.clone(),
+            amount: 1_000,
+            resolved_at: 100,
+        }
+    );
+}
+
+#[test]
+fn manual_cancellation_emits_cancelled_dispute_resolution() {
+    let fixture = Fixture::new(60);
+    fixture.authorize(12, 2_000);
+
+    fixture.client.cancel_pending_claim(&12);
+
+    assert_eq!(
+        fixture.last_dispute_event(),
+        DisputeResolved {
+            version: EVENT_VERSION_V2,
+            bounty_id: 12,
+            outcome: DisputeOutcome::Cancelled,
+            resolver: fixture.admin.clone(),
+            recipient: fixture.recipient.clone(),
+            amount: 2_000,
+            resolved_at: 100,
+        }
+    );
+}
+
+#[test]
+fn expired_claim_emits_expired_dispute_resolution() {
+    let fixture = Fixture::new(10);
+    fixture.authorize(13, 3_000);
+    fixture.env.ledger().set_timestamp(111);
+
+    fixture.client.cancel_pending_claim(&13);
+
+    assert_eq!(
+        fixture.last_dispute_event(),
+        DisputeResolved {
+            version: EVENT_VERSION_V2,
+            bounty_id: 13,
+            outcome: DisputeOutcome::Expired,
+            resolver: fixture.admin.clone(),
+            recipient: fixture.recipient.clone(),
+            amount: 3_000,
+            resolved_at: 111,
+        }
+    );
+}

--- a/bounty_escrow/contracts/escrow/src/test_expiration_and_dispute.rs
+++ b/bounty_escrow/contracts/escrow/src/test_expiration_and_dispute.rs
@@ -22,6 +22,31 @@ fn create_escrow_contract<'a>(e: &Env) -> BountyEscrowContractClient<'a> {
     BountyEscrowContractClient::new(e, &contract_id)
 }
 
+fn last_claim_cancelled_event_data(env: &Env) -> Val {
+    let claim_topic = Symbol::new(env, "claim");
+    let cancel_topic = Symbol::new(env, "cancel");
+    let mut matched = None;
+
+    for (_contract, topics, data) in env.events().all().iter() {
+        if topics.len() != 2 {
+            continue;
+        }
+
+        let first = topics
+            .get(0)
+            .and_then(|value| Symbol::try_from_val(env, &value).ok());
+        let second = topics
+            .get(1)
+            .and_then(|value| Symbol::try_from_val(env, &value).ok());
+
+        if first == Some(claim_topic.clone()) && second == Some(cancel_topic.clone()) {
+            matched = Some(data);
+        }
+    }
+
+    matched.expect("cancel should emit the legacy ClaimCancelled event")
+}
+
 struct TestSetup<'a> {
     env: Env,
     admin: Address,
@@ -221,8 +246,7 @@ fn test_cancel_expired_claim_emits_expired_reason() {
 
     setup.escrow.cancel_pending_claim(&bounty_id);
 
-    let events = setup.env.events().all();
-    let (_contract, _topics, data) = events.last().expect("cancel should emit an event");
+    let data = last_claim_cancelled_event_data(&setup.env);
     let data_map: Map<Symbol, Val> =
         Map::try_from_val(&setup.env, &data).expect("event payload should be a map");
     let reason_val = data_map
@@ -256,8 +280,7 @@ fn test_cancel_active_claim_emits_manual_reason() {
 
     setup.escrow.cancel_pending_claim(&bounty_id);
 
-    let events = setup.env.events().all();
-    let (_contract, _topics, data) = events.last().expect("cancel should emit an event");
+    let data = last_claim_cancelled_event_data(&setup.env);
     let data_map: Map<Symbol, Val> =
         Map::try_from_val(&setup.env, &data).expect("event payload should be a map");
     let reason_val = data_map
@@ -291,8 +314,7 @@ fn test_cancel_claim_at_boundary_emits_manual_reason() {
 
     setup.escrow.cancel_pending_claim(&bounty_id);
 
-    let events = setup.env.events().all();
-    let (_contract, _topics, data) = events.last().expect("cancel should emit an event");
+    let data = last_claim_cancelled_event_data(&setup.env);
     let data_map: Map<Symbol, Val> =
         Map::try_from_val(&setup.env, &data).expect("event payload should be a map");
     let reason_val = data_map

--- a/bounty_escrow/contracts/escrow/src/test_serialization.rs
+++ b/bounty_escrow/contracts/escrow/src/test_serialization.rs
@@ -150,6 +150,12 @@ fn ser_event_types() {
     roundtrip(&env, events::ClaimCancelled{ version: 1, bounty_id: 1,
         recipient: a.clone(), amount: 100, cancelled_at: 42,
         cancelled_by: a.clone(), reason: Symbol::new(&env, "test") });
+    roundtrip(&env, events::DisputeOutcome::Claimed);
+    roundtrip(&env, events::DisputeOutcome::Cancelled);
+    roundtrip(&env, events::DisputeOutcome::Expired);
+    roundtrip(&env, events::DisputeResolved{ version: 2, bounty_id: 1,
+        outcome: events::DisputeOutcome::Claimed, resolver: a.clone(),
+        recipient: a.clone(), amount: 100, resolved_at: 42 });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- adds a versioned `DisputeResolved` event under the stable `(dispute, resolved)` topic
- records `Claimed`, `Cancelled`, and `Expired` terminal outcomes
- includes the bounty ID, resolver, recipient, amount, and resolution timestamp
- preserves the existing claim lifecycle events for backward compatibility
- updates existing cancellation tests to locate legacy events by topic instead of assuming they are emitted last
- adds event payload, topic, outcome, and serialization coverage

## Validation

- `cargo test --manifest-path bounty_escrow/Cargo.toml -p bounty-escrow test_dispute_events`
- `cargo test --manifest-path bounty_escrow/Cargo.toml -p bounty-escrow ser_event_types`
- `cargo test --manifest-path bounty_escrow/Cargo.toml -p bounty-escrow`
- 548 tests passed, 0 failed
- `git diff --check`

Closes #169