### PR TITLE
fix(program-escrow): wire check_proposal_vetoed into a real execute_governance_proposal entrypoint

### DIFF
--- a/bounty_escrow/contracts/escrow/src/governance_integration.rs
+++ b/bounty_escrow/contracts/escrow/src/governance_integration.rs
@@ -17,6 +17,10 @@ pub trait GovernanceInterface {
     fn get_version_numeric_encoded(env: Env) -> u32;
     fn is_upg_ok(env: Env, wasm_hash: BytesN<32>) -> bool;
     fn execute_proposal(env: Env, proposal_id: u32) -> Result<(), GovernanceError>;
+    /// Returns true when a proposal identified by `proposal_id` has been
+    /// vetoed or cancelled before execution.  A vetoed proposal must never
+    /// be executed even if it previously reached `Approved` status.
+    fn is_vetoed(env: Env, proposal_id: u32) -> bool;
 }
 
 #[soroban_sdk::contracterror]
@@ -94,17 +98,38 @@ pub fn check_upgrade_approval(env: &Env, wasm_hash: &BytesN<32>) -> bool {
     GovernanceClient::new(env, &gov_addr).is_upg_ok(wasm_hash)
 }
 
-/// Validate and consume an approved governance proposal before an escrow action.
+/// Check whether a governance proposal has been vetoed or cancelled.
+///
+/// Returns `true` when the governance contract reports the proposal as
+/// vetoed/cancelled, meaning it **must not** be executed even if it
+/// previously reached `Approved` status.  Returns `false` when no
+/// governance contract is configured (open/permissionless mode).
+pub fn check_proposal_vetoed(env: &Env, proposal_id: u32) -> bool {
+    let Some(gov_addr) = get_governance_contract(env) else {
+        return false;
+    };
+
+    GovernanceClient::new(env, &gov_addr).is_vetoed(&proposal_id)
+}
+
+/// Validate and consume an approved, non-vetoed governance proposal before
+/// an escrow action.
 ///
 /// This delegates to grainlify-core's `execute_proposal`, so quorum,
 /// approval threshold, execution delay, and replay protection are enforced by
