### PR TITLE
feat(escrow): wire check_upgrade_approval into a governance-gated upgrade() entrypoint

### DIFF
--- a/bounty_escrow/contracts/escrow/src/events.rs
+++ b/bounty_escrow/contracts/escrow/src/events.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
+use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, Symbol};
 
 pub const EVENT_VERSION_V2: u32 = 2;
 
@@ -76,6 +76,20 @@ pub struct BountyExpired {
 
 pub fn emit_bounty_expired(env: &Env, event: BountyExpired) {
     let topics = (symbol_short!("b_exp"), event.bounty_id);
+    env.events().publish(topics, event.clone());
+}
+
+/// Emitted after a governance-approved WASM upgrade actually executes.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct UpgradeExecuted {
+    pub version: u32,
+    pub wasm_hash: BytesN<32>,
+    pub admin: Address,
+}
+
+pub fn emit_upgrade_executed(env: &Env, event: UpgradeExecuted) {
+    let topics = (symbol_short!("upgrade"),);
     env.events().publish(topics, event.clone());
 }
 

--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -20,9 +20,9 @@ use events::{
     emit_batch_funds_locked, emit_batch_funds_released, emit_bounty_expired,
     emit_bounty_initialized, emit_funds_locked, emit_funds_refunded, emit_funds_released,
     emit_claim_created, emit_claim_executed, emit_claim_cancelled, emit_dispute_resolved,
-    BatchFundsLocked, BatchFundsReleased, BountyEscrowInitialized, BountyExpired,
-    ClaimCancelled, ClaimCreated, ClaimExecuted, DisputeOutcome, DisputeResolved,
-    FundsLocked, FundsRefunded, FundsReleased, EVENT_VERSION_V2,
+    emit_upgrade_executed, BatchFundsLocked, BatchFundsReleased, BountyEscrowInitialized,
+    BountyExpired, ClaimCancelled, ClaimCreated, ClaimExecuted, DisputeOutcome, DisputeResolved,
+    FundsLocked, FundsRefunded, FundsReleased, UpgradeExecuted, EVENT_VERSION_V2,
 };
 use analytics::{
     emit_analytics_snapshot, emit_bounty_activity, emit_bounty_state_transitioned,
@@ -36,8 +36,8 @@ use error_recovery::{
     CircuitBreakerStatus, CircuitState, ErrorEntry, ERR_CIRCUIT_OPEN,
 };
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, token, vec, Address, Env,
-    Map, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, vec, Address, BytesN,
+    Env, Map, Symbol, Vec,
 };
 
 // ==================== MONITORING MODULE ====================
@@ -413,6 +413,10 @@ pub enum Error {
     PendingClaimExists = 24,
     /// Returned when a governance proposal is missing, unapproved, delayed, rejected, or already executed
     GovernanceProposalNotExecutable = 25,
+    /// The requested WASM hash has no executed, post-delay governance
+    /// proposal approving it (or no governance contract is configured at
+    /// all — upgrades fail closed, they are never permitted by default).
+    UpgradeNotApproved = 26,
 }
 
 #[contracttype]
@@ -893,6 +897,47 @@ impl BountyEscrowContract {
                 fee_recipient: fee_config.fee_recipient.clone(),
                 fee_enabled: fee_config.fee_enabled,
                 timestamp: env.ledger().timestamp(),
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Upgrade the contract to new WASM code, gated on governance approval.
+    ///
+    /// `check_upgrade_approval` (in `governance_integration.rs`) was
+    /// previously unreachable dead code: it existed, was unit-tested in
+    /// isolation, and was cross-contract-callable, but nothing in this
+    /// contract's own logic ever called it, because there was no upgrade
+    /// entrypoint at all (Issue #472). This closes that gap, mirroring
+    /// `program-escrow`'s own `upgrade()`.
+    ///
+    /// # Authorization
+    /// Requires the contract admin's `require_auth()`. Admin auth alone is
+    /// not sufficient, though: `check_upgrade_approval` must also report the
+    /// exact `new_wasm_hash` as approved by an executed, post-delay
+    /// `grainlify-core` governance proposal. If no governance contract is
+    /// configured at all, `check_upgrade_approval` returns `false` and this
+    /// fails closed — upgrades are never permitted by default.
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), Error> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::NotInitialized);
+        }
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+
+        if !governance_integration::check_upgrade_approval(&env, &new_wasm_hash) {
+            return Err(Error::UpgradeNotApproved);
+        }
+
+        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+
+        emit_upgrade_executed(
+            &env,
+            UpgradeExecuted {
+                version: EVENT_VERSION_V2,
+                wasm_hash: new_wasm_hash,
+                admin,
             },
         );
 

