### PR TITLE
fix(program-escrow): require auth in release_prog_schedule_automatic

### DIFF
--- a/program-escrow/src/lib.rs
+++ b/program-escrow/src/lib.rs
@@ -2951,6 +2951,15 @@ impl ProgramEscrowContract {
 
         let mut schedules = Self::get_program_release_schedules(env.clone());
         let mut program_data = Self::get_program_info(env.clone());
+
+        // Require the same authorization as the sibling release entrypoints
+        // (release_program_schedule_manual, trigger_program_releases) —
+        // without this, any address could choose the exact release timing
+        // for a due schedule and force gas costs onto whoever watches
+        // schedules, even though the recipient/amount are fixed and can't
+        // be redirected (Issue #435).
+        program_data.authorized_payout_key.require_auth();
+
         let now = env.ledger().timestamp();
         let mut released_schedule: Option<ProgramReleaseSchedule> = None;
 


### PR DESCRIPTION
## Summary
`release_prog_schedule_automatic` released due schedules without calling
`require_auth()`, unlike its sibling entrypoints
(`release_program_schedule_manual`, `trigger_program_releases`). Recipient
and amount are fixed by the schedule, so this couldn't redirect funds, but
any address could trigger release at a time of their choosing and push
the gas cost onto whoever calls it.

## Changes
- `release_prog_schedule_automatic` now requires
  `program_data.authorized_payout_key.require_auth()`, matching the other
  release paths.

## Test plan
- [x] `cargo test -p program-escrow`

Closes #435
