### PR TITLE
fix(docs): correct EscrowQueryFilter examples in query docs

### DIFF
--- a/bounty_escrow/contracts/escrow/src/test_query_filters.rs
+++ b/bounty_escrow/contracts/escrow/src/test_query_filters.rs
@@ -1130,3 +1130,28 @@ fn test_query_limit_clamped_to_max_query_limit() {
     let composite = s.escrow.query_escrows(&filter, &0, &u32::MAX);
     assert_eq!(composite.len(), MAX_QUERY_LIMIT);
 }
+
+// Regression guard for issue #486: docs/QUERY_DOCUMENTATION.md and
+// docs/QUERY_QUICK_REFERENCE.md previously showed an Option-based
+// EscrowQueryFilter shape that does not match this struct and would not
+// compile. This mirrors the "Query all locked escrows with amount >= 1000"
+// example verbatim, so if the struct's field shape ever drifts again, this
+// test (not just the docs) fails to compile.
+#[test]
+fn test_escrow_query_filter_doc_example_compiles() {
+    let s = Setup::new();
+
+    let filter = EscrowQueryFilter {
+        has_status_filter: true,
+        status: EscrowStatus::Locked,
+        has_depositor_filter: false,
+        depositor: Address::generate(&s.env),
+        min_amount: 1000,
+        max_amount: i128::MAX,
+        min_deadline: 0,
+        max_deadline: u64::MAX,
+    };
+    // Not asserting on contents here -- the point is that this construction
+    // and call compiles against the real struct/entrypoint shape.
+    let _results = s.escrow.query_escrows(&filter, &0, &50);
+}

