### PR TITLE
fix(bounty_escrow): add overflow checks to aggregation functions in analytics.rs

### DIFF
--- a/bounty_escrow/contracts/escrow/src/analytics.rs
+++ b/bounty_escrow/contracts/escrow/src/analytics.rs
@@ -13,31 +13,64 @@
 //! ## Events
 //! - `BountyStateTransitioned` - Emitted when a bounty status changes
 //! - `AnalyticsSnapshot` - Periodic snapshots of contract-wide metrics
+//!
+//! ## Arithmetic safety
+//! All aggregate accumulator updates use `checked_add` / `checked_sub` to
+//! prevent silent wrap-around on `i128` fields.  Any overflow returns
+//! [`AnalyticsError::Overflow`] rather than panicking or wrapping silently.
 
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 
 /// Analytics version
 pub const ANALYTICS_VERSION_V1: u32 = 1;
 
+/// Error type for analytics operations.
+///
+/// `AnalyticsError::Overflow` is returned whenever a checked arithmetic
+/// operation on an aggregate accumulator would overflow `i128` or `u32`.
+/// Appended at the end to avoid renumbering any previously-defined variants
+/// in the parent contract's `Error` enum.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum AnalyticsError {
+    /// Arithmetic overflow in an aggregate accumulator.
+    ///
+    /// This should never occur during normal contract operation because bounty
+    /// amounts are bounded by the token supply, but is returned instead of
+    /// panicking or wrapping silently when near-`i128::MAX` inputs are detected.
+    Overflow,
+}
+
 /// Compact analytics struct for bounty-level summaries
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BountyAnalytics {
-    /// Total amount originally locked in this bounty
+    /// Total amount originally locked in this bounty.
+    ///
+    /// Expected input bound: 0 ≤ total_amount_locked ≤ i128::MAX / 2.
+    /// Values above this bound will cause `checked_add` to return
+    /// `AnalyticsError::Overflow` on the first accumulation.
     pub total_amount_locked: i128,
-    /// Total amount released to contributors
+    /// Total amount released to contributors.
+    ///
+    /// Expected input bound: 0 ≤ total_amount_released ≤ total_amount_locked.
     pub total_amount_released: i128,
-    /// Total amount refunded to original depositor
+    /// Total amount refunded to original depositor.
+    ///
+    /// Expected input bound: 0 ≤ total_amount_refunded ≤ total_amount_locked.
     pub total_amount_refunded: i128,
-    /// Current remaining amount in escrow
+    /// Current remaining amount in escrow.
     pub remaining_amount: i128,
     /// Bounty creation timestamp
     pub created_at: u64,
     /// Timestamp of last state transition
     pub last_updated: u64,
-    /// Number of partial releases performed
+    /// Number of partial releases performed.
+    ///
+    /// Expected input bound: partial_releases_count ≤ u32::MAX.
     pub partial_releases_count: u32,
-    /// Number of partial refunds performed
+    /// Number of partial refunds performed.
+    ///
+    /// Expected input bound: partial_refunds_count ≤ u32::MAX.
     pub partial_refunds_count: u32,
 }
 
@@ -157,50 +190,94 @@ pub fn init_bounty_analytics(env: &Env, bounty_id: u64, amount: i128, timestamp:
         .set(&AnalyticsKey::BountyMetrics(bounty_id), &analytics);
 }
 
-/// Update analytics on release
+/// Update analytics on release.
+///
+/// # Input bounds
+/// `release_amount` must satisfy `0 ≤ release_amount ≤ i128::MAX − analytics.total_amount_released`.
+/// Values outside this range cause `Err(AnalyticsError::Overflow)` to be returned instead
+/// of panicking or allowing silent wrap-around of the accumulator.
+///
+/// # Errors
+/// Returns `Err(AnalyticsError::Overflow)` when the checked addition of
+/// `release_amount` into `total_amount_released` or `partial_releases_count`
+/// would exceed the type's maximum value.
 pub fn update_analytics_on_release(
     env: &Env,
     bounty_id: u64,
     release_amount: i128,
     timestamp: u64,
-) {
+) -> Result<(), AnalyticsError> {
     if let Some(mut analytics) = env
         .storage()
         .persistent()
         .get::<AnalyticsKey, BountyAnalytics>(&AnalyticsKey::BountyMetrics(bounty_id))
     {
-        analytics.total_amount_released += release_amount;
+        // Use checked_add to detect overflow rather than panicking or wrapping.
+        // Changing field order or types here is a BREAKING CHANGE for off-chain
+        // consumers (e.g. internal/soroban/event_parser.go) that decode
+        // BountyAnalytics by field position — update those consumers before
+        // deploying any schema change.
+        analytics.total_amount_released = analytics
+            .total_amount_released
+            .checked_add(release_amount)
+            .ok_or(AnalyticsError::Overflow)?;
         analytics.remaining_amount = analytics.remaining_amount.saturating_sub(release_amount);
         analytics.last_updated = timestamp;
-        analytics.partial_releases_count += 1;
+        analytics.partial_releases_count = analytics
+            .partial_releases_count
+            .checked_add(1)
+            .ok_or(AnalyticsError::Overflow)?;
 
         env.storage()
             .persistent()
             .set(&AnalyticsKey::BountyMetrics(bounty_id), &analytics);
     }
+    Ok(())
 }
 