-/// the governance module rather than a caller-supplied flag.
+/// the governance module rather than a caller-supplied flag. Additionally
+/// rejects a proposal `check_proposal_vetoed` reports as vetoed/cancelled,
+/// aligning this contract with program-escrow's veto-aware equivalent.
 pub fn execute_governance_proposal(env: &Env, proposal_id: u32) -> bool {
     let Some(gov_addr) = get_governance_contract(env) else {
         return false;
     };
 
     if !check_governance_version(env) {
+        return false;
+    }
+
+    if check_proposal_vetoed(env, proposal_id) {
         return false;
     }
 

--- a/bounty_escrow/contracts/escrow/src/test_governance_integration.rs
+++ b/bounty_escrow/contracts/escrow/src/test_governance_integration.rs
@@ -41,6 +41,7 @@ mod mock_governance_with_proposal_state {
     use soroban_sdk::{contract, contractimpl, symbol_short, BytesN, Env, Map, Symbol};
 
     const PROPOSAL_STATES: Symbol = symbol_short!("PR_STATE");
+    const VETOED_KEY: Symbol = symbol_short!("VETOED_ID");
     const STATUS_PENDING: u32 = 1;
     const STATUS_APPROVED: u32 = 2;
     const STATUS_REJECTED: u32 = 3;
@@ -115,6 +116,22 @@ mod mock_governance_with_proposal_state {
 
         pub fn executed_status(_env: Env) -> u32 {
             STATUS_EXECUTED
+        }
+
+        /// Returns `true` when `proposal_id` has been marked as vetoed.
+        /// Stores the ID of the single vetoed proposal (u32::MAX = none vetoed).
+        pub fn is_vetoed(env: Env, proposal_id: u32) -> bool {
+            let vetoed_id: u32 = env
+                .storage()
+                .instance()
+                .get(&VETOED_KEY)
+                .unwrap_or(u32::MAX);
+            vetoed_id == proposal_id
+        }
+
+        /// Test-only helper: mark `proposal_id` as vetoed.
+        pub fn set_vetoed(env: Env, proposal_id: u32) {
+            env.storage().instance().set(&VETOED_KEY, &proposal_id);
         }
     }
 }
@@ -281,6 +298,48 @@ fn test_governance_proposal_execution_consumes_approved_proposal_once() {
     assert_eq!(
         setup.escrow.try_execute_governance_proposal(&4),
         Err(Ok(Error::GovernanceProposalNotExecutable))
+    );
+}
+
+/// Issue #473: aligning bounty_escrow's GovernanceInterface with
+/// program-escrow's — a proposal reported as vetoed must be rejected by
+/// execute_governance_proposal even though it is otherwise Approved and
+/// would execute successfully.
+#[test]
+fn test_governance_proposal_execution_rejects_vetoed_proposal() {
+    let setup = ValueTransferSetup::new();
+    let governance = configure_stateful_governance(&setup.env, &setup.escrow);
+
+    governance.set_proposal_status(&5, &governance.approved_status());
+    governance.set_vetoed(&5);
+
+    assert_eq!(
+        setup.escrow.try_execute_governance_proposal(&5),
+        Err(Ok(Error::GovernanceProposalNotExecutable)),
+        "a vetoed proposal must be rejected even though it is Approved"
+    );
+    assert_eq!(
+        governance.get_proposal_status(&5),
+        governance.approved_status(),
+        "the mock's proposal status must be untouched — execute_proposal must never have been called"
+    );
+}
+
+/// A non-vetoed, Approved proposal must still execute normally — the veto
+/// wiring must not block legitimate governance actions.
+#[test]
+fn test_governance_proposal_execution_succeeds_for_non_vetoed_approved_proposal() {
+    let setup = ValueTransferSetup::new();
+    let governance = configure_stateful_governance(&setup.env, &setup.escrow);
+
+    governance.set_proposal_status(&6, &governance.approved_status());
+    // proposal 5 is vetoed in the sibling test's mock instance, but each test
+    // gets its own fresh contract registration, so this mock has no veto set.
+
+    setup.escrow.execute_governance_proposal(&6);
+    assert_eq!(
+        governance.get_proposal_status(&6),
+        governance.executed_status()
     );
 }
 

--- a/program-escrow/src/governance_integration.rs
+++ b/program-escrow/src/governance_integration.rs
@@ -19,6 +19,30 @@ pub trait GovernanceInterface {
     /// vetoed or cancelled before execution.  A vetoed proposal must never
     /// be executed even if it previously reached `Approved` status.
     fn is_vetoed(env: Env, proposal_id: u32) -> bool;
+    fn execute_proposal(env: Env, proposal_id: u32) -> Result<(), GovernanceError>;
+}
+
+#[soroban_sdk::contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum GovernanceError {
+    NotInitialized = 1,
+    InvalidThreshold = 2,
+    ThresholdTooLow = 3,
+    InsufficientStake = 4,
+    ProposalsNotFound = 5,
+    ProposalNotFound = 6,
+    ProposalNotActive = 7,
+    VotingNotStarted = 8,
+    VotingEnded = 9,
+    VotingStillActive = 10,
+    AlreadyVoted = 11,
+    ProposalNotApproved = 12,
+    ExecutionDelayNotMet = 13,
+    ProposalExpired = 14,
+    ZeroVotingPower = 15,
+    InvalidTotalVotingPower = 16,
+    Unauthorized = 17,
 }
 
 /// Set the governance contract address (admin only)
@@ -85,6 +109,34 @@ pub fn check_proposal_vetoed(env: &Env, proposal_id: u32) -> bool {
     };
 
     GovernanceClient::new(env, &gov_addr).is_vetoed(&proposal_id)
