### PR TITLE
fix(sdk): map remaining bounty escrow errors

### DIFF
--- a/sdk/src/__tests__/error-mapping.test.ts
+++ b/sdk/src/__tests__/error-mapping.test.ts
@@ -29,7 +29,7 @@ const PROGRAM_ESCROW_DISCRIMINANTS: number[] = [4, 5];
 /** contracts/bounty_escrow/contracts/escrow/src/lib.rs — Error enum */
 const BOUNTY_ESCROW_DISCRIMINANTS: number[] = [
   1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, /* gap at 15 */ 16, 17, 18,
-  19, 20, 21, 22, 23,
+  19, 20, 21, 22, 23, 24, 25, 26, 27,
 ];
 
 /** contracts/grainlify-core/src/governance.rs — Error enum */
@@ -93,7 +93,7 @@ describe('Numeric error code tables', () => {
   });
 
   describe('Bounty-escrow', () => {
-    it('maps every contract discriminant (1-23, excluding 15)', () => {
+    it('maps every contract discriminant (1-27, excluding 15)', () => {
       for (const code of BOUNTY_ESCROW_DISCRIMINANTS) {
         expect(BOUNTY_ESCROW_ERROR_MAP[code]).toBeDefined();
       }
@@ -103,6 +103,21 @@ describe('Numeric error code tables', () => {
       for (const code of BOUNTY_ESCROW_DISCRIMINANTS) {
         const err = parseContractErrorByCode(code, 'bounty_escrow');
         expect(err).toBeInstanceOf(ContractError);
+        expect(err.code).not.toBe('CONTRACT_ERROR');
+        expect(err.contractErrorCode).toBe(code);
+      }
+    });
+
+    it('resolves pending-claim, upgrade, and analytics errors to specific codes', () => {
+      const cases: [number, ContractErrorCode][] = [
+        [24, ContractErrorCode.BOUNTY_PENDING_CLAIM_EXISTS],
+        [26, ContractErrorCode.BOUNTY_UPGRADE_NOT_APPROVED],
+        [27, ContractErrorCode.BOUNTY_ANALYTICS_OVERFLOW],
+      ];
+
+      for (const [code, expected] of cases) {
+        const err = parseContractErrorByCode(code, 'bounty_escrow');
+        expect(err.code).toBe(expected);
         expect(err.code).not.toBe('CONTRACT_ERROR');
         expect(err.contractErrorCode).toBe(code);
       }
@@ -354,16 +369,16 @@ describe('Cross-layer consistency', () => {
 describe('Enum size regression guards', () => {
   it('ContractErrorCode has the expected number of values', () => {
     const count = Object.keys(ContractErrorCode).length;
-    // 12 program-escrow + 23 bounty-escrow + 19 governance + 3 circuit-breaker = 57
-    expect(count).toBe(57);
+    // 12 program-escrow + 26 bounty-escrow + 19 governance + 3 circuit-breaker = 60
+    expect(count).toBe(60);
   });
 
   it('PROGRAM_ESCROW_ERROR_MAP has 2 entries', () => {
     expect(Object.keys(PROGRAM_ESCROW_ERROR_MAP).length).toBe(2);
   });
 
-  it('BOUNTY_ESCROW_ERROR_MAP has 23 entries', () => {
-    expect(Object.keys(BOUNTY_ESCROW_ERROR_MAP).length).toBe(23);
+  it('BOUNTY_ESCROW_ERROR_MAP has 26 entries', () => {
+    expect(Object.keys(BOUNTY_ESCROW_ERROR_MAP).length).toBe(26);
   });
 
   it('GOVERNANCE_ERROR_MAP has 19 entries', () => {

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -99,7 +99,10 @@ export enum ContractErrorCode {
   BOUNTY_CIRCUIT_BREAKER_OPEN = 'BOUNTY_CIRCUIT_BREAKER_OPEN', // 21
   BOUNTY_CLAIM_EXPIRED        = 'BOUNTY_CLAIM_EXPIRED',        // 22
   BOUNTY_GOVERNANCE_VERSION_TOO_LOW = 'BOUNTY_GOVERNANCE_VERSION_TOO_LOW', // 23
+  BOUNTY_PENDING_CLAIM_EXISTS = 'BOUNTY_PENDING_CLAIM_EXISTS', // 24
   BOUNTY_GOVERNANCE_PROPOSAL_NOT_EXECUTABLE = 'BOUNTY_GOVERNANCE_PROPOSAL_NOT_EXECUTABLE', // 25
+  BOUNTY_UPGRADE_NOT_APPROVED = 'BOUNTY_UPGRADE_NOT_APPROVED', // 26
+  BOUNTY_ANALYTICS_OVERFLOW   = 'BOUNTY_ANALYTICS_OVERFLOW',   // 27
 
   // ── Governance (contracts/grainlify-core/governance) ───────────────────
   GOV_NOT_INITIALIZED        = 'GOV_NOT_INITIALIZED',          // 1
@@ -170,7 +173,10 @@ const CONTRACT_ERROR_MESSAGES: Record<ContractErrorCode, string> = {
   [ContractErrorCode.BOUNTY_CIRCUIT_BREAKER_OPEN]: 'Bounty escrow circuit breaker is open',
   [ContractErrorCode.BOUNTY_CLAIM_EXPIRED]:        'Authorized bounty claim window has expired',
   [ContractErrorCode.BOUNTY_GOVERNANCE_VERSION_TOO_LOW]: 'Linked governance contract version is below the bounty escrow minimum',
+  [ContractErrorCode.BOUNTY_PENDING_CLAIM_EXISTS]: 'A pending claim already exists for this bounty',
   [ContractErrorCode.BOUNTY_GOVERNANCE_PROPOSAL_NOT_EXECUTABLE]: 'Governance proposal is not executable for this bounty escrow action',
+  [ContractErrorCode.BOUNTY_UPGRADE_NOT_APPROVED]: 'Governance has not approved this bounty escrow upgrade',
+  [ContractErrorCode.BOUNTY_ANALYTICS_OVERFLOW]:   'Bounty analytics calculation overflowed',
 
   // Governance
   [ContractErrorCode.GOV_NOT_INITIALIZED]:        'Governance contract has not been initialized',
@@ -233,7 +239,10 @@ export const BOUNTY_ESCROW_ERROR_MAP: Record<number, ContractErrorCode> = {
   21: ContractErrorCode.BOUNTY_CIRCUIT_BREAKER_OPEN,
   22: ContractErrorCode.BOUNTY_CLAIM_EXPIRED,
   23: ContractErrorCode.BOUNTY_GOVERNANCE_VERSION_TOO_LOW,
+  24: ContractErrorCode.BOUNTY_PENDING_CLAIM_EXISTS,
   25: ContractErrorCode.BOUNTY_GOVERNANCE_PROPOSAL_NOT_EXECUTABLE,
+  26: ContractErrorCode.BOUNTY_UPGRADE_NOT_APPROVED,
+  27: ContractErrorCode.BOUNTY_ANALYTICS_OVERFLOW,
 };
 
 /** Governance #[contracterror] discriminants → SDK code */


### PR DESCRIPTION
Closes #532

## Summary

- add typed SDK error codes and messages for bounty-escrow errors 24 (`PendingClaimExists`), 26 (`UpgradeNotApproved`), and 27 (`AnalyticsOverflow`)
- map all three on-chain discriminants in `BOUNTY_ESCROW_ERROR_MAP`
- extend the authoritative error-map regression suite so each code resolves to its specific typed error instead of the generic `CONTRACT_ERROR` fallback

## Validation

- `npm run build`
- `npm test -- --runInBand` — 9 suites and 304 tests passed
- `npm run test:coverage -- --runInBand` — 304 tests passed; `errors.ts` reached 100% statements, 99.34% branches, 100% functions, and 100% lines
- `git diff --check`