--- a/docs/QUERY_DOCUMENTATION.md
+++ b/docs/QUERY_DOCUMENTATION.md
@@ -27,12 +27,14 @@ pub fn query_escrows(env: Env, filter: EscrowQueryFilter, offset: u32, limit: u3
 ```rust
 // Query all locked escrows with amount >= 1000
 let filter = EscrowQueryFilter {
-    status: Some(EscrowStatus::Locked),
-    depositor: None,
-    min_amount: Some(1000),
-    max_amount: None,
-    min_deadline: None,
-    max_deadline: None,
+    has_status_filter: true,
+    status: EscrowStatus::Locked,
+    has_depositor_filter: false,
+    depositor: Address::generate(&env), // ignored: has_depositor_filter is false
+    min_amount: 1000,
+    max_amount: i128::MAX,
+    min_deadline: 0,
+    max_deadline: u64::MAX,
 };
 let results = contract.query_escrows(env, filter, 0, 50);
 ```
@@ -73,7 +75,12 @@ pub fn get_escrows_by_status(env: Env, status: EscrowStatus, offset: u32, limit:
 pub fn get_escrow_count(env: Env) -> u32
 ```
 
-**Purpose**: Get total number of escrows in the system.
+**Purpose**: Lifetime total number of bounties ever locked (append-only,
+never decreases — includes settled `Released`/`Refunded` bounties, not
+just active ones). For a live/active count use
+`count_bounties_by_status(EscrowStatus::Locked)` or `get_aggregate_stats`
+instead. `get_total_bounties_created` is an identically-behaved alias
+with a less ambiguous name.
 
 ## Program Escrow Query Functions
 
@@ -187,8 +194,14 @@ pub fn get_total_scheduled_amount(env: Env) -> i128
    
    // Less efficient: Filter all escrows by depositor
    let filter = EscrowQueryFilter {
-       depositor: Some(depositor),
-       ..Default::default()
+       has_status_filter: false,
+       status: EscrowStatus::Locked, // ignored: has_status_filter is false
+       has_depositor_filter: true,
+       depositor,
+       min_amount: 0,
+       max_amount: i128::MAX,
+       min_deadline: 0,
+       max_deadline: u64::MAX,
    };
    let results = contract.query_escrows(env, filter, 0, 50);
    ```
@@ -197,10 +210,14 @@ pub fn get_total_scheduled_amount(env: Env) -> i128
    ```rust
    // Efficient: Apply multiple filters in single query
    let filter = EscrowQueryFilter {
-       status: Some(EscrowStatus::Locked),
-       min_amount: Some(1000),
-       max_deadline: Some(current_time + 86400),
-       ..Default::default()
+       has_status_filter: true,
+       status: EscrowStatus::Locked,
+       has_depositor_filter: false,
+       depositor: Address::generate(&env), // ignored: has_depositor_filter is false
+       min_amount: 1000,
+       max_amount: i128::MAX,
+       min_deadline: 0,
+       max_deadline: current_time + 86400,
    };
    ```
 

--- a/docs/QUERY_QUICK_REFERENCE.md
+++ b/docs/QUERY_QUICK_REFERENCE.md
@@ -18,12 +18,14 @@ let balance = contract.get_balance(env)?;
 ```rust
 // All locked escrows
 let filter = EscrowQueryFilter {
-    status: Some(EscrowStatus::Locked),
-    depositor: None,
-    min_amount: None,
-    max_amount: None,
-    min_deadline: None,
-    max_deadline: None,
+    has_status_filter: true,
+    status: EscrowStatus::Locked,
+    has_depositor_filter: false,
+    depositor: Address::generate(&env), // ignored: has_depositor_filter is false
+    min_amount: 0,
+    max_amount: i128::MAX,
+    min_deadline: 0,
+    max_deadline: u64::MAX,
 };
 let results = contract.query_escrows(env, filter, 0, 50);
 
@@ -32,12 +34,14 @@ let results = contract.query_escrows_by_depositor(env, depositor_addr, 0, 50);
 
 // High-value escrows expiring soon
 let filter = EscrowQueryFilter {
-    status: Some(EscrowStatus::Locked),
-    depositor: None,
-    min_amount: Some(10000),
-    max_amount: None,
-    min_deadline: None,
-    max_deadline: Some(current_time + 86400), // 24 hours
+    has_status_filter: true,
+    status: EscrowStatus::Locked,
+    has_depositor_filter: false,
+    depositor: Address::generate(&env), // ignored: has_depositor_filter is false
+    min_amount: 10000,
+    max_amount: i128::MAX,
+    min_deadline: 0,
+    max_deadline: current_time + 86400, // 24 hours
 };
 let results = contract.query_escrows(env, filter, 0, 50);
 ```
@@ -171,7 +175,7 @@ loop {
 // Bounty Escrow Dashboard
 let stats = contract.get_aggregate_stats(env.clone());
 let user_escrows = contract.query_escrows_by_depositor(env.clone(), user_addr, 0, 10);
-let total_count = contract.get_escrow_count(env);
+let total_count = contract.get_escrow_count(env); // lifetime total, not a live/active count
 
 // Program Escrow Dashboard
 let stats = contract.get_program_aggregate_stats(env.clone());
@@ -185,9 +189,14 @@ let due = contract.get_due_schedules(env);
 // Check for expiring escrows
 let soon = current_time + 3600; // 1 hour
 let filter = EscrowQueryFilter {
-    status: Some(EscrowStatus::Locked),
-    max_deadline: Some(soon),
-    ..Default::default()
+    has_status_filter: true,
+    status: EscrowStatus::Locked,
+    has_depositor_filter: false,
+    depositor: Address::generate(&env), // ignored: has_depositor_filter is false
+    min_amount: 0,
+    max_amount: i128::MAX,
+    min_deadline: 0,
+    max_deadline: soon,
 };
 let expiring = contract.query_escrows(env, filter, 0, 100);
 
@@ -220,25 +229,38 @@ let daily_total: i128 = daily_payouts.iter().map(|p| p.amount).sum();
 ```rust
 // Empty filter (no filtering)
 let filter = EscrowQueryFilter {
-    status: None,
-    depositor: None,
-    min_amount: None,
-    max_amount: None,
-    min_deadline: None,
-    max_deadline: None,
+    has_status_filter: false,
+    status: EscrowStatus::Locked, // ignored: has_status_filter is false
+    has_depositor_filter: false,
+    depositor: Address::generate(&env), // ignored: has_depositor_filter is false
+    min_amount: 0,
+    max_amount: i128::MAX,
+    min_deadline: 0,
+    max_deadline: u64::MAX,
 };
 
 // Status only
 let filter = EscrowQueryFilter {
-    status: Some(EscrowStatus::Locked),
-    ..Default::default()
+    has_status_filter: true,
+    status: EscrowStatus::Locked,
+    has_depositor_filter: false,
+    depositor: Address::generate(&env), // ignored: has_depositor_filter is false
+    min_amount: 0,
+    max_amount: i128::MAX,
+    min_deadline: 0,
+    max_deadline: u64::MAX,
 };
 
 // Amount range
 let filter = EscrowQueryFilter {
-    min_amount: Some(1000),
-    max_amount: Some(10000),
-    ..Default::default()
+    has_status_filter: false,
+    status: EscrowStatus::Locked, // ignored: has_status_filter is false
+    has_depositor_filter: false,
+    depositor: Address::generate(&env), // ignored: has_depositor_filter is false
+    min_amount: 1000,
+    max_amount: 10000,
+    min_deadline: 0,
+    max_deadline: u64::MAX,
 };
 
 // Time range


### PR DESCRIPTION
Closes #486

## Summary
Both `docs/QUERY_DOCUMENTATION.md` and `docs/QUERY_QUICK_REFERENCE.md` showed `EscrowQueryFilter` examples using an `Option`-based shape (`status: Some(...)`, `depositor: None`, `..Default::default()`) that doesn't match the real struct in `bounty_escrow/contracts/escrow/src/lib.rs` (explicit `has_status_filter`/`has_depositor_filter` bools alongside non-`Option` `status`/`depositor`/`min_amount`/`max_amount`/`min_deadline`/`max_deadline` fields, with sentinel values for "no filter"). None of these examples would compile — `EscrowQueryFilter` also doesn't derive `Default`, so the `..Default::default()` ones were a second, independent compile error.

- Rewrote all 9 `EscrowQueryFilter` examples across both docs to the real field shape.
- Added `test_escrow_query_filter_doc_example_compiles` in `bounty_escrow/contracts/escrow/src/test_query_filters.rs`, mirroring the "Query all locked escrows with amount >= 1000" example verbatim against the real `query_escrows` entrypoint — a regression guard so this class of doc/struct drift fails to compile in CI instead of relying on manual review.

## Verification
This repo's Cargo build/tests are slow to compile from a cold cache in this environment (multiple concurrent builds contending for the target dir), so I could not get a full `cargo test -p bounty-escrow` run to complete in time. I did verify the actual struct definition (`bounty_escrow/contracts/escrow/src/lib.rs:509-518`) matches every field I used, and this repo's own `test_query_filters.rs` already had an identically-shaped `EscrowQueryFilter` construction elsewhere in the same file (for a different test) that I cross-checked against — flagging this transparently rather than claiming a completed test run.
