### PR TITLE
test: add direct reentrancy guard unit coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+          targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -51,6 +52,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+          targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -52,7 +51,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/program-escrow/src/reentrancy_guard.rs
+++ b/program-escrow/src/reentrancy_guard.rs
@@ -104,3 +104,80 @@ macro_rules! with_reentrancy_guard {
         result
     }};
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ProgramEscrowContract;
+    use soroban_sdk::Env;
+
+    fn with_contract_env<F, T>(f: F) -> T
+    where
+        F: FnOnce(Env) -> T,
+    {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, ProgramEscrowContract);
+        env.as_contract(&contract_id, || f(env.clone()))
+    }
+
+    fn nested_guarded_call(env: &Env, depth: u8) {
+        check_not_entered(env);
+        set_entered(env);
+
+        if depth > 0 {
+            nested_guarded_call(env, depth - 1);
+        }
+
+        clear_entered(env);
+    }
+
+    fn outer_guarded_call(env: &Env, should_error: bool) -> Result<(), &'static str> {
+        check_not_entered(env);
+        set_entered(env);
+
+        let result = if should_error {
+            Err("outer call failed")
+        } else {
+            Ok(())
+        };
+
+        clear_entered(env);
+        result
+    }
+
+    #[test]
+    #[should_panic(expected = "Reentrancy detected")]
+    fn guard_blocks_nested_call_while_entered() {
+        with_contract_env(|env| {
+            nested_guarded_call(&env, 1);
+        });
+    }
+
+    #[test]
+    fn guard_resets_after_normal_outer_call() {
+        with_contract_env(|env| {
+            let result = outer_guarded_call(&env, false);
+            assert!(result.is_ok());
+            assert!(!is_entered(&env));
+
+            check_not_entered(&env);
+            set_entered(&env);
+            clear_entered(&env);
+            assert!(!is_entered(&env));
+        });
+    }
+
+    #[test]
+    fn guard_resets_after_error_returning_outer_call() {
+        with_contract_env(|env| {
+            let result = outer_guarded_call(&env, true);
+            assert_eq!(result, Err("outer call failed"));
+            assert!(!is_entered(&env));
+
+            check_not_entered(&env);
+            set_entered(&env);
+            clear_entered(&env);
+            assert!(!is_entered(&env));
+        });
+    }
+}

--- a/program-escrow/src/reentrancy_guard_standalone_test.rs
+++ b/program-escrow/src/reentrancy_guard_standalone_test.rs
@@ -18,6 +18,35 @@ where
     env.as_contract(&contract_id, || f(env.clone()))
 }
 
+/// Minimal recursive harness used to validate that the guard blocks a nested
+/// invocation while the outer call is still marked as entered.
+fn guarded_nested_call(env: &Env, depth: u8) {
+    check_not_entered(env);
+    set_entered(env);
+
+    if depth > 0 {
+        guarded_nested_call(env, depth - 1);
+    }
+
+    clear_entered(env);
+}
+
+/// Minimal harness that simulates an outer call that returns either success or
+/// an error after the guard has been armed.
+fn guarded_outer_call(env: &Env, should_error: bool) -> Result<(), &'static str> {
+    check_not_entered(env);
+    set_entered(env);
+
+    let result = if should_error {
+        Err("outer call failed")
+    } else {
+        Ok(())
+    };
+
+    clear_entered(env);
+    result
+}
+
 #[test]
 fn test_guard_initially_not_set() {
     let env = Env::default();
@@ -47,6 +76,50 @@ fn test_guard_can_be_set_and_cleared() {
             !is_entered(&env),
             "Guard should be cleared after clear_entered"
         );
+    });
+}
+
+#[test]
+#[should_panic(expected = "Reentrancy detected")]
+fn test_guard_blocks_nested_call_while_entered() {
+    with_contract_env(|env| {
+        guarded_nested_call(&env, 1);
+    });
+}
+
+#[test]
+fn test_guard_resets_after_normal_outer_call() {
+    with_contract_env(|env| {
+        let result = guarded_outer_call(&env, false);
+        assert!(result.is_ok(), "outer call should succeed");
+        assert!(
+            !is_entered(&env),
+            "guard should be cleared after a successful outer call"
+        );
+
+        // A later unrelated call should be allowed once the guard has been reset.
+        check_not_entered(&env);
+        set_entered(&env);
+        clear_entered(&env);
+        assert!(!is_entered(&env));
+    });
+}
+
+#[test]
+fn test_guard_resets_after_error_returning_outer_call() {
+    with_contract_env(|env| {
+        let result = guarded_outer_call(&env, true);
+        assert_eq!(result, Err("outer call failed"));
+        assert!(
+            !is_entered(&env),
+            "guard should be cleared after an error-returning outer call"
+        );
+
+        // The contract should still be usable for a subsequent non-nested call.
+        check_not_entered(&env);
+        set_entered(&env);
+        clear_entered(&env);
+        assert!(!is_entered(&env));
     });
 }
 


### PR DESCRIPTION
Summary
Add direct unit coverage for the [reentrancy_guard](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) primitive itself.

What changed
Added isolated tests for the guard’s enter/clear behavior
Verified nested reentry is blocked while the guard is set
Verified the guard clears correctly after both successful and error-returning outer calls
Confirmed the guard can be reused for a subsequent non-nested call without remaining stuck

Closes #194 