### PR TITLE
Closes #445: Implemented: bounty_escrow query_escrows_by_status/by_amount/by_deadline/get_escrow_ids_by_status/query_expiring_bounties accept an unbounded limit with no upper cap  #445

### DIFF
--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -364,6 +364,9 @@ mod anti_abuse {
 const BASIS_POINTS: i128 = 10_000;
 const MAX_FEE_RATE: i128 = 5_000; // 50% max fee
 const MAX_BATCH_SIZE: u32 = 20;
+/// Hard ceiling on the `limit` parameter for read-side pagination functions.
+/// Callers needing more results must loop with `offset` to paginate.
+const MAX_QUERY_LIMIT: u32 = 100;
 /// Extend escrow persistent entries when the ledger sequence is within roughly one day of expiry.
 const ESCROW_TTL_THRESHOLD: u32 = 17_280;
 /// Keep escrow persistent entries alive for roughly thirty days on five-second ledgers.
@@ -2383,8 +2386,10 @@ impl BountyEscrowContract {
 
     /// Query escrows with filtering and pagination
     /// Pass 0 for min values and i128::MAX/u64::MAX for max values to disable those filters
-    /// Query escrows with filtering and pagination
-    /// Pass 0 for min values and i128::MAX/u64::MAX for max values to disable those filters
+    ///
+    /// # Pagination
+    /// The `limit` parameter is capped at [`MAX_QUERY_LIMIT`] (100). Callers
+    /// needing more results must loop with increasing `offset` values.
     ///
     /// # Authorization
     /// None — callable by anyone (read-only query).
@@ -2394,6 +2399,7 @@ impl BountyEscrowContract {
         offset: u32,
         limit: u32,
     ) -> Vec<EscrowWithId> {
+        let limit = limit.min(MAX_QUERY_LIMIT);
         let index: Vec<u64> = env
             .storage()
             .persistent()
@@ -2428,7 +2434,10 @@ impl BountyEscrowContract {
     }
 
     /// Query escrows with amount range filtering
-    /// Query escrows with amount range filtering
+    ///
+    /// # Pagination
+    /// The `limit` parameter is capped at [`MAX_QUERY_LIMIT`] (100). Callers
+    /// needing more results must loop with increasing `offset` values.
     ///
     /// # Authorization
     /// None — callable by anyone (read-only query).
@@ -2439,6 +2448,7 @@ impl BountyEscrowContract {
         offset: u32,
         limit: u32,
     ) -> Vec<EscrowWithId> {
+        let limit = limit.min(MAX_QUERY_LIMIT);
         let index: Vec<u64> = env
             .storage()
             .persistent()
@@ -2473,7 +2483,10 @@ impl BountyEscrowContract {
     }
 
     /// Query escrows with deadline range filtering
-    /// Query escrows with deadline range filtering
+    ///
+    /// # Pagination
+    /// The `limit` parameter is capped at [`MAX_QUERY_LIMIT`] (100). Callers
+    /// needing more results must loop with increasing `offset` values.
     ///
     /// # Authorization
     /// None — callable by anyone (read-only query).
@@ -2484,6 +2497,7 @@ impl BountyEscrowContract {
         offset: u32,
         limit: u32,
     ) -> Vec<EscrowWithId> {
+        let limit = limit.min(MAX_QUERY_LIMIT);
         let index: Vec<u64> = env
             .storage()
             .persistent()
@@ -2568,8 +2582,9 @@ impl BountyEscrowContract {
     ///
     /// # Pagination
     /// - offset: Number of matching records to skip
-    /// - limit: Maximum number of records to return
+    /// - limit: Maximum number of records to return (capped at [`MAX_QUERY_LIMIT`] — 100)
     /// - Pagination is stable and works correctly with any filter combination
+    /// - Callers needing more results must loop with increasing `offset` values
     ///
     /// # Security Notes
     /// - Read-only query function - no state modifications
@@ -2581,6 +2596,7 @@ impl BountyEscrowContract {
         offset: u32,
         limit: u32,
     ) -> Vec<EscrowWithId> {
+        let limit = limit.min(MAX_QUERY_LIMIT);
         // Optimization: use depositor index when depositor filter is active
         let index: Vec<u64> = if filter.has_depositor_filter {
             env.storage()
@@ -2801,7 +2817,10 @@ impl BountyEscrowContract {
     }
 
     /// Get escrow IDs by status
-    /// Get escrow IDs by status
+    ///
+    /// # Pagination
+    /// The `limit` parameter is capped at [`MAX_QUERY_LIMIT`] (100). Callers
+    /// needing more results must loop with increasing `offset` values.
     ///
     /// # Authorization
     /// None — callable by anyone (read-only query).
@@ -2811,6 +2830,7 @@ impl BountyEscrowContract {
         offset: u32,
         limit: u32,
     ) -> Vec<u64> {
+        let limit = limit.min(MAX_QUERY_LIMIT);
         let index: Vec<u64> = env
             .storage()
             .persistent()
@@ -3719,23 +3739,19 @@ impl BountyEscrowContract {
     /// # Arguments
     /// * `max_deadline` - Only return bounties with deadline <= this timestamp
     /// * `offset` - Pagination offset
-    /// * `limit` - Maximum number of results
+    /// * `limit` - Maximum number of results (capped at [`MAX_QUERY_LIMIT`] — 100)
     ///
     /// # Returns
     /// Vector of bounties sorted by deadline that match the criteria
-    /// Query bounties by expiration status (approaching or already expired)
     ///
-    /// # Arguments
-    /// * `max_deadline` - Only return bounties with deadline <= this timestamp
-    /// * `offset` - Pagination offset
-    /// * `limit` - Maximum number of results
-    ///
-    /// # Returns
-    /// Vector of bounties sorted by deadline that match the criteria
+    /// # Pagination
+    /// The `limit` parameter is capped at [`MAX_QUERY_LIMIT`] (100). Callers
+    /// needing more results must loop with increasing `offset` values.
     ///
     /// # Authorization
     /// None — callable by anyone (read-only query).
     pub fn query_expiring_bounties(env: Env, max_deadline: u64, offset: u32, limit: u32) -> Vec<u64> {
+        let limit = limit.min(MAX_QUERY_LIMIT);
         let index: Vec<u64> = env
             .storage()
             .persistent()

--- a/bounty_escrow/contracts/escrow/src/test_query_filters.rs
+++ b/bounty_escrow/contracts/escrow/src/test_query_filters.rs
@@ -28,6 +28,7 @@ fn create_escrow(env: &Env) -> BountyEscrowContractClient<'static> {
 
 struct Setup {
     env: Env,
+    admin: Address,
     depositor: Address,
     contributor: Address,
     token: token::Client<'static>,
@@ -48,6 +49,7 @@ impl Setup {
         token_admin.mint(&depositor, &10_000_000);
         Setup {
             env,
+            admin,
             depositor,
             contributor,
             token,
@@ -1074,4 +1076,57 @@ fn test_query_expiring_bounties_empty_index() {
     
     let results = s.escrow.query_expiring_bounties(&(base + 100), &0, &10);
     assert_eq!(results.len(), 0);
+}
+
+#[test]
+fn test_query_limit_clamped_to_max_query_limit() {
+    let s = Setup::new();
+    s.env.budget().reset_unlimited();
+    let dl = s.env.ledger().timestamp() + 1000;
+
+    // Whitelist depositor to bypass anti-abuse rate limiter
+    s.escrow
+        .set_whitelist(&s.depositor, &true);
+
+    // Create more escrows than MAX_QUERY_LIMIT (100)
+    let total = MAX_QUERY_LIMIT + 10;
+    for id in 1..=total as u64 {
+        s.escrow.lock_funds(&s.depositor, &id, &(id as i128), &dl);
+    }
+
+    // Verify the index actually exceeds the cap
+    let count = s.escrow.get_escrow_count();
+    assert!(count > MAX_QUERY_LIMIT);
+
+    // query_escrows_by_status with limit = u32::MAX should return at most MAX_QUERY_LIMIT
+    let results =
+        s.escrow
+            .query_escrows_by_status(&EscrowStatus::Locked, &0, &u32::MAX);
+    assert_eq!(results.len(), MAX_QUERY_LIMIT);
+
+    // get_escrow_ids_by_status with limit = u32::MAX should return at most MAX_QUERY_LIMIT
+    let ids = s
+        .escrow
+        .get_escrow_ids_by_status(&EscrowStatus::Locked, &0, &u32::MAX);
+    assert_eq!(ids.len(), MAX_QUERY_LIMIT);
+
+    // query_expiring_bounties with limit = u32::MAX should return at most MAX_QUERY_LIMIT
+    let expiring = s
+        .escrow
+        .query_expiring_bounties(&(dl + 1), &0, &u32::MAX);
+    assert_eq!(expiring.len(), MAX_QUERY_LIMIT);
+
+    // query_escrows (composite filter) with limit = u32::MAX
+    let filter = EscrowQueryFilter {
+        has_status_filter: true,
+        status: EscrowStatus::Locked,
+        has_depositor_filter: false,
+        depositor: s.depositor.clone(),
+        min_amount: 0,
+        max_amount: i128::MAX,
+        min_deadline: 0,
+        max_deadline: u64::MAX,
+    };
+    let composite = s.escrow.query_escrows(&filter, &0, &u32::MAX);
+    assert_eq!(composite.len(), MAX_QUERY_LIMIT);
 }


### PR DESCRIPTION
Closes #445

## Summary

Adds a hard ceiling (`MAX_QUERY_LIMIT = 100`) to all six read-side pagination functions in `bounty_escrow/contracts/escrow/src/lib.rs`, mirroring how `MAX_BATCH_SIZE` already bounds the write-side batch functions. Without this, a caller can pass `limit: u32::MAX` and force the contract to build a `Vec` containing every matching escrow — risking Soroban's per-invocation CPU/memory budget and creating a self-inflicted availability failure for indexers/dashboards.

## Changes

- **`MAX_QUERY_LIMIT` constant** added at line 367, next to `MAX_BATCH_SIZE`.
- **`let limit = limit.min(MAX_QUERY_LIMIT);`** inserted at the top of each function:
  - `query_escrows_by_status`
  - `query_escrows_by_amount`
  - `query_escrows_by_deadline`
  - `query_escrows`
  - `get_escrow_ids_by_status`
  - `query_expiring_bounties`
- **Doc comments** on all six functions updated to document the cap and instruct callers to loop with `offset` for larger result sets.
- **`Setup` struct** in `test_query_filters.rs` now stores `admin` to support whitelisting in the new test.
- **New test** `test_query_limit_clamped_to_max_query_limit` creates 110 escrows, calls four pagination functions with `limit = u32::MAX`, and asserts each returns exactly `MAX_QUERY_LIMIT` results.

## Test Results

cargo test -p bounty-escrow  →  556 passed, 0 failed

## Security Note

This is an **availability/DoS hardening** item, not a fund-safety bug. Nothing here moves funds, but an off-chain integrator trusting the SDK type signature of `limit: u32` without knowing the undocumented practical ceiling can construct a call that reliably fails against Soroban's resource limits — with no in-contract signal explaining why.
EOF