### PR TITLE
fix: add schedule_upgrade + timelock handling to rollback.sh

### DIFF
--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -244,6 +244,10 @@ load_rollback_config() {
     : "${SOROBAN_NETWORK:=$NETWORK}"
     : "${DEPLOYER_IDENTITY:=default}"
     : "${CLI_TIMEOUT:=120}"
+    # How long perform_rollback will poll/sleep for a scheduled upgrade's
+    # timelock to elapse before giving up and asking the operator to re-run.
+    # grainlify-core's default delay is 24h — never auto-wait for that long.
+    : "${MAX_AUTO_WAIT_SECONDS:=300}"
 
     ROLLBACK_LOG="${PROJECT_ROOT}/deployments/rollbacks.json"
 
@@ -335,6 +339,102 @@ record_rollback() {
 }
 
 # ------------------------------------------------------------------------------
+# Upgrade Timelock Helpers
+# ------------------------------------------------------------------------------
+#
+# grainlify-core's upgrade() requires a prior schedule_upgrade() call and an
+# elapsed timelock (require_scheduled_upgrade). These helpers query that
+# state via read-only invokes so the rollback flow can account for it instead
+# of failing blind at the upgrade step.
+
+# Read grainlify-core's configured upgrade delay, in seconds.
+# Prints the delay, or "0" if the call fails (contract predates this
+# feature, or the read itself errored) so callers can treat it as "no
+# timelock" rather than crashing.
+query_upgrade_delay() {
+    local cli_cmd
+    cli_cmd=$(get_cli_command)
+
+    local delay
+    if ! delay=$(run_with_timeout "$CLI_TIMEOUT" \
+        $cli_cmd contract invoke \
+        --id "$CONTRACT_ID" \
+        --network "$SOROBAN_NETWORK" \
+        --source "$DEPLOYER_IDENTITY" \
+        -- \
+        get_upgrade_delay 2>/dev/null); then
+        echo "0"
+        return 0
+    fi
+
+    delay=$(echo "$delay" | tr -dc '0-9')
+    echo "${delay:-0}"
+}
+
+# Returns 0 (true) if a scheduled upgrade for $1 (a wasm hash) exists and its
+# timelock has already elapsed — i.e. calling upgrade() right now would
+# succeed without a preceding schedule_upgrade() call.
+query_is_upgrade_ready() {
+    local wasm_hash="$1"
+    local cli_cmd
+    cli_cmd=$(get_cli_command)
+
+    local result
+    result=$($cli_cmd contract invoke \
+        --id "$CONTRACT_ID" \
+        --network "$SOROBAN_NETWORK" \
+        --source "$DEPLOYER_IDENTITY" \
+        -- \
+        is_upgrade_ready \
+        --wasm_hash "$wasm_hash" 2>/dev/null || echo "false")
+
+    [[ "$result" == "true" ]]
+}
+
+# Extracts the executable_at unix timestamp from get_scheduled_upgrade's
+# output. Handles both JSON-object output (newer CLI versions) and plain
+# text, mirroring extract_wasm_hash's fallback approach in
+# verify-deployment.sh, since the exact stellar/soroban CLI return-value
+# format for a struct varies by version.
+extract_executable_at() {
+    local output="$1"
+    local value=""
+
+    if command -v jq &> /dev/null && echo "$output" | jq -e . > /dev/null 2>&1; then
+        value=$(echo "$output" | jq -r '
+            .executable_at // .executableAt // empty
+        ' 2>/dev/null | head -n 1)
+    fi
+
+    if [[ -z "$value" ]]; then
+        value=$(echo "$output" \
+            | grep -Eoi '"?executable_at"?[" :]+([0-9]+)' \
+            | grep -Eo '[0-9]+$' \
+            | head -n 1 || true)
+    fi
+
+    echo "$value"
+}
+
+# Prints the executable_at timestamp of the active scheduled upgrade for
+# $CONTRACT_ID (any hash — this just reads whatever is currently scheduled),
+# or empty string if none is scheduled or the read fails.
+query_scheduled_executable_at() {
+    local cli_cmd
+    cli_cmd=$(get_cli_command)
+
+    local result
+    result=$($cli_cmd contract invoke \
+        --id "$CONTRACT_ID" \
+        --network "$SOROBAN_NETWORK" \
+        --source "$DEPLOYER_IDENTITY" \
+        -- \
+        get_scheduled_upgrade 2>/dev/null || echo "")
+
+    extract_executable_at "$result"
+}
+
+# ------------------------------------------------------------------------------
 # Rollback Execution
 # ------------------------------------------------------------------------------
 
@@ -343,6 +443,34 @@ perform_rollback() {
 
     local cli_cmd
     cli_cmd=$(get_cli_command)
+
+    # Check the timelock BEFORE anything else so the operator sees whether
+    # this rollback can execute immediately, up front — not as a surprise
+    # after they've already committed to it. See issue #488: grainlify-core's
+    # upgrade() requires a prior schedule_upgrade() call and an elapsed
+    # delay (default 24h); discovering that only at failure time is the
+    # worst possible surprise during an active incident.
+    local upgrade_delay upgrade_ready
+    upgrade_delay=$(query_upgrade_delay)
+    if query_is_upgrade_ready "$PREVIOUS_WASM_HASH"; then
+        upgrade_ready="true"
+    else
+        upgrade_ready="false"
+    fi
+
+    echo ""
+    if [[ "$upgrade_ready" == "true" ]]; then
+        log_success "An upgrade to this WASM hash is already scheduled and its timelock has elapsed — rollback can execute immediately."
+    elif [[ "$upgrade_delay" -gt 0 ]]; then
+        log_warn "Configured upgrade delay: ${upgrade_delay}s — this rollback must call schedule_upgrade first and CANNOT take effect until that timelock elapses."
+        if [[ "$upgrade_delay" -le "$MAX_AUTO_WAIT_SECONDS" ]]; then
+            log_warn "Delay is within MAX_AUTO_WAIT_SECONDS (${MAX_AUTO_WAIT_SECONDS}s) — this script will wait it out automatically."
+        else
+            log_warn "Delay exceeds MAX_AUTO_WAIT_SECONDS (${MAX_AUTO_WAIT_SECONDS}s) — this script will schedule the rollback, print the exact time it becomes executable, and exit. Re-run the same command after that time."
+        fi
+    else
+        log_info "No upgrade timelock configured (delay: 0s) — rollback can execute immediately after scheduling."
+    fi
 
     # Display critical warning
     echo ""
@@ -368,6 +496,7 @@ perform_rollback() {
     echo "  Target WASM Hash: $PREVIOUS_WASM_HASH"
     echo "  Network:          $SOROBAN_NETWORK"
     echo "  Source:           $DEPLOYER_IDENTITY"
+    echo "  Upgrade Delay:    ${upgrade_delay}s ($([[ "$upgrade_ready" == "true" ]] && echo "already elapsed" || echo "will start counting once scheduled below"))"
     echo ""
 
     # Mainnet extra warning
@@ -398,9 +527,75 @@ perform_rollback() {
     # Dry run mode
     if [[ "$DRY_RUN" == "true" ]]; then
         log_warn "[DRY RUN] Would execute the following:"
-        log_warn "  $cli_cmd contract invoke --id $CONTRACT_ID -- upgrade --new_wasm_hash $PREVIOUS_WASM_HASH"
+        if [[ "$upgrade_ready" != "true" ]]; then
+            log_warn "  1. $cli_cmd contract invoke --id $CONTRACT_ID -- schedule_upgrade --wasm_hash $PREVIOUS_WASM_HASH"
+            log_warn "     (then wait out or re-run after the ${upgrade_delay}s timelock)"
+            log_warn "  2. $cli_cmd contract invoke --id $CONTRACT_ID -- upgrade --new_wasm_hash $PREVIOUS_WASM_HASH"
+        else
+            log_warn "  $cli_cmd contract invoke --id $CONTRACT_ID -- upgrade --new_wasm_hash $PREVIOUS_WASM_HASH"
+            log_warn "  (schedule_upgrade already elapsed for this hash — no scheduling step needed)"
+        fi
         log_success "[DRY RUN] Simulation complete"
         return 0
+    fi
+
+    # Schedule the upgrade first, unless it's already scheduled-and-ready for
+    # this exact wasm hash (e.g. an operator pre-scheduled it proactively
+    # ahead of an incident). grainlify-core's upgrade() panics with
+    # "No scheduled upgrade" / "Upgrade timelock not elapsed" without this.
+    if [[ "$upgrade_ready" != "true" ]]; then
+        log_info "Scheduling rollback (schedule_upgrade)..."
+
+        local schedule_result
+        if ! schedule_result=$(run_with_timeout "$CLI_TIMEOUT" \
+            $cli_cmd contract invoke \
+            --id "$CONTRACT_ID" \
+            --network "$SOROBAN_NETWORK" \
+            --source "$DEPLOYER_IDENTITY" \
+            --send=yes \
+            -- \
+            schedule_upgrade \
+            --wasm_hash "$PREVIOUS_WASM_HASH" 2>&1); then
+
+            log_error "schedule_upgrade failed!"
+            log_error "Output: $schedule_result"
+            log_error ""
+            log_error "Possible causes:"
+            log_error "  - Source is not contract admin"
+            log_error "  - Network issues"
+            exit 1
+        fi
+
+        log_success "Rollback scheduled"
+
+        local executable_at now remaining
+        executable_at=$(query_scheduled_executable_at)
+        now=$(date +%s)
+
+        if [[ -n "$executable_at" ]]; then
+            remaining=$(( executable_at - now ))
+            [[ "$remaining" -lt 0 ]] && remaining=0
+            log_info "Executable at: $(date -u -d "@$executable_at" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -r "$executable_at" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "$executable_at (unix)") (in ${remaining}s)"
+        else
+            log_warn "Could not read back executable_at from get_scheduled_upgrade; falling back to the configured delay (${upgrade_delay}s)."
+            remaining="$upgrade_delay"
+        fi
+
+        if [[ "$remaining" -gt "$MAX_AUTO_WAIT_SECONDS" ]]; then
+            log_warn ""
+            log_warn "Timelock exceeds MAX_AUTO_WAIT_SECONDS (${MAX_AUTO_WAIT_SECONDS}s) — not blocking this session for it."
+            log_warn "Re-run this exact command in ${remaining}s (or later) to complete the rollback:"
+            log_warn "  $0 $CONTRACT_ID $PREVIOUS_WASM_HASH -n $NETWORK -s $DEPLOYER_IDENTITY${FORCE:+ --force}"
+            log_success "Rollback scheduled successfully — awaiting timelock, no further action needed until then."
+            return 0
+        fi
+
+        if [[ "$remaining" -gt 0 ]]; then
+            log_info "Waiting ${remaining}s for the timelock to elapse..."
+            sleep "$remaining"
+        fi
+    else
+        log_info "Rollback already scheduled and its timelock has elapsed — skipping schedule_upgrade."
     fi
 
     # Execute rollback (call upgrade with old hash)
@@ -424,6 +619,7 @@ perform_rollback() {
         log_error "  - WASM hash not installed on network"
         log_error "  - Source is not contract admin"
         log_error "  - Network issues"
+        log_error "  - No scheduled upgrade exists for this hash yet, or its timelock hasn't elapsed"
         log_error ""
         log_error "If the WASM hash is not installed, you need the original .wasm file:"
         log_error "  stellar contract install --wasm old_contract.wasm --network $NETWORK"

--- a/scripts/test_rollback_timelock.sh
+++ b/scripts/test_rollback_timelock.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Grainlify - rollback.sh timelock integration test (issue #488)
+# ==============================================================================
+# Exercises perform_rollback's schedule_upgrade + timelock handling against a
+# fake `stellar` CLI that simulates grainlify-core's ScheduledUpgrade state
+# machine, instead of a real deployed contract. This lets the test control
+# timing precisely (a real 24h default delay is not something CI should ever
+# wait on) while still driving rollback.sh exactly as it would invoke a real
+# CLI — same subcommands, same flags, same stdout/exit-code contract.
+#
+# Does NOT replace testing against a real local sandbox deployment (see the
+# issue's own suggested execution step 4); it covers the bash orchestration
+# logic that a real-network test would be slow and non-deterministic for.
+# ==============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROLLBACK_SCRIPT="$SCRIPT_DIR/rollback.sh"
+
+TEST_TMP="$(mktemp -d)"
+
+# rollback.sh writes real rollback history to deployments/rollbacks.json
+# relative to the repo root (by design — that's what a real operator run is
+# supposed to do). Back it up and restore it so running this test doesn't
+# pollute the real registry with fake test entries.
+ROLLBACK_LOG_PATH="$SCRIPT_DIR/../deployments/rollbacks.json"
+ROLLBACK_LOG_BACKUP=""
+if [[ -f "$ROLLBACK_LOG_PATH" ]]; then
+    ROLLBACK_LOG_BACKUP="$TEST_TMP/rollbacks.json.orig"
+    cp "$ROLLBACK_LOG_PATH" "$ROLLBACK_LOG_BACKUP"
+fi
+
+cleanup() {
+    if [[ -n "$ROLLBACK_LOG_BACKUP" ]]; then
+        cp "$ROLLBACK_LOG_BACKUP" "$ROLLBACK_LOG_PATH"
+    else
+        rm -f "$ROLLBACK_LOG_PATH"
+    fi
+    rm -rf "$TEST_TMP"
+}
+trap cleanup EXIT
+
+FAKE_CLI_DIR="$TEST_TMP/bin"
+STATE_DIR="$TEST_TMP/state"
+mkdir -p "$FAKE_CLI_DIR" "$STATE_DIR"
+
+CONTRACT_ID="CTESTCONTRACTID000000000000000000000000000000000000000001"
+TARGET_HASH="1111111111111111111111111111111111111111111111111111111111111111"
+TARGET_HASH="${TARGET_HASH:0:64}"
+
+fail() { echo "✘ FAIL: $1"; exit 1; }
+pass() { echo "✔ PASS: $1"; }
+
+# ------------------------------------------------------------------------------
+# Fake `stellar` CLI
+# ------------------------------------------------------------------------------
+# Understands exactly the subset of `stellar keys address` / `stellar contract
+# invoke -- <fn>` that rollback.sh calls, and simulates ScheduledUpgrade state
+# (schedule_upgrade / get_scheduled_upgrade / is_upgrade_ready / upgrade /
+# get_upgrade_delay) in $STATE_DIR/schedule.json, driven by a real wall clock
+# so rollback.sh's own `date +%s` reads agree with it.
+write_fake_cli() {
+    local delay_seconds="$1"
+
+    cat > "$FAKE_CLI_DIR/stellar" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+STATE_DIR="$STATE_DIR"
+DELAY=$delay_seconds
+SCHEDULE_FILE="\$STATE_DIR/schedule.json"
+
+if [[ "\$1" == "keys" && "\$2" == "address" ]]; then
+    echo "GFAKEADMINADDRESS0000000000000000000000000000000000000"
+    exit 0
+fi
+
+if [[ "\$1" == "contract" && "\$2" == "invoke" ]]; then
+    # Find the function name: first arg after the literal "--"
+    fn=""
+    args=("\$@")
+    for i in "\${!args[@]}"; do
+        if [[ "\${args[\$i]}" == "--" ]]; then
+            fn="\${args[\$((i+1))]}"
+            break
+        fi
+    done
+
+    case "\$fn" in
+        get_upgrade_delay)
+            echo "\$DELAY"
+            ;;
+        is_upgrade_ready)
+            if [[ -f "\$SCHEDULE_FILE" ]]; then
+                executable_at=\$(cat "\$SCHEDULE_FILE")
+                now=\$(date +%s)
+                if [[ "\$now" -ge "\$executable_at" ]]; then
+                    echo "true"
+                else
+                    echo "false"
+                fi
+            else
+                echo "false"
+            fi
+            ;;
+        schedule_upgrade)
+            now=\$(date +%s)
+            executable_at=\$((now + DELAY))
+            echo "\$executable_at" > "\$SCHEDULE_FILE"
+            echo "{\"wasm_hash\":\"$TARGET_HASH\",\"scheduled_at\":\$now,\"executable_at\":\$executable_at}"
+            ;;
+        get_scheduled_upgrade)
+            if [[ -f "\$SCHEDULE_FILE" ]]; then
+                executable_at=\$(cat "\$SCHEDULE_FILE")
+                echo "{\"wasm_hash\":\"$TARGET_HASH\",\"executable_at\":\$executable_at}"
+            else
+                echo "null"
+            fi
+            ;;
+        upgrade)
+            if [[ ! -f "\$SCHEDULE_FILE" ]]; then
+                echo "HostError: panic: No scheduled upgrade" >&2
+                exit 1
+            fi
+            executable_at=\$(cat "\$SCHEDULE_FILE")
+            now=\$(date +%s)
+            if [[ "\$now" -lt "\$executable_at" ]]; then
+                echo "HostError: panic: Upgrade timelock not elapsed" >&2
+                exit 1
+            fi
+            rm -f "\$SCHEDULE_FILE"
+            echo "success"
+            ;;
+        *)
+            echo "fake stellar CLI: unhandled function '\$fn'" >&2
+            exit 1
+            ;;
+    esac
+    exit 0
+fi
+
+echo "fake stellar CLI: unhandled invocation: \$*" >&2
+exit 1
+EOF
+    chmod +x "$FAKE_CLI_DIR/stellar"
+}
+
+run_rollback() {
+    # -n testnet: config/testnet.env points SOROBAN_RPC_URL at the real,
+    # publicly reachable testnet endpoint, so preflight's network-connectivity
+    # check (a plain curl reachability probe, not an actual RPC call) passes
+    # without needing a local Soroban node running for this test.
+    PATH="$FAKE_CLI_DIR:$PATH" \
+    "$ROLLBACK_SCRIPT" "$CONTRACT_ID" "$TARGET_HASH" \
+        -n testnet --force "$@" 2>&1
+}
+
+echo "=== rollback.sh timelock integration tests (fake CLI) ==="
+
+# 1. Short delay: script schedules, auto-waits, then upgrades — succeeds
+#    end-to-end in one invocation. This is the issue's core acceptance
+#    criterion: rollback succeeds against a deployment with an active
+#    timelock.
+rm -f "$STATE_DIR/schedule.json"
+write_fake_cli 2
+output=$(MAX_AUTO_WAIT_SECONDS=30 run_rollback) || fail "short-delay rollback exited non-zero: $output"
+echo "$output" | grep -q "Rollback executed successfully" \
+    || fail "short-delay rollback did not report success: $output"
+echo "$output" | grep -qi "will wait it out automatically" \
+    || fail "short-delay rollback did not disclose the timelock upfront: $output"
+pass "short delay (2s, within MAX_AUTO_WAIT_SECONDS): schedules, waits, upgrades — succeeds in one run"
+
+# 2. Long delay: script schedules and exits cleanly with re-run
+#    instructions, instead of blocking for the full delay.
+rm -f "$STATE_DIR/schedule.json"
+write_fake_cli 86400
+start=$(date +%s)
+output=$(MAX_AUTO_WAIT_SECONDS=5 run_rollback) || fail "long-delay rollback exited non-zero: $output"
+elapsed=$(( $(date +%s) - start ))
+[[ "$elapsed" -lt 10 ]] || fail "long-delay rollback blocked for ${elapsed}s instead of exiting promptly"
+echo "$output" | grep -qi "Re-run this exact command" \
+    || fail "long-delay rollback did not print re-run instructions: $output"
+echo "$output" | grep -qi "exceeds MAX_AUTO_WAIT_SECONDS" \
+    || fail "long-delay rollback did not explain why it stopped: $output"
+[[ -f "$STATE_DIR/schedule.json" ]] || fail "long-delay rollback did not actually call schedule_upgrade"
+pass "long delay (86400s, exceeds MAX_AUTO_WAIT_SECONDS): schedules, exits promptly (${elapsed}s) with re-run instructions"
+
+# 3. Re-running after the (simulated) timelock has elapsed picks up the
+#    existing schedule and completes without scheduling again.
+sed -i "s/.*/$(( $(date +%s) - 1 ))/" "$STATE_DIR/schedule.json"
+output=$(MAX_AUTO_WAIT_SECONDS=5 run_rollback) || fail "re-run after elapsed timelock exited non-zero: $output"
+echo "$output" | grep -q "Rollback executed successfully" \
+    || fail "re-run after elapsed timelock did not succeed: $output"
+echo "$output" | grep -qi "already scheduled and its timelock has elapsed" \
+    || fail "re-run after elapsed timelock did not recognise the existing schedule: $output"
+pass "re-run after timelock elapses: recognises the existing schedule, skips re-scheduling, upgrades"
+
+# 4. schedule_upgrade failure (e.g. wrong admin) surfaces a clear error and
+#    does not attempt the upgrade call.
+rm -f "$STATE_DIR/schedule.json"
+write_fake_cli 60
+cat > "$FAKE_CLI_DIR/stellar" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "keys" ]]; then echo "GFAKE"; exit 0; fi
+if [[ "$*" == *"get_upgrade_delay"* ]]; then echo "60"; exit 0; fi
+if [[ "$*" == *"is_upgrade_ready"* ]]; then echo "false"; exit 0; fi
+if [[ "$*" == *"schedule_upgrade"* ]]; then
+    echo "HostError: panic: Unauthorized" >&2
+    exit 1
+fi
+echo "unexpected call: $*" >&2
+exit 1
+EOF
+chmod +x "$FAKE_CLI_DIR/stellar"
+set +e
+output=$(run_rollback)
+exit_code=$?
+set -e
+[[ "$exit_code" -ne 0 ]] || fail "schedule_upgrade failure should have exited non-zero"
+echo "$output" | grep -q "schedule_upgrade failed" \
+    || fail "schedule_upgrade failure did not surface a clear error: $output"
+pass "schedule_upgrade failure (e.g. wrong admin) surfaces a clear error, never reaches the upgrade call"
+
+# 5. --dry-run: describes the schedule_upgrade + upgrade two-step plan and
+#    the configured delay, without ever calling schedule_upgrade for real.
+rm -f "$STATE_DIR/schedule.json"
+write_fake_cli 3600
+output=$(run_rollback --dry-run) || fail "dry-run exited non-zero: $output"
+echo "$output" | grep -q "DRY RUN" \
+    || fail "dry-run did not report simulation mode: $output"
+echo "$output" | grep -q "schedule_upgrade" \
+    || fail "dry-run did not mention the schedule_upgrade step: $output"
+echo "$output" | grep -q "3600" \
+    || fail "dry-run did not surface the configured delay: $output"
+[[ ! -f "$STATE_DIR/schedule.json" ]] \
+    || fail "dry-run must not actually call schedule_upgrade"
+pass "dry-run describes the schedule_upgrade + upgrade plan and the delay, without executing anything"
+
+echo ""
+echo "All rollback.sh timelock tests passed!"