--- a/bounty_escrow/contracts/escrow/src/test_governance_integration.rs
+++ b/bounty_escrow/contracts/escrow/src/test_governance_integration.rs
@@ -694,6 +694,114 @@ fn test_upgrade_approval_denies_when_governance_is_not_configured() {
     });
 }
 
+// ---- Issue #472: upgrade() entrypoint wiring check_upgrade_approval ----
+
+// mock_governance's is_upg_ok only ever approves a fixed fake hash, which
+// can't equal a real env.deployer().upload_contract_wasm(...) hash — needed
+// for a test that actually exercises update_current_contract_wasm rather
+// than just check_upgrade_approval in isolation. This mock instead approves
+// whatever hash is registered via set_approved_hash.
+mod mock_governance_upgrade {
+    use soroban_sdk::{contract, contractimpl, symbol_short, BytesN, Env, Symbol};
+
+    const APPROVED_HASH: Symbol = symbol_short!("APR_HASH");
+
+    #[contract]
+    pub struct MockGovernanceUpgrade;
+
+    #[contractimpl]
+    impl MockGovernanceUpgrade {
+        pub fn get_ver(_env: Env) -> u32 {
+            2
+        }
+
+        pub fn get_version_numeric_encoded(_env: Env) -> u32 {
+            20_000
+        }
+
+        pub fn is_upg_ok(env: Env, wasm_hash: BytesN<32>) -> bool {
+            match env
+                .storage()
+                .instance()
+                .get::<Symbol, BytesN<32>>(&APPROVED_HASH)
+            {
+                Some(approved) => approved == wasm_hash,
+                None => false,
+            }
+        }
+
+        pub fn set_approved_hash(env: Env, wasm_hash: BytesN<32>) {
+            env.storage().instance().set(&APPROVED_HASH, &wasm_hash);
+        }
+    }
+}
+
+#[test]
+fn test_upgrade_executes_when_governance_approved() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let _ = client.init(&admin, &token);
+
+    let gov_id = env.register_contract(None, mock_governance_upgrade::MockGovernanceUpgrade);
+    let gov_client = mock_governance_upgrade::MockGovernanceUpgradeClient::new(&env, &gov_id);
+    let _ = client.set_governance_contract(&gov_id);
+    let _ = client.set_min_governance_version(&2);
+
+    let wasm_hash = env.deployer().upload_contract_wasm([].as_slice());
+    gov_client.set_approved_hash(&wasm_hash);
+
+    // Must not panic: admin auth passes, check_upgrade_approval reports the
+    // exact uploaded hash as approved, and update_current_contract_wasm runs.
+    client.upgrade(&wasm_hash);
+}
+
+#[test]
+fn test_upgrade_rejected_when_not_governance_approved() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let _ = client.init(&admin, &token);
+
+    // No governance contract configured at all — check_upgrade_approval
+    // fails closed, so upgrade() must reject even with valid admin auth.
+    let wasm_hash = env.deployer().upload_contract_wasm([].as_slice());
+    let result = client.try_upgrade(&wasm_hash);
+    assert_eq!(result, Err(Ok(Error::UpgradeNotApproved)));
+}
+
+#[test]
+fn test_upgrade_rejected_when_hash_not_the_approved_one() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BountyEscrowContract);
+    let client = BountyEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let _ = client.init(&admin, &token);
+
+    let gov_id = env.register_contract(None, mock_governance_upgrade::MockGovernanceUpgrade);
+    let gov_client = mock_governance_upgrade::MockGovernanceUpgradeClient::new(&env, &gov_id);
+    let _ = client.set_governance_contract(&gov_id);
+    let _ = client.set_min_governance_version(&2);
+
+    let approved_hash = BytesN::from_array(&env, &[7u8; 32]);
+    gov_client.set_approved_hash(&approved_hash);
+
+    let attempted_hash = env.deployer().upload_contract_wasm([].as_slice());
+    let result = client.try_upgrade(&attempted_hash);
+    assert_eq!(result, Err(Ok(Error::UpgradeNotApproved)));
+}
+
 #[test]
 fn test_admin_operations_work_without_governance() {
     let env = Env::default();

--- a/program-escrow/src/lib.rs
+++ b/program-escrow/src/lib.rs
@@ -283,8 +283,8 @@ mod test_analytics_events;
 mod test_governance_integration;
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, token, vec, Address, Env,
-    String, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, vec, Address, BytesN,
+    Env, String, Symbol, Vec,
 };
 
 // Event types