-/// Update analytics on refund
+/// Update analytics on refund.
+///
+/// # Input bounds
+/// `refund_amount` must satisfy `0 ≤ refund_amount ≤ i128::MAX − analytics.total_amount_refunded`.
+/// Values outside this range cause `Err(AnalyticsError::Overflow)` to be returned instead
+/// of panicking or allowing silent wrap-around of the accumulator.
+///
+/// # Errors
+/// Returns `Err(AnalyticsError::Overflow)` when the checked addition of
+/// `refund_amount` into `total_amount_refunded` or `partial_refunds_count`
+/// would exceed the type's maximum value.
 pub fn update_analytics_on_refund(
     env: &Env,
     bounty_id: u64,
     refund_amount: i128,
     timestamp: u64,
-) {
+) -> Result<(), AnalyticsError> {
     if let Some(mut analytics) = env
         .storage()
         .persistent()
         .get::<AnalyticsKey, BountyAnalytics>(&AnalyticsKey::BountyMetrics(bounty_id))
     {
-        analytics.total_amount_refunded += refund_amount;
+        // Use checked_add to detect overflow rather than panicking or wrapping.
+        // Changing field order or types here is a BREAKING CHANGE for off-chain
+        // consumers (e.g. internal/soroban/event_parser.go) that decode
+        // BountyAnalytics by field position — update those consumers before
+        // deploying any schema change.
+        analytics.total_amount_refunded = analytics
+            .total_amount_refunded
+            .checked_add(refund_amount)
+            .ok_or(AnalyticsError::Overflow)?;
         analytics.remaining_amount = analytics.remaining_amount.saturating_sub(refund_amount);
         analytics.last_updated = timestamp;
-        analytics.partial_refunds_count += 1;
+        analytics.partial_refunds_count = analytics
+            .partial_refunds_count
+            .checked_add(1)
+            .ok_or(AnalyticsError::Overflow)?;
 
         env.storage()
             .persistent()
             .set(&AnalyticsKey::BountyMetrics(bounty_id), &analytics);
     }
+    Ok(())
 }
 
 /// Get per-bounty analytics
