### PR TITLE
fix(bounty_escrow): get_fee_config panics on uninitialized contract

### DIFF
--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -836,6 +836,12 @@ impl BountyEscrowContract {
     }
 
     /// Get fee configuration (internal helper)
+    ///
+    /// Falls back to a disabled config on a freshly deployed, uninitialized
+    /// contract (no `DataKey::Admin` set yet) rather than panicking --
+    /// `fee_recipient` is irrelevant while `fee_enabled` is false, so the
+    /// contract's own address is a safe placeholder until `init` configures
+    /// a real admin/fee recipient.
     fn get_fee_config_internal(env: &Env) -> FeeConfig {
         env.storage()
             .instance()
@@ -843,7 +849,11 @@ impl BountyEscrowContract {
             .unwrap_or_else(|| FeeConfig {
                 lock_fee_rate: 0,
                 release_fee_rate: 0,
-                fee_recipient: env.storage().instance().get(&DataKey::Admin).unwrap(),
+                fee_recipient: env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::Admin)
+                    .unwrap_or_else(|| env.current_contract_address()),
                 fee_enabled: false,
             })
     }

--- a/bounty_escrow/contracts/escrow/src/test_bounty_escrow.rs
+++ b/bounty_escrow/contracts/escrow/src/test_bounty_escrow.rs
@@ -2241,3 +2241,18 @@ fn test_pause_state_changed_event_for_refund_operation() {
     assert!(event.paused);
     assert_eq!(event.admin, admin);
 }
+
+// Regression guard for issue #458: get_fee_config previously panicked on a
+// freshly deployed, uninitialized contract (unwrap() on the not-yet-set
+// DataKey::Admin key inside the fee_recipient fallback), instead of
+// returning a graceful disabled default.
+#[test]
+fn test_get_fee_config_on_uninitialized_contract_does_not_panic() {
+    let (_env, client, _contract_id) = create_test_env();
+
+    let config = client.get_fee_config();
+
+    assert_eq!(config.lock_fee_rate, 0);
+    assert_eq!(config.release_fee_rate, 0);
+    assert!(!config.fee_enabled);
+}


### PR DESCRIPTION
Closes #458

## Summary
`get_fee_config_internal`'s fallback path (no `DataKey::FeeConfig` stored yet) built a default `FeeConfig` whose `fee_recipient` came from `env.storage().instance().get(&DataKey::Admin).unwrap()` — an unconditional `.unwrap()` that panics on a freshly deployed, uninitialized contract (no `init` call yet, so `DataKey::Admin` isn't set).

`fee_recipient` is irrelevant on that fallback path anyway, since it's always paired with `fee_enabled: false`. Fixed by falling back to the contract's own address (`env.current_contract_address()`) instead of unwrapping — a pattern already used elsewhere in this same file for similar defaults.

## Tests
Added `test_get_fee_config_on_uninitialized_contract_does_not_panic` in `bounty_escrow/contracts/escrow/src/test_bounty_escrow.rs`, using the existing `create_test_env()` helper (which deploys without calling `init`).

## Verification
This repo's Cargo build is slow to compile from a cold cache in this environment (multiple concurrent builds/rust-analyzer instances contending for the shared `target/` dir lock), so I was not able to get a `cargo test` run to complete in time. The change itself is a single-line fallback swap (`.unwrap()` → `.unwrap_or_else(|| env.current_contract_address())`), and `env.current_contract_address()` is already used identically elsewhere in this file for the same kind of default — flagging the unverified build transparently rather than claiming a completed test run.