+}
+
+/// Validate and consume an approved, non-vetoed governance proposal before a
+/// governance-triggered escrow action proceeds.
+///
+/// This is the real code path `check_proposal_vetoed` was declared for: it
+/// delegates to grainlify-core's `execute_proposal` (so quorum, approval
+/// threshold, execution delay, and replay protection are enforced by the
+/// governance module itself, not a caller-supplied flag), and additionally
+/// rejects a proposal `check_proposal_vetoed` reports as vetoed/cancelled —
+/// closing the gap where the veto check existed but nothing ever called it.
+pub fn execute_governance_proposal(env: &Env, proposal_id: u32) -> bool {
+    let Some(gov_addr) = get_governance_contract(env) else {
+        return false;
+    };
+
+    if !check_governance_version(env) {
+        return false;
+    }
+
+    if check_proposal_vetoed(env, proposal_id) {
+        return false;
+    }
+
+    matches!(
+        GovernanceClient::new(env, &gov_addr).try_execute_proposal(&proposal_id),
+        Ok(Ok(()))
+    )
 }
 
 #[cfg(test)]

--- a/program-escrow/src/lib.rs
+++ b/program-escrow/src/lib.rs
@@ -549,6 +549,9 @@ pub enum Error {
     GovernanceVersionTooLow = 4,
     /// large-payout threshold_bps exceeds 10_000 (100%).
     InvalidThresholdBps = 5,
+    /// Governance proposal is not in an executable state: pending, rejected,
+    /// missing, delayed, vetoed/cancelled, or already executed.
+    GovernanceProposalNotExecutable = 6,
 }
 
 #[contracttype]
@@ -1694,6 +1697,34 @@ impl ProgramEscrowContract {
         if !governance_integration::check_governance_version(env) {
             return Err(Error::GovernanceVersionTooLow);
         }
+        Ok(())
+    }
+
+    /// Validate and consume an approved, non-vetoed governance proposal
+    /// before executing a governance-triggered action.
+    ///
+    /// The configured grainlify-core governance contract re-checks quorum
+    /// and approval state by executing the proposal itself, and the veto
+    /// check rejects a proposal reported as vetoed/cancelled even if it
+    /// previously reached `Approved` status. Pending, rejected, delayed,
+    /// vetoed, missing, or already-executed proposals are all rejected.
+    ///
+    /// # Authorization
+    /// No caller authorization is required — callable by anyone, mirroring
+    /// `bounty_escrow::execute_governance_proposal`. Safety comes from the
+    /// governance contract re-validating the proposal's own approval state
+    /// on every call, not from caller identity; this function only marks an
+    /// already-legitimately-approved, non-vetoed proposal as consumed.
+    ///
+    /// # Errors
+    /// `GovernanceVersionTooLow`, `GovernanceProposalNotExecutable`.
+    pub fn execute_governance_proposal(env: Env, proposal_id: u32) -> Result<(), Error> {
+        Self::check_governance_requirements(&env)?;
+
+        if !governance_integration::execute_governance_proposal(&env, proposal_id) {
+            return Err(Error::GovernanceProposalNotExecutable);
+        }
+
         Ok(())
     }
     // ========================================================================

--- a/program-escrow/src/test_governance_integration.rs
+++ b/program-escrow/src/test_governance_integration.rs
@@ -39,6 +39,16 @@ mod mock_governance {
         pub fn set_vetoed(env: Env, proposal_id: u32) {
             env.storage().instance().set(&VETOED_KEY, &proposal_id);
         }
+
+        /// Always succeeds. `execute_governance_proposal`'s own veto check
+        /// short-circuits before this is ever reached for a vetoed proposal,
+        /// so this mock only needs to model the non-vetoed, approved case.
+        pub fn execute_proposal(
+            _env: Env,
+            _proposal_id: u32,
+        ) -> Result<(), crate::governance_integration::GovernanceError> {
+            Ok(())
+        }
     }
 }
 