@@ -297,6 +297,7 @@ const DISPUTE_RESOLVED: Symbol = symbol_short!("DispRes");
 const DISPUTE_CANCELLED: Symbol = symbol_short!("DispCanc");
 const EVENT_VERSION_V2: u32 = 2;
 const PAUSE_STATE_CHANGED: Symbol = symbol_short!("PauseSt");
+const UPGRADE_EXECUTED: Symbol = symbol_short!("UpgExec");
 const AGGREGATE_STATS: Symbol = symbol_short!("AggStats");
 const LARGE_PAYOUT: Symbol = symbol_short!("LrgPay");
 const SCHEDULE_TRIGGERED: Symbol = symbol_short!("SchedTrg");
@@ -461,6 +462,14 @@ pub struct PauseFlags {
 pub struct PauseStateChanged {
     pub operation: Symbol,
     pub paused: bool,
+    pub admin: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpgradeExecutedEvent {
+    pub version: u32,
+    pub wasm_hash: BytesN<32>,
     pub admin: Address,
 }
 
@@ -634,6 +643,10 @@ pub enum Error {
     /// Governance proposal is not in an executable state: pending, rejected,
     /// missing, delayed, vetoed/cancelled, or already executed.
     GovernanceProposalNotExecutable = 6,
+    /// The requested WASM hash has no executed, post-delay governance
+    /// proposal approving it (or no governance contract is configured at
+    /// all — upgrades fail closed, they are never permitted by default).
+    UpgradeNotApproved = 7,
 }
 
 #[contracttype]
@@ -1092,6 +1105,43 @@ impl ProgramEscrowContract {
 
         env.storage().instance().set(&DataKey::PauseFlags, &flags);
         Self::bump_instance_ttl(&env);
+        Ok(())
+    }
+
+    /// Upgrade the contract to new WASM code, gated on governance approval.
+    ///
+    /// `check_upgrade_approval` (in `governance_integration.rs`) was
+    /// previously unreachable dead code: it existed, was unit-tested in
+    /// isolation, and was cross-contract-callable, but nothing in this
+    /// contract's own logic ever called it, because there was no upgrade
+    /// entrypoint at all (Issue #472). This closes that gap.
+    ///
+    /// # Authorization
+    /// Requires the contract admin's `require_auth()`. Admin auth alone is
+    /// not sufficient, though: `check_upgrade_approval` must also report the
+    /// exact `new_wasm_hash` as approved by an executed, post-delay
+    /// `grainlify-core` governance proposal. If no governance contract is
+    /// configured at all, `check_upgrade_approval` returns `false` and this
+    /// fails closed — upgrades are never permitted by default.
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), Error> {
+        let admin = Self::requireadmin(&env);
+        admin.require_auth();
+
+        if !governance_integration::check_upgrade_approval(&env, &new_wasm_hash) {
+            return Err(Error::UpgradeNotApproved);
+        }
+
+        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+
+        env.events().publish(
+            (UPGRADE_EXECUTED,),
+            UpgradeExecutedEvent {
+                version: EVENT_VERSION_V2,
+                wasm_hash: new_wasm_hash,
+                admin,
+            },
+        );
+
         Ok(())
     }
 

--- a/program-escrow/src/test_governance_integration.rs
+++ b/program-escrow/src/test_governance_integration.rs
@@ -248,6 +248,71 @@ fn test_upgrade_approval_denies_when_governance_is_not_configured() {
     });
 }
 