### PR DESCRIPTION
Closes #488

## What

`grainlify-core`'s `upgrade()` requires a prior `schedule_upgrade()` call and an elapsed timelock (`require_scheduled_upgrade` panics with `"No scheduled upgrade"` or `"Upgrade timelock not elapsed"` otherwise). `scripts/rollback.sh::perform_rollback` invoked `upgrade` directly with no preceding `schedule_upgrade` call, so it could never succeed against a `grainlify-core` deployment with the timelock feature active — and since rollback is specifically the tool reached for during an active incident, discovering an unexpected multi-hour wait only at the point of failure is the worst possible time for that surprise.

## How

- **New read-only helpers**: `query_upgrade_delay`, `query_is_upgrade_ready`, `query_scheduled_executable_at` (+ `extract_executable_at`, which mirrors `verify-deployment.sh`'s `extract_wasm_hash` — try `jq` on JSON output first, fall back to a regex scan, since the exact CLI struct-return format varies by version).
- **Delay surfaced upfront**: the configured timelock (and whether a matching schedule is already scheduled-and-ready) is shown in the "Rollback Details" block *before* the operator confirms, not after they've committed to the rollback — directly addressing the issue's security concern.
- **Schedule-then-wait-or-instruct flow**: `perform_rollback` now calls `schedule_upgrade` before `upgrade`, unless `is_upgrade_ready` is already true for the target hash (e.g. an operator pre-scheduled it ahead of an incident). After scheduling, it reads back `executable_at`:
  - if the remaining wait is within a new `MAX_AUTO_WAIT_SECONDS` config (default 300s), it sleeps it out and completes the rollback in one run;
  - otherwise it prints the exact re-run command and computed `executable_at` time, and exits `0` — the script is safely re-runnable: a second invocation after the delay sees `is_upgrade_ready == true` and skips straight to `upgrade`.

  This satisfies the issue's "either wait or clearly instruct the operator to re-run" requirement without ever blocking a session for `grainlify-core`'s 24h default delay.
- `--dry-run` now describes the `schedule_upgrade` + `upgrade` two-step plan (or the one-step plan, if already scheduled-and-ready).
- The upgrade-invocation failure diagnostics now list the missing-schedule/timelock-not-elapsed cause explicitly.

## Test

Added `scripts/test_rollback_timelock.sh` — a fake-CLI integration test (a `stellar` stub simulating `grainlify-core`'s `ScheduledUpgrade` state machine in a temp file, same black-box style as the existing `test_upgrade_failures.sh`) rather than a real local Soroban sandbox, since the only thing under test here is `rollback.sh`'s own bash orchestration logic, and a real 24h default delay isn't something any test should wait on. Covers:

1. Short delay — auto-waits and completes the rollback in one run.
2. Long delay — schedules, exits promptly with re-run instructions, does not block.
3. Re-running after the delay elapses — recognises the existing schedule, does not re-schedule.
4. `schedule_upgrade` failure (e.g. wrong admin) — clear error, never reaches `upgrade`.
5. `--dry-run` — describes the plan, executes nothing.

All 5 pass. The test backs up and restores `deployments/rollbacks.json` so running it doesn't pollute the real rollback registry.

## Verification

- `bash -n` and `shellcheck`: clean on both files (the only shellcheck note on `rollback.sh` is the same info-level unquoted-`$cli_cmd` style already present throughout the rest of the file).
- Confirmed existing input-validation failure paths (missing contract ID, missing wasm hash) are unaffected.
- `scripts/test_rollback_timelock.sh`: 5/5 passing.