### PR TITLE
feat(sdk): add analytics view methods to BountyEscrowClient

### DIFF
--- a/sdk/src/__tests__/bounty-escrow-client.test.ts
+++ b/sdk/src/__tests__/bounty-escrow-client.test.ts
@@ -222,6 +222,58 @@ describe('BountyEscrowClient', () => {
       expect(invoke).toHaveBeenNthCalledWith(4, 'get_escrow_count', []);
     });
 
+    it('routes analytics views to the matching contract methods', async () => {
+      const bountyAnalytics = {
+        total_amount_locked: 100n,
+        total_amount_released: 40n,
+        total_amount_refunded: 0n,
+        remaining_amount: 60n,
+        created_at: 1n,
+        last_updated: 2n,
+        partial_releases_count: 1,
+        partial_refunds_count: 0,
+      };
+      const contractAnalytics = {
+        active_bounty_count: 5,
+        released_bounty_count: 2,
+        refunded_bounty_count: 1,
+        total_locked: 500n,
+        total_released: 200n,
+        total_refunded: 50n,
+        average_bounty_amount: 100n,
+        snapshot_timestamp: 123n,
+      };
+      const invoke = mockInvoke();
+      invoke
+        .mockResolvedValueOnce(bountyAnalytics)
+        .mockResolvedValueOnce(contractAnalytics)
+        .mockResolvedValueOnce(3)
+        .mockResolvedValueOnce(300n)
+        .mockResolvedValueOnce([2, 100n, 1, 40n, 0, 0n])
+        .mockResolvedValueOnce([5n, 3n]);
+
+      await expect(client.getBountyAnalytics(1n)).resolves.toEqual(bountyAnalytics);
+      await expect(client.getContractAnalytics()).resolves.toEqual(contractAnalytics);
+      await expect(client.countBountiesByStatus('Locked')).resolves.toBe(3);
+      await expect(client.getVolumeByStatus('Locked')).resolves.toBe(300n);
+      await expect(client.getDepositorStats(validGAddress1)).resolves.toEqual({
+        locked_count: 2,
+        locked_amount: 100n,
+        released_count: 1,
+        released_amount: 40n,
+        refunded_count: 0,
+        refunded_amount: 0n,
+      });
+      await expect(client.getHighValueBounties(1000n, 10)).resolves.toEqual([5n, 3n]);
+
+      expect(invoke).toHaveBeenNthCalledWith(1, 'get_bounty_analytics', [1n]);
+      expect(invoke).toHaveBeenNthCalledWith(2, 'get_contract_analytics', []);
+      expect(invoke).toHaveBeenNthCalledWith(3, 'count_bounties_by_status', ['Locked']);
+      expect(invoke).toHaveBeenNthCalledWith(4, 'get_volume_by_status', ['Locked']);
+      expect(invoke).toHaveBeenNthCalledWith(5, 'get_depositor_stats', [validGAddress1]);
+      expect(invoke).toHaveBeenNthCalledWith(6, 'get_high_value_bounties', [1000n, 10]);
+    });
+
     it('routes bounty query helpers to the matching contract methods', async () => {
       const invoke = mockInvoke([]);
       const filter: EscrowQueryFilter = {
@@ -486,6 +538,7 @@ describe('BountyEscrowClient', () => {
       await client.resetCircuit(validGAddress2, sourceKeypair);
       expect(invoke).toHaveBeenCalledWith('reset_circuit', [validGAddress2], sourceKeypair);
     });
+
 
     it('routes updateMultisigConfig correctly', async () => {
       const invoke = mockInvoke();

--- a/sdk/src/bounty-escrow-client.ts
+++ b/sdk/src/bounty-escrow-client.ts
@@ -123,6 +123,40 @@ export interface AggregateStats {
   count_refunded: number;
 }
 
+/** Per-bounty analytics snapshot (from `get_bounty_analytics`). */
+export interface BountyAnalytics {
+  total_amount_locked: bigint;
+  total_amount_released: bigint;
+  total_amount_refunded: bigint;
+  remaining_amount: bigint;
+  created_at: bigint;
+  last_updated: bigint;
+  partial_releases_count: number;
+  partial_refunds_count: number;
+}
+
+/** Contract-wide analytics snapshot (from `get_contract_analytics`). */
+export interface ContractAnalytics {
+  active_bounty_count: number;
+  released_bounty_count: number;
+  refunded_bounty_count: number;
+  total_locked: bigint;
+  total_released: bigint;
+  total_refunded: bigint;
+  average_bounty_amount: bigint;
+  snapshot_timestamp: bigint;
+}
+
+/** Per-depositor lifetime stats (from `get_depositor_stats`), by escrow status. */
+export interface DepositorStats {
+  locked_count: number;
+  locked_amount: bigint;
+  released_count: number;
+  released_amount: bigint;
+  refunded_count: number;
+  refunded_amount: bigint;
+}
+
 /** Admin approval record required before a refund can be executed. */
 export interface RefundApproval {
   /** Application-level bounty identifier. */
@@ -656,6 +690,100 @@ export class BountyEscrowClient {
     try {
       const result = await this.invokeContract('get_aggregate_stats', []);
       return result as AggregateStats;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /**
+   * Get the per-bounty analytics snapshot (accumulators updated on every
+   * state transition -- O(1) read, suitable for regular polling).
+   *
+   * @throws {ContractError} If the bounty does not exist.
+   */
+  async getBountyAnalytics(bountyId: bigint): Promise<BountyAnalytics> {
+    try {
+      const result = await this.invokeContract('get_bounty_analytics', [bountyId]);
+      return result as BountyAnalytics;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /**
+   * Get the contract-wide analytics snapshot.
+   */
+  async getContractAnalytics(): Promise<ContractAnalytics> {
+    try {
+      const result = await this.invokeContract('get_contract_analytics', []);
+      return result as ContractAnalytics;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /**
+   * Count bounties currently in the given status.
+   */
+  async countBountiesByStatus(status: EscrowStatus): Promise<number> {
+    try {
+      const result = await this.invokeContract('count_bounties_by_status', [status]);
+      return Number(result);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /**
+   * Total volume (sum of amounts) of bounties currently in the given status.
+   */
+  async getVolumeByStatus(status: EscrowStatus): Promise<bigint> {
+    try {
+      const result = await this.invokeContract('get_volume_by_status', [status]);
+      return result as bigint;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /**
+   * Get a depositor's lifetime bounty stats, broken down by status.
+   */
+  async getDepositorStats(depositor: string): Promise<DepositorStats> {
+    this.validateAddress(depositor, 'depositor');
+    try {
+      const [lockedCount, lockedAmount, releasedCount, releasedAmount, refundedCount, refundedAmount] =
+        (await this.invokeContract('get_depositor_stats', [depositor])) as [
+          number,
+          bigint,
+          number,
+          bigint,
+          number,
+          bigint
+        ];
+      return {
+        locked_count: lockedCount,
+        locked_amount: lockedAmount,
+        released_count: releasedCount,
+        released_amount: releasedAmount,
+        refunded_count: refundedCount,
+        refunded_amount: refundedAmount,
+      };
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /**
+   * Get bounty ids with a remaining amount at or above `minAmount`, newest first.
+   *
+   * @param minAmount - Minimum remaining amount (inclusive).
+   * @param limit - Maximum number of ids to return.
+   */
+  async getHighValueBounties(minAmount: bigint, limit: number): Promise<bigint[]> {
+    try {
+      const result = await this.invokeContract('get_high_value_bounties', [minAmount, limit]);
+      return result as bigint[];
     } catch (error) {
       throw this.handleError(error);
     }


### PR DESCRIPTION
Closes #459

## Summary
`sdk/src/bounty-escrow-client.ts` wraps 40+ `bounty_escrow` entrypoints but had no method for any analytics view function. Added:

- `getBountyAnalytics(bountyId)`, `getContractAnalytics()`, `countBountiesByStatus(status)`, `getVolumeByStatus(status)`, `getDepositorStats(depositor)`, `getHighValueBounties(minAmount, limit)`.
- `getAggregateStats()` already existed (contrary to the issue's "confirm during implementation" note) — no change needed there.
- New `BountyAnalytics`/`ContractAnalytics`/`DepositorStats` TypeScript types matching the Rust structs in `bounty_escrow/contracts/escrow/src/analytics.rs`. `get_depositor_stats` returns a positional tuple `(u32, i128, u32, i128, u32, i128)` on the Rust side — `getDepositorStats` unpacks it into the named `DepositorStats` type for SDK ergonomics rather than exposing a bare tuple.
- All six follow the exact `invokeContract`-based pattern already used by `getEscrowInfo`/`getBalance`/`getRefundHistory`.

## Tests
`sdk/src/__tests__/bounty-escrow-client.test.ts`: one test exercising all six new methods against mocked invocations, asserting both the parsed return values and the exact contract-call arguments.

## Verification
`npx jest src/__tests__/bounty-escrow-client.test.ts` — 78/78 passing. `npx tsc --noEmit` clean. Full SDK suite (`npx jest`, 311/311) also clean.