@@ -643,6 +653,70 @@ fn test_veto_after_execution_does_not_retroactively_revoke_approval() {
         );
         assert!(vetoed, "vetoed must be true to block the late-veto scenario");
     });
+}
+
+// ============================================================================
+// Issue #473: check_proposal_vetoed must actually be consulted by a real
+// code path, not just declared. execute_governance_proposal is that path.
+// ============================================================================
+
+/// A vetoed proposal must be rejected by execute_governance_proposal even
+/// though the mock's execute_proposal itself would otherwise succeed —
+/// proving check_proposal_vetoed is now genuinely wired into the contract,
+/// not merely callable in isolation from tests.
+#[test]
+fn test_execute_governance_proposal_rejects_vetoed_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+
+    let gov_contract_id = env.register_contract(None, mock_governance::MockGovernanceContract);
+    let gov_client = mock_governance::MockGovernanceContractClient::new(&env, &gov_contract_id);
+
+    client.set_governance_contract(&gov_contract_id);
+    client.set_min_governance_version(&2);
+
+    gov_client.set_vetoed(&0);
+
+    let result = client.try_execute_governance_proposal(&0);
+    assert_eq!(
+        result,
+        Err(Ok(Error::GovernanceProposalNotExecutable)),
+        "a vetoed proposal must be rejected even though the mock's execute_proposal would succeed"
+    );
+}
+
+/// A non-vetoed proposal proceeds normally through execute_governance_proposal
+/// — the veto wiring must not block legitimate governance actions.
+#[test]
+fn test_execute_governance_proposal_succeeds_for_non_vetoed_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+
+    let gov_contract_id = env.register_contract(None, mock_governance::MockGovernanceContract);
+    let gov_client = mock_governance::MockGovernanceContractClient::new(&env, &gov_contract_id);
+
+    client.set_governance_contract(&gov_contract_id);
+    client.set_min_governance_version(&2);
+
+    // proposal 1 was never vetoed (only proposal 0 is ever marked in these tests).
+    gov_client.set_vetoed(&0);
+
+    let result = client.try_execute_governance_proposal(&1);
+    assert_eq!(
+        result,
+        Ok(Ok(())),
+        "a non-vetoed proposal must proceed normally"
+    );
 }
 
 /// Issue #386: grainlify-core's is_vetoed used to be a hardcoded stub that


### PR DESCRIPTION
Closes #473

check_proposal_vetoed / GovernanceInterface::is_vetoed were declared in
program-escrow but never called from anywhere in the contract — a veto/
cancellation check that existed in the interface but provided no actual
protection.

- Added execute_governance_proposal(proposal_id) to program-escrow,
  mirroring bounty_escrow's existing entrypoint: validates governance
  version, checks check_proposal_vetoed, then delegates to grainlify-core's
  execute_proposal (quorum/threshold/delay/replay all enforced there).
- Added the missing execute_proposal method to program-escrow's
  GovernanceInterface trait (it only had get_ver/is_upg_ok/is_vetoed before).
- Aligned bounty_escrow's GovernanceInterface to also declare is_vetoed, and
  wired a veto check into its existing execute_governance_proposal, which
  lacked this too.
- New tests on both contracts proving a vetoed-but-approved proposal is
  rejected, and a non-vetoed proposal still executes normally.

Note: grainlify-core's cancel_proposal can currently only cancel an Active
proposal, not an already-Approved one (a known design gap, already flagged
in program-escrow's own test file under issue #236), so today this check is
defense-in-depth rather than reachable through the public API. Wiring it in
now means the protection is real the moment cancel_proposal is extended to
cover Approved proposals too.

Tests: program-escrow governance_integration tests 8/8 pass (4 pre-existing,
unrelated failures elsewhere confirmed present on unmodified main too).
bounty-escrow full suite 562/562 passes.