@@ -260,7 +337,7 @@ mod tests {
             let amount = 1000i128;
 
             init_bounty_analytics(&env, bounty_id, amount, 100);
-            update_analytics_on_release(&env, bounty_id, 500, 200);
+            update_analytics_on_release(&env, bounty_id, 500, 200).unwrap();
 
             let analytics = get_bounty_analytics(&env, bounty_id).unwrap();
             assert_eq!(analytics.total_amount_released, 500);
@@ -280,7 +357,7 @@ mod tests {
             let amount = 1000i128;
 
             init_bounty_analytics(&env, bounty_id, amount, 100);
-            update_analytics_on_refund(&env, bounty_id, 300, 200);
+            update_analytics_on_refund(&env, bounty_id, 300, 200).unwrap();
 
             let analytics = get_bounty_analytics(&env, bounty_id).unwrap();
             assert_eq!(analytics.total_amount_refunded, 300);
@@ -303,20 +380,20 @@ mod tests {
             init_bounty_analytics(&env, bounty_id, amount, 100);
 
             // Partial release
-            update_analytics_on_release(&env, bounty_id, 300, 200);
+            update_analytics_on_release(&env, bounty_id, 300, 200).unwrap();
             let analytics = get_bounty_analytics(&env, bounty_id).unwrap();
             assert_eq!(analytics.remaining_amount, 700);
             assert_eq!(analytics.total_amount_released, 300);
 
             // Another release
-            update_analytics_on_release(&env, bounty_id, 300, 300);
+            update_analytics_on_release(&env, bounty_id, 300, 300).unwrap();
             let analytics = get_bounty_analytics(&env, bounty_id).unwrap();
             assert_eq!(analytics.remaining_amount, 400);
             assert_eq!(analytics.total_amount_released, 600);
             assert_eq!(analytics.partial_releases_count, 2);
 
             // Final refund for remaining
-            update_analytics_on_refund(&env, bounty_id, 400, 400);
+            update_analytics_on_refund(&env, bounty_id, 400, 400).unwrap();
             let analytics = get_bounty_analytics(&env, bounty_id).unwrap();
             assert_eq!(analytics.remaining_amount, 0);
             assert_eq!(analytics.total_amount_refunded, 400);
@@ -332,6 +409,207 @@ mod tests {
         env.as_contract(&contract_id, || {
             let analytics = get_bounty_analytics(&env, 999u64);
             assert!(analytics.is_none());
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Overflow / checked-arithmetic tests (Issue #165)
+    // -----------------------------------------------------------------------
+
+    /// release: near-max value that still fits must succeed.
+    ///
+    /// Hand-computed:
+    ///   total_amount_released = 0 before
+    ///   release_amount        = i128::MAX − 1
+    ///   result                = i128::MAX − 1  (no overflow)
+    #[test]
+    fn test_release_near_max_no_overflow() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, DummyAnalyticsContract);
+
+        env.as_contract(&contract_id, || {
+            let bounty_id = 100u64;
+            // Initialize with a very large locked amount so the accumulator
+            // starts at 0 and we can push it close to i128::MAX.
+            init_bounty_analytics(&env, bounty_id, i128::MAX, 1);
+
+            let near_max = i128::MAX - 1;
+            let result = update_analytics_on_release(&env, bounty_id, near_max, 2);
+            assert!(result.is_ok(), "near-max release must not overflow");
+
+            let a = get_bounty_analytics(&env, bounty_id).unwrap();
+            assert_eq!(a.total_amount_released, near_max);
+        });
+    }
+
+    /// release: adding to an accumulator already at i128::MAX must return Overflow.
+    ///
+    /// Hand-computed:
+    ///   total_amount_released = i128::MAX before the second call
+    ///   release_amount        = 1
+    ///   i128::MAX + 1 overflows → AnalyticsError::Overflow
+    #[test]
+    fn test_release_overflow_returns_error_not_panic() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, DummyAnalyticsContract);
+
+        env.as_contract(&contract_id, || {
+            let bounty_id = 101u64;
+            init_bounty_analytics(&env, bounty_id, i128::MAX, 1);
+
+            // First call: fill the accumulator to i128::MAX.
+            update_analytics_on_release(&env, bounty_id, i128::MAX, 2)
+                .expect("first call must succeed");
+
+            // Second call: any positive increment must now overflow.
+            let overflow_result = update_analytics_on_release(&env, bounty_id, 1, 3);
+            assert_eq!(
+                overflow_result,
+                Err(AnalyticsError::Overflow),
+                "overflow must return Err(AnalyticsError::Overflow), not panic"
+            );
+        });
+    }
+
+    /// refund: near-max value that still fits must succeed.
+    ///
+    /// Hand-computed:
+    ///   total_amount_refunded = 0 before
+    ///   refund_amount         = i128::MAX − 1
+    ///   result                = i128::MAX − 1  (no overflow)
+    #[test]
+    fn test_refund_near_max_no_overflow() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, DummyAnalyticsContract);
+
+        env.as_contract(&contract_id, || {
+            let bounty_id = 102u64;
+            init_bounty_analytics(&env, bounty_id, i128::MAX, 1);
+
+            let near_max = i128::MAX - 1;
+            let result = update_analytics_on_refund(&env, bounty_id, near_max, 2);
+            assert!(result.is_ok(), "near-max refund must not overflow");
+
+            let a = get_bounty_analytics(&env, bounty_id).unwrap();
+            assert_eq!(a.total_amount_refunded, near_max);
+        });
+    }
+
+    /// refund: adding to an accumulator already at i128::MAX must return Overflow.
+    ///
+    /// Hand-computed:
+    ///   total_amount_refunded = i128::MAX before the second call
+    ///   refund_amount         = 1
+    ///   i128::MAX + 1 overflows → AnalyticsError::Overflow
+    #[test]
+    fn test_refund_overflow_returns_error_not_panic() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, DummyAnalyticsContract);
+
+        env.as_contract(&contract_id, || {
+            let bounty_id = 103u64;
+            init_bounty_analytics(&env, bounty_id, i128::MAX, 1);
+
+            // First call: fill the accumulator to i128::MAX.
+            update_analytics_on_refund(&env, bounty_id, i128::MAX, 2)
+                .expect("first call must succeed");
+
+            // Second call: any positive increment must now overflow.
+            let overflow_result = update_analytics_on_refund(&env, bounty_id, 1, 3);
+            assert_eq!(
+                overflow_result,
+                Err(AnalyticsError::Overflow),
+                "overflow must return Err(AnalyticsError::Overflow), not panic"
+            );
+        });
+    }
+
+    /// release: state must not be mutated after an overflow is detected.
+    ///
+    /// The accumulator and counter should remain at their pre-call values when
+    /// the checked_add detects an overflow and returns early.
+    #[test]
+    fn test_release_overflow_state_not_mutated() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, DummyAnalyticsContract);
+
+        env.as_contract(&contract_id, || {
+            let bounty_id = 104u64;
+            init_bounty_analytics(&env, bounty_id, i128::MAX, 1);
+
+            // Fill the accumulator to i128::MAX.
+            update_analytics_on_release(&env, bounty_id, i128::MAX, 2).unwrap();
+
+            let before = get_bounty_analytics(&env, bounty_id).unwrap();
+
+            // This must fail without mutating state.
+            let _ = update_analytics_on_release(&env, bounty_id, 1, 3);
+
+            let after = get_bounty_analytics(&env, bounty_id).unwrap();
+            assert_eq!(
+                before.total_amount_released, after.total_amount_released,
+                "total_amount_released must not change after overflow"
+            );
+            assert_eq!(
+                before.partial_releases_count, after.partial_releases_count,
+                "partial_releases_count must not change after overflow"
+            );
+        });
+    }
+
+    /// refund: state must not be mutated after an overflow is detected.
+    #[test]
+    fn test_refund_overflow_state_not_mutated() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, DummyAnalyticsContract);
+
+        env.as_contract(&contract_id, || {
+            let bounty_id = 105u64;
+            init_bounty_analytics(&env, bounty_id, i128::MAX, 1);
+
+            // Fill the accumulator to i128::MAX.
+            update_analytics_on_refund(&env, bounty_id, i128::MAX, 2).unwrap();
+
+            let before = get_bounty_analytics(&env, bounty_id).unwrap();
+
+            // This must fail without mutating state.
+            let _ = update_analytics_on_refund(&env, bounty_id, 1, 3);
+
+            let after = get_bounty_analytics(&env, bounty_id).unwrap();
+            assert_eq!(
+                before.total_amount_refunded, after.total_amount_refunded,
+                "total_amount_refunded must not change after overflow"
+            );
+            assert_eq!(
+                before.partial_refunds_count, after.partial_refunds_count,
+                "partial_refunds_count must not change after overflow"
+            );
+        });
+    }
+
+    /// Missing bounty: update on a non-existent bounty must return Ok(()) (silent no-op).
+    #[test]
+    fn test_release_missing_bounty_is_noop_ok() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, DummyAnalyticsContract);
+
+        env.as_contract(&contract_id, || {
+            let result = update_analytics_on_release(&env, 999, 500, 100);
+            assert_eq!(result, Ok(()), "missing bounty must return Ok(())");
+            assert!(get_bounty_analytics(&env, 999).is_none());
+        });
+    }
+
+    /// Missing bounty: update on a non-existent bounty must return Ok(()) (silent no-op).
+    #[test]
+    fn test_refund_missing_bounty_is_noop_ok() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, DummyAnalyticsContract);
+
+        env.as_contract(&contract_id, || {
+            let result = update_analytics_on_refund(&env, 999, 300, 50);
+            assert_eq!(result, Ok(()), "missing bounty must return Ok(())");
+            assert!(get_bounty_analytics(&env, 999).is_none());
         });
     }
 }