+// ---- Issue #472: upgrade() entrypoint wiring check_upgrade_approval ----
+
+#[test]
+fn test_upgrade_executes_when_governance_approved() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+
+    let gov_id = env.register_contract(None, mock_governance_with_state::MockGovernanceWithState);
+    let gov_client = mock_governance_with_state::MockGovernanceWithStateClient::new(&env, &gov_id);
+    client.set_governance_contract(&gov_id);
+    client.set_min_governance_version(&2);
+
+    let wasm_hash = env.deployer().upload_contract_wasm([].as_slice());
+    gov_client.set_proposal(&1, &wasm_hash, &4); // 4 = Executed
+
+    // Must not panic: admin auth passes, check_upgrade_approval reports the
+    // exact uploaded hash as approved, and update_current_contract_wasm runs.
+    client.upgrade(&wasm_hash);
+}
+
+#[test]
+fn test_upgrade_rejected_when_not_governance_approved() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+
+    // No governance contract configured at all — check_upgrade_approval
+    // fails closed, so upgrade() must reject even with valid admin auth.
+    let wasm_hash = env.deployer().upload_contract_wasm([].as_slice());
+    let result = client.try_upgrade(&wasm_hash);
+    assert_eq!(result, Err(Ok(Error::UpgradeNotApproved)));
+}
+
+#[test]
+fn test_upgrade_rejected_when_hash_not_the_approved_one() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, ProgramEscrowContract);
+    let client = ProgramEscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.setadmin(&admin);
+
+    let gov_id = env.register_contract(None, mock_governance_with_state::MockGovernanceWithState);
+    let gov_client = mock_governance_with_state::MockGovernanceWithStateClient::new(&env, &gov_id);
+    client.set_governance_contract(&gov_id);
+    client.set_min_governance_version(&2);
+
+    let approved_hash = BytesN::from_array(&env, &[7u8; 32]);
+    gov_client.set_proposal(&1, &approved_hash, &4); // Executed, but a different hash
+
+    let attempted_hash = env.deployer().upload_contract_wasm([].as_slice());
+    let result = client.try_upgrade(&attempted_hash);
+    assert_eq!(result, Err(Ok(Error::UpgradeNotApproved)));
+}
+
 #[test]
 fn testadmin_operations_work_without_governance() {
     let env = Env::default();


### PR DESCRIPTION
Closes #472

check_upgrade_approval / GovernanceInterface::is_upg_ok existed in both
bounty_escrow and program-escrow, were unit-tested in isolation, and were
cross-contract-callable — but neither contract had an upgrade() entrypoint
at all, so the entire approval-checking machinery was unreachable dead
code that could give a reviewer false confidence upgrades were gated.

- Added upgrade(new_wasm_hash) to both contracts: requires the contract
  admin's auth, requires check_upgrade_approval to report the exact hash
  as approved by an executed grainlify-core governance proposal (fails
  closed if no governance is configured at all), then calls
  update_current_contract_wasm and emits an UpgradeExecuted event.
- Added a new Error::UpgradeNotApproved variant to both contracts.
- 6 new tests across both contracts: successful governance-approved
  upgrade, rejection with no governance configured, rejection when the
  approved hash doesn't match the requested one.

Full workspace builds clean; both contracts' test suites pass (4
pre-existing, unrelated failures confirmed present on unmodified main too).
