### PR TITLE
test: cover migration state getters lifecycle

### DIFF
--- a/grainlify-core/src/lib.rs
+++ b/grainlify-core/src/lib.rs
@@ -2242,7 +2242,7 @@ mod test {
     }
 
     #[test]
-    fn test_get_previous_version() {
+    fn test_migration_state_getters_none_before_any_migration() {
         let env = Env::default();
         env.mock_all_auths();
 
@@ -2252,14 +2252,130 @@ mod test {
         let admin = Address::generate(&env);
         client.init_admin(&admin);
 
-        // Initially no previous version
-        assert!(client.get_previous_version().is_none());
+        assert_eq!(client.get_migration_state(), None);
+        assert_eq!(client.get_previous_version(), None);
+        assert_eq!(client.get_analytics().migrations_run, 0);
+        assert_eq!(client.get_state_snapshot().migrations_run, 0);
+    }
 
-        // Simulate upgrade (this would normally be done via upgrade() but we'll set version directly)
-        client.set_version(&2);
+    #[test]
+    fn test_migration_state_getters_across_upgrade_and_migrate_lifecycle() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|li| li.timestamp = 8_000);
 
-        // Previous version should still be None unless upgrade() was called
-        // This test verifies the get_previous_version function works
+        let contract_id = env.register_contract(None, GrainlifyContract);
+        let client = GrainlifyContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.init_admin(&admin);
+
+        let pre_upgrade_version = client.get_version();
+
+        assert_eq!(client.get_migration_state(), None);
+        assert_eq!(client.get_previous_version(), None);
+        assert_eq!(client.get_analytics().migrations_run, 0);
+
+        // Drive the real single-admin upgrade path. The empty uploaded WASM is
+        // sufficient for exercising update_current_contract_wasm in the test host.
+        let replacement_wasm_hash = env.deployer().upload_contract_wasm([].as_slice());
+
+        client.set_upgrade_delay(&600);
+        let scheduled = client.schedule_upgrade(&replacement_wasm_hash);
+
+        assert_eq!(scheduled.scheduled_at, 8_000);
+        assert_eq!(scheduled.executable_at, 8_600);
+
+        env.ledger().with_mut(|li| li.timestamp = scheduled.executable_at);
+        client.upgrade(&replacement_wasm_hash);
+
+        // The replacement test WASM has no callable entrypoints. Invoke the
+        // implementation directly in the preserved contract context to verify
+        // instance storage written by the real upgrade invocation.
+        let version_after_upgrade = env.as_contract(&contract_id, || {
+            GrainlifyContract::get_version(env.clone())
+        });
+        let previous_version = env.as_contract(&contract_id, || {
+            GrainlifyContract::get_previous_version(env.clone())
+        });
+        let migration_state_before = env.as_contract(&contract_id, || {
+            GrainlifyContract::get_migration_state(env.clone())
+        });
+
+        assert_eq!(version_after_upgrade, pre_upgrade_version);
+        assert_eq!(previous_version, Some(pre_upgrade_version));
+        assert_eq!(migration_state_before, None);
+
+        let target_version = pre_upgrade_version + 1;
+        let migration_hash = BytesN::from_array(&env, &[4u8; 32]);
+        let migrated_at = scheduled.executable_at + 1;
+
+        env.ledger().with_mut(|li| li.timestamp = migrated_at);
+
+        env.as_contract(&contract_id, || {
+            GrainlifyContract::migrate(
+                env.clone(),
+                target_version,
+                migration_hash.clone(),
+            );
+        });
+
+        let migration_state = env
+            .as_contract(&contract_id, || {
+                GrainlifyContract::get_migration_state(env.clone())
+            })
+            .expect("completed migration must record migration state");
+
+        assert_eq!(
+            migration_state,
+            MigrationState {
+                from_version: pre_upgrade_version,
+                to_version: target_version,
+                migrated_at,
+                migration_hash: migration_hash.clone(),
+            }
+        );
+
+        let previous_after_migration = env.as_contract(&contract_id, || {
+            GrainlifyContract::get_previous_version(env.clone())
+        });
+        let analytics_after_migration = env.as_contract(&contract_id, || {
+            GrainlifyContract::get_analytics(env.clone())
+        });
+        let snapshot_after_migration = env.as_contract(&contract_id, || {
+            GrainlifyContract::get_state_snapshot(env.clone())
+        });
+
+        assert_eq!(
+            previous_after_migration,
+            Some(pre_upgrade_version),
+            "migration must not overwrite the version captured by upgrade()"
+        );
+        assert_eq!(analytics_after_migration.upgrades_executed, 1);
+        assert_eq!(analytics_after_migration.migrations_run, 1);
+        assert_eq!(snapshot_after_migration.migrations_run, 1);
+
+        // The same completed migration is idempotent: state and counters must
+        // remain unchanged.
+        env.ledger().with_mut(|li| li.timestamp = migrated_at + 100);
+
+        env.as_contract(&contract_id, || {
+            GrainlifyContract::migrate(
+                env.clone(),
+                target_version,
+                migration_hash.clone(),
+            );
+        });
+
+        let state_after_repeat = env.as_contract(&contract_id, || {
+            GrainlifyContract::get_migration_state(env.clone())
+        });
+        let analytics_after_repeat = env.as_contract(&contract_id, || {
+            GrainlifyContract::get_analytics(env.clone())
+        });
+
+        assert_eq!(state_after_repeat, Some(migration_state));
+        assert_eq!(analytics_after_repeat.migrations_run, 1);
     }
 
     /// get_version_semver_string must return "3.0.0" after migrating to version 3.


### PR DESCRIPTION
## Summary

- directly verifies `get_migration_state()` and `get_previous_version()` return `None` before migration or upgrade
- executes the real scheduled single-admin WASM upgrade path
- verifies `get_previous_version()` preserves the version upgraded from
- verifies the complete migration state after the supported migration
- confirms the migration counter increments exactly once
- confirms an idempotent repeated migration does not change state or increment the counter

## Validation

- `cargo test -p grainlify-core migration_state_getters` — 2 passed
- `cargo test -p grainlify-core migration` — 17 passed
- `cargo test -p grainlify-core` — 125 passed; 2 unrelated existing tests fail in `test_migrate_docs_example` and `test_upgrade_replay_guard_and_rescheduling`
- `git diff --check`

Closes #401