### PR TITLE
fix(scripts): correct demo_upgrade.sh path and init call

### DIFF
--- a/scripts/demo_upgrade.sh
+++ b/scripts/demo_upgrade.sh
@@ -3,7 +3,7 @@ set -e
 
 # Configuration
 NETWORK="testnet"
-CONTRACT_DIR="contracts/grainlify-core"
+CONTRACT_DIR="grainlify-core"
 SRC_FILE="$CONTRACT_DIR/src/lib.rs"
 SOURCE="demo_user"
 
@@ -27,7 +27,7 @@ echo "Contract Deployed: $ID"
 # 4. Initialize V1
 echo "[4/9] Initializing V1..."
 ADMIN_ADDR=$(soroban keys address "$SOURCE")
-soroban contract invoke --id "$ID" --source "$SOURCE" --network "$NETWORK" --send=yes -- init --admin "$ADMIN_ADDR"
+soroban contract invoke --id "$ID" --source "$SOURCE" --network "$NETWORK" --send=yes -- init_admin --admin "$ADMIN_ADDR"
 
 # 5. Check Version
 echo "[5/9] Checking Version (Expect: 1)..."


### PR DESCRIPTION
Closes #481

## Summary
- Fixed `CONTRACT_DIR` from the nonexistent `contracts/grainlify-core` to the real `grainlify-core/` path (confirmed via `ls grainlify-core/Cargo.toml`).
- Fixed the initialization call from `-- init --admin "$ADMIN_ADDR"` to `-- init_admin --admin "$ADMIN_ADDR"`, matching the actual entrypoint signature: `init(signers: Vec<Address>, threshold: u32)` is the multisig path, `init_admin(admin: Address)` is the single-admin path this demo is meant to exercise (it later calls `scripts/upgrade_contract.sh`, which is single-admin-oriented).

## Scope
Per the issue, step 8/9 (`scripts/upgrade_contract.sh`) still invokes `upgrade` directly without the `schedule_upgrade` + timelock step that `grainlify-core::upgrade()` now requires — a separate, tracked companion fix. This PR only fixes the two concrete staleness bugs the issue describes (wrong path, wrong init call); it does not attempt the timelock coordination, and I did not have a testnet sandbox available to run the full 9-step demo end-to-end.