--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -417,6 +417,10 @@ pub enum Error {
     /// proposal approving it (or no governance contract is configured at
     /// all — upgrades fail closed, they are never permitted by default).
     UpgradeNotApproved = 26,
+    /// Returned when an arithmetic operation on an analytics accumulator
+    /// would overflow `i128` or `u32`.  Appended last to preserve
+    /// existing discriminant ordering.
+    AnalyticsOverflow = 27,
 }
 
 #[contracttype]
@@ -1540,8 +1544,9 @@ impl BountyEscrowContract {
 
         let timestamp = env.ledger().timestamp();
 
-        // Update analytics
-        update_analytics_on_release(&env, bounty_id, release_amount, timestamp);
+        // Update analytics; map overflow to a typed error rather than panicking.
+        update_analytics_on_release(&env, bounty_id, release_amount, timestamp)
+            .map_err(|_| Error::AnalyticsOverflow)?;
 
         // Update incremental aggregate counters
         Self::transition_locked_to_released(&env, release_amount);
@@ -2033,7 +2038,8 @@ impl BountyEscrowContract {
         // Update per-bounty analytics (mirrors release_funds/refund) so
         // total_amount_released/remaining_amount never drift out of sync
         // with the escrow's own remaining_amount after a partial release.
-        update_analytics_on_release(&env, bounty_id, payout_amount, env.ledger().timestamp());
+        update_analytics_on_release(&env, bounty_id, payout_amount, env.ledger().timestamp())
+            .map_err(|_| Error::AnalyticsOverflow)?;
 
         // Update incremental aggregate counters
         Self::partial_release_from_locked(&env, payout_amount);
@@ -2192,8 +2198,9 @@ impl BountyEscrowContract {
             .set(&DataKey::Escrow(bounty_id), &escrow);
         Self::bump_escrow_ttl(&env, bounty_id);
 
-        // Update analytics
-        update_analytics_on_refund(&env, bounty_id, refund_amount, now);
+        // Update analytics; map overflow to a typed error rather than panicking.
+        update_analytics_on_refund(&env, bounty_id, refund_amount, now)
+            .map_err(|_| Error::AnalyticsOverflow)?;
 
         // Update incremental aggregate counters
         match (original_status, escrow.status.clone()) {
@@ -2373,7 +2380,8 @@ impl BountyEscrowContract {
                 .set(&DataKey::Escrow(bounty_id), &escrow);
             Self::bump_escrow_ttl(&env, bounty_id);
 
-            update_analytics_on_refund(&env, bounty_id, refund_amount, now);
+            update_analytics_on_refund(&env, bounty_id, refund_amount, now)
+                .map_err(|_| Error::AnalyticsOverflow)?;
 
             emit_bounty_state_transitioned(
                 &env,

--- a/bounty_escrow/contracts/escrow/src/test_analytics_statistics.rs
+++ b/bounty_escrow/contracts/escrow/src/test_analytics_statistics.rs
@@ -139,7 +139,7 @@ fn test_init_analytics_multiple_bounties_independent() {
 fn test_release_missing_bounty_is_noop() {
     let (env, id) = setup();
     env.as_contract(&id, || {
-        update_analytics_on_release(&env, 99, 500, 100); // no init – must not panic
+        update_analytics_on_release(&env, 99, 500, 100).unwrap(); // no init – must not panic
         assert!(get_bounty_analytics(&env, 99).is_none());
     });
 }
@@ -158,7 +158,7 @@ fn test_release_single_partial_release() {
     let (env, id) = setup();
     env.as_contract(&id, || {
         init_bounty_analytics(&env, 20, 1_000, 100);
-        update_analytics_on_release(&env, 20, 500, 200);
+        update_analytics_on_release(&env, 20, 500, 200).unwrap();
 
         let a = get_bounty_analytics(&env, 20).unwrap();
         assert_eq!(a.total_amount_released, 500);
@@ -182,19 +182,19 @@ fn test_release_multiple_partial_releases_accumulate() {
     env.as_contract(&id, || {
         init_bounty_analytics(&env, 21, 1_000, 1);
 
-        update_analytics_on_release(&env, 21, 300, 2);
+        update_analytics_on_release(&env, 21, 300, 2).unwrap();
         let a = get_bounty_analytics(&env, 21).unwrap();
         assert_eq!(a.total_amount_released, 300);
         assert_eq!(a.remaining_amount, 700);
         assert_eq!(a.partial_releases_count, 1);
 
-        update_analytics_on_release(&env, 21, 300, 3);
+        update_analytics_on_release(&env, 21, 300, 3).unwrap();
         let a = get_bounty_analytics(&env, 21).unwrap();
         assert_eq!(a.total_amount_released, 600);
         assert_eq!(a.remaining_amount, 400);
         assert_eq!(a.partial_releases_count, 2);
 
-        update_analytics_on_release(&env, 21, 400, 4);
+        update_analytics_on_release(&env, 21, 400, 4).unwrap();
         let a = get_bounty_analytics(&env, 21).unwrap();
         assert_eq!(a.total_amount_released, 1_000);
         assert_eq!(a.remaining_amount, 0);
@@ -210,7 +210,7 @@ fn test_release_exact_amount_drains_to_zero() {
     let (env, id) = setup();
     env.as_contract(&id, || {
         init_bounty_analytics(&env, 22, 500, 1);
-        update_analytics_on_release(&env, 22, 500, 2);
+        update_analytics_on_release(&env, 22, 500, 2).unwrap();
 
         let a = get_bounty_analytics(&env, 22).unwrap();
         assert_eq!(a.remaining_amount, 0);
@@ -227,7 +227,7 @@ fn test_release_zero_amount_increments_count_only() {
     let (env, id) = setup();
     env.as_contract(&id, || {
         init_bounty_analytics(&env, 23, 1_000, 1);
-        update_analytics_on_release(&env, 23, 0, 2);
+        update_analytics_on_release(&env, 23, 0, 2).unwrap();
 
         let a = get_bounty_analytics(&env, 23).unwrap();
         assert_eq!(a.total_amount_released, 0);
@@ -245,7 +245,7 @@ fn test_release_zero_amount_increments_count_only() {
 fn test_refund_missing_bounty_is_noop() {
     let (env, id) = setup();
     env.as_contract(&id, || {
-        update_analytics_on_refund(&env, 88, 100, 50);
+        update_analytics_on_refund(&env, 88, 100, 50).unwrap();
         assert!(get_bounty_analytics(&env, 88).is_none());
     });
 }
@@ -264,7 +264,7 @@ fn test_refund_single_partial_refund() {
     let (env, id) = setup();
     env.as_contract(&id, || {
         init_bounty_analytics(&env, 30, 1_000, 100);
-        update_analytics_on_refund(&env, 30, 300, 200);
+        update_analytics_on_refund(&env, 30, 300, 200).unwrap();
 
         let a = get_bounty_analytics(&env, 30).unwrap();
         assert_eq!(a.total_amount_refunded, 300);
@@ -287,13 +287,13 @@ fn test_refund_multiple_partial_refunds_accumulate() {
     env.as_contract(&id, || {
         init_bounty_analytics(&env, 31, 800, 10);
 
-        update_analytics_on_refund(&env, 31, 200, 20);
+        update_analytics_on_refund(&env, 31, 200, 20).unwrap();
         let a = get_bounty_analytics(&env, 31).unwrap();
         assert_eq!(a.total_amount_refunded, 200);
         assert_eq!(a.remaining_amount, 600);
         assert_eq!(a.partial_refunds_count, 1);
 
-        update_analytics_on_refund(&env, 31, 600, 30);
+        update_analytics_on_refund(&env, 31, 600, 30).unwrap();
         let a = get_bounty_analytics(&env, 31).unwrap();
         assert_eq!(a.total_amount_refunded, 800);
         assert_eq!(a.remaining_amount, 0);
@@ -309,7 +309,7 @@ fn test_refund_exact_amount_drains_to_zero() {
     let (env, id) = setup();
     env.as_contract(&id, || {
         init_bounty_analytics(&env, 32, 400, 1);
-        update_analytics_on_refund(&env, 32, 400, 2);
+        update_analytics_on_refund(&env, 32, 400, 2).unwrap();
 
         let a = get_bounty_analytics(&env, 32).unwrap();
         assert_eq!(a.remaining_amount, 0);
@@ -326,7 +326,7 @@ fn test_refund_zero_amount_increments_count_only() {
     let (env, id) = setup();
     env.as_contract(&id, || {
         init_bounty_analytics(&env, 33, 500, 1);
-        update_analytics_on_refund(&env, 33, 0, 2);
+        update_analytics_on_refund(&env, 33, 0, 2).unwrap();
 
         let a = get_bounty_analytics(&env, 33).unwrap();
         assert_eq!(a.total_amount_refunded, 0);
@@ -351,8 +351,8 @@ fn test_lifecycle_release_then_refund_drains_to_zero() {
     env.as_contract(&id, || {
         init_bounty_analytics(&env, 40, 1_000, 1);
 
-        update_analytics_on_release(&env, 40, 600, 2);
-        update_analytics_on_refund(&env, 40, 400, 3);
+        update_analytics_on_release(&env, 40, 600, 2).unwrap();
+        update_analytics_on_refund(&env, 40, 400, 3).unwrap();
 
         let a = get_bounty_analytics(&env, 40).unwrap();
         assert_eq!(a.total_amount_released, 600);
@@ -388,17 +388,17 @@ fn test_lifecycle_multiple_bounties_cross_check_totals() {
     env.as_contract(&id, || {
         // bounty 50: fully released
         init_bounty_analytics(&env, 50, 2_000, 1);
-        update_analytics_on_release(&env, 50, 2_000, 2);
+        update_analytics_on_release(&env, 50, 2_000, 2).unwrap();
 
         // bounty 51: fully refunded in two steps
         init_bounty_analytics(&env, 51, 3_000, 1);
-        update_analytics_on_refund(&env, 51, 1_000, 2);
-        update_analytics_on_refund(&env, 51, 2_000, 3);
+        update_analytics_on_refund(&env, 51, 1_000, 2).unwrap();
+        update_analytics_on_refund(&env, 51, 2_000, 3).unwrap();
 
         // bounty 52: partial release then refund remainder
         init_bounty_analytics(&env, 52, 5_000, 1);
-        update_analytics_on_release(&env, 52, 2_000, 2);
-        update_analytics_on_refund(&env, 52, 3_000, 3);
+        update_analytics_on_release(&env, 52, 2_000, 2).unwrap();
+        update_analytics_on_refund(&env, 52, 3_000, 3).unwrap();
 
         let a50 = get_bounty_analytics(&env, 50).unwrap();
         let a51 = get_bounty_analytics(&env, 51).unwrap();
@@ -540,10 +540,10 @@ fn test_average_bounty_amount_cross_checked_with_analytics_helpers() {
     let (env, id) = setup();
     env.as_contract(&id, || {
         init_bounty_analytics(&env, 60, 6_000, 1);
-        update_analytics_on_release(&env, 60, 6_000, 2);
+        update_analytics_on_release(&env, 60, 6_000, 2).unwrap();
 
         init_bounty_analytics(&env, 61, 4_000, 1);
-        update_analytics_on_release(&env, 61, 4_000, 2);
+        update_analytics_on_release(&env, 61, 4_000, 2).unwrap();
 
         let a60 = get_bounty_analytics(&env, 60).unwrap();
         let a61 = get_bounty_analytics(&env, 61).unwrap();
@@ -601,8 +601,8 @@ fn test_large_amounts_no_overflow() {
     let (env, id) = setup();
     env.as_contract(&id, || {
         init_bounty_analytics(&env, 70, locked, 1);
-        update_analytics_on_release(&env, 70, half, 2);
-        update_analytics_on_release(&env, 70, locked - half, 3);
+        update_analytics_on_release(&env, 70, half, 2).unwrap();
+        update_analytics_on_release(&env, 70, locked - half, 3).unwrap();
 
         let a = get_bounty_analytics(&env, 70).unwrap();
         assert_eq!(a.total_amount_locked, locked);

--- a/bounty_escrow/contracts/escrow/src/test_bounty_analytics.rs
+++ b/bounty_escrow/contracts/escrow/src/test_bounty_analytics.rs
@@ -141,8 +141,8 @@ fn test_state_lifecycle_cross_period() {
         let p2_ts = PERIOD_SECONDS * 2 + 100;
 
         init_bounty_analytics(&env, 1, 1000, p0_ts);
-        update_analytics_on_release(&env, 1, 200, p1_ts);
-        update_analytics_on_refund(&env, 1, 800, p2_ts);
+        update_analytics_on_release(&env, 1, 200, p1_ts).unwrap();
+        update_analytics_on_refund(&env, 1, 800, p2_ts).unwrap();
 
         let analytics = get_bounty_analytics(&env, 1).unwrap();
         assert_eq!(analytics.created_at, p0_ts);
@@ -198,21 +198,21 @@ fn test_direct_sequential_releases() {
         init_bounty_analytics(&env, bounty_id, amount, 100);
 
         // First partial release
-        update_analytics_on_release(&env, bounty_id, 200, 200);
+        update_analytics_on_release(&env, bounty_id, 200, 200).unwrap();
         let a = get_bounty_analytics(&env, bounty_id).unwrap();
         assert_eq!(a.total_amount_released, 200);
         assert_eq!(a.remaining_amount, 800);
         assert_eq!(a.partial_releases_count, 1);
 
         // Second partial release
-        update_analytics_on_release(&env, bounty_id, 300, 300);
+        update_analytics_on_release(&env, bounty_id, 300, 300).unwrap();
         let a = get_bounty_analytics(&env, bounty_id).unwrap();
         assert_eq!(a.total_amount_released, 500);
         assert_eq!(a.remaining_amount, 500);
         assert_eq!(a.partial_releases_count, 2);
 
         // Third partial release
-        update_analytics_on_release(&env, bounty_id, 100, 400);
+        update_analytics_on_release(&env, bounty_id, 100, 400).unwrap();
         let a = get_bounty_analytics(&env, bounty_id).unwrap();
         assert_eq!(a.total_amount_released, 600);
         assert_eq!(a.remaining_amount, 400);
@@ -237,14 +237,14 @@ fn test_direct_sequential_refunds() {
         init_bounty_analytics(&env, bounty_id, amount, 100);
 
         // First partial refund
-        update_analytics_on_refund(&env, bounty_id, 150, 200);
+        update_analytics_on_refund(&env, bounty_id, 150, 200).unwrap();
         let a = get_bounty_analytics(&env, bounty_id).unwrap();
         assert_eq!(a.total_amount_refunded, 150);
         assert_eq!(a.remaining_amount, 850);
         assert_eq!(a.partial_refunds_count, 1);
 
         // Second partial refund
-        update_analytics_on_refund(&env, bounty_id, 250, 300);
+        update_analytics_on_refund(&env, bounty_id, 250, 300).unwrap();
         let a = get_bounty_analytics(&env, bounty_id).unwrap();
         assert_eq!(a.total_amount_refunded, 400);
         assert_eq!(a.remaining_amount, 600);
@@ -270,7 +270,7 @@ fn test_direct_saturating_sub_boundary() {
 
         // Release more than remaining — saturating_sub prevents overflow but NOT underflow below 0
         init_bounty_analytics(&env, bounty_id, amount, 100);
-        update_analytics_on_release(&env, bounty_id, 200, 200);
+        update_analytics_on_release(&env, bounty_id, 200, 200).unwrap();
         let a = get_bounty_analytics(&env, bounty_id).unwrap();
         // saturating_sub(100, 200) on i128 = -100 — does NOT floor at zero
         assert_eq!(a.remaining_amount, -100, "saturating_sub on i128 allows negative values");
@@ -280,7 +280,7 @@ fn test_direct_saturating_sub_boundary() {
         // Refund on a different bounty — refund more than remaining
         let bounty_id2 = 14u64;
         init_bounty_analytics(&env, bounty_id2, 50, 100);
-        update_analytics_on_refund(&env, bounty_id2, 500, 200);
+        update_analytics_on_refund(&env, bounty_id2, 500, 200).unwrap();
         let a2 = get_bounty_analytics(&env, bounty_id2).unwrap();
         assert_eq!(a2.remaining_amount, -450, "refund excess goes negative via saturating_sub");
         assert_eq!(a2.total_amount_refunded, 500, "total_refunded accumulates via raw +=");
@@ -298,7 +298,7 @@ fn test_direct_release_on_uninitialized_bounty() {
         let bounty_id = 9999u64;
 
         // This should not panic — just silent no-op
-        update_analytics_on_release(&env, bounty_id, 100, 200);
+        update_analytics_on_release(&env, bounty_id, 100, 200).unwrap();
 
         // Verify no record was created
         let result = get_bounty_analytics(&env, bounty_id);
@@ -316,7 +316,7 @@ fn test_direct_refund_on_uninitialized_bounty() {
         let bounty_id = 9998u64;
 
         // This should not panic — just silent no-op
-        update_analytics_on_refund(&env, bounty_id, 100, 200);
+        update_analytics_on_refund(&env, bounty_id, 100, 200).unwrap();
 
         // Verify no record was created
         let result = get_bounty_analytics(&env, bounty_id);


### PR DESCRIPTION
## Summary

Closes #165

Replaces raw `+=` arithmetic on aggregate accumulators in `analytics.rs` with `checked_add`, returning a typed `AnalyticsError::Overflow` rather than panicking or wrapping silently on near-`i128::MAX` inputs.

## Changes

### `analytics.rs`
- Added `AnalyticsError` enum with `Overflow` variant.
- Updated `update_analytics_on_release` and `update_analytics_on_refund` signatures to return `Result<(), AnalyticsError>`.
- Replaced `total_amount_released +=` and `total_amount_refunded +=` with `checked_add(...).ok_or(AnalyticsError::Overflow)?`.
- Replaced `partial_releases_count +=1` and `partial_refunds_count += 1` with `checked_add(1)`.
- Added doc comments on each aggregation function stating expected input bounds.
- Added breaking-change compatibility comment near accumulator mutations referencing off-chain consumers.

### `lib.rs`
- Added `Error::AnalyticsOverflow = 27` (appended to preserve existing discriminant ordering).
- Updated all 4 call sites to propagate `AnalyticsError` → `Error::AnalyticsOverflow` via `.map_err(|_| Error::AnalyticsOverflow)?`.

### Tests
- 8 new overflow/checked-arithmetic tests in `analytics.rs::tests`:
  - `test_release_near_max_no_overflow`
  - `test_release_overflow_returns_error_not_panic`
  - `test_release_overflow_state_not_mutated`
  - `test_refund_near_max_no_overflow`
  - `test_refund_overflow_returns_error_not_panic`
  - `test_refund_overflow_state_not_mutated`
  - `test_release_missing_bounty_is_noop_ok`
  - `test_refund_missing_bounty_is_noop_ok`
- Updated existing call sites in `test_analytics_statistics.rs` and `test_bounty_analytics.rs` to handle the new `Result` return type.

## Testing

```
cargo test -p bounty-escrow --lib
test result: ok. 585 passed; 0 failed; 0 ignored
```