### PR TITLE
fix(bounty_escrow): set_amount_policy returns typed error instead of panic

### DIFF
--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -423,6 +423,8 @@ pub enum Error {
     /// would overflow `i128` or `u32`.  Appended last to preserve
     /// existing discriminant ordering.
     AnalyticsOverflow = 27,
+    /// Returned by `set_amount_policy` when `min_amount` exceeds `max_amount`.
+    InvalidAmountRange = 28,
 }
 
 #[contracttype]
@@ -2878,8 +2880,8 @@ impl BountyEscrowContract {
     /// immediately for subsequent lock_funds calls.
     ///
     /// Passing min_amount == max_amount restricts locking to a single exact value.
-    /// min_amount must not exceed max_amount — the call panics if this invariant
-    /// is violated.
+    /// min_amount must not exceed max_amount — returns `Error::InvalidAmountRange`
+    /// if this invariant is violated.
     pub fn set_amount_policy(
         env: Env,
         caller: Address,
@@ -2896,7 +2898,7 @@ impl BountyEscrowContract {
         admin.require_auth();
 
         if min_amount > max_amount {
-            panic!("invalid policy: min_amount cannot exceed max_amount");
+            return Err(Error::InvalidAmountRange);
         }
 
         // Persist the policy so lock_funds can enforce it on every subsequent call.

--- a/bounty_escrow/contracts/escrow/src/test_bounty_escrow.rs
+++ b/bounty_escrow/contracts/escrow/src/test_bounty_escrow.rs
@@ -1123,9 +1123,11 @@ fn test_no_policy_set_allows_any_positive_amount() {
     assert_eq!(client.get_escrow_info(&7).amount, 999_999);
 }
 
-/// Supplying min > max is a logically invalid policy and must be rejected.
+/// Supplying min > max is a logically invalid policy and must be rejected
+/// with the typed InvalidAmountRange error (issue #467: this previously
+/// used an untyped panic!() instead).
 #[test]
-#[should_panic] // InvalidPolicy / contract-defined panic for malformed config
+#[should_panic(expected = "Error(Contract, #28)")] // InvalidAmountRange
 fn test_set_amount_policy_min_greater_than_max_rejected() {
     let (env, client, _) = create_test_env();
     let admin = Address::generate(&env);
@@ -1136,8 +1138,25 @@ fn test_set_amount_policy_min_greater_than_max_rejected() {
     let (token, _token_client, _) = create_token_contract(&env, &token_admin);
     client.init(&admin, &token);
 
-    // min=5_000 > max=100 — invalid policy, must panic.
+    // min=5_000 > max=100 — invalid policy, must be rejected.
     client.set_amount_policy(&admin, &5_000_i128, &100_i128);
+}
+
+/// The non-panicking try_ variant surfaces the same InvalidAmountRange
+/// error as a typed Result, without panicking.
+#[test]
+fn test_set_amount_policy_min_greater_than_max_returns_typed_error() {
+    let (env, client, _) = create_test_env();
+    let admin = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token, _token_client, _) = create_token_contract(&env, &token_admin);
+    client.init(&admin, &token);
+
+    let result = client.try_set_amount_policy(&admin, &5_000_i128, &100_i128);
+    assert_eq!(result, Err(Ok(ContractError::InvalidAmountRange)));
 }
 
 /// The admin must be able to update the policy after initial configuration, and


### PR DESCRIPTION
Closes #467

## Summary
`set_amount_policy` used `panic!("invalid policy: min_amount cannot exceed max_amount")` for an invalid min/max range, instead of this contract's own typed `Error` enum — which every *other* validation failure in the same function already uses (`Error::NotInitialized`, `Error::Unauthorized`).

- Added `Error::InvalidAmountRange` (code 28, next available discriminant after `AnalyticsOverflow = 27`).
- `set_amount_policy` now returns `Err(Error::InvalidAmountRange)` instead of panicking.

## Tests
- Updated the existing `test_set_amount_policy_min_greater_than_max_rejected`: it still panics (the generated client's non-`try_` wrapper unwraps a `Result::Err` into a host panic), but now asserts the precise `Error(Contract, #28)` message instead of a bare `#[should_panic]`.
- Added `test_set_amount_policy_min_greater_than_max_returns_typed_error`, exercising `try_set_amount_policy`'s non-panicking `Result` path directly and asserting `Err(Ok(ContractError::InvalidAmountRange))`, matching the exact assertion pattern already used elsewhere in this file (e.g. the `InvalidFeeRate` tests).

## Verification
This repo's Cargo build is slow to compile from a cold cache in this environment (multiple concurrent builds contending for the shared `target/` dir lock), so I was not able to get a `cargo test` run to complete in time. The change is a minimal, mechanical `panic!` → `return Err(...)` swap matching the exact pattern of every neighboring guard in the same function, and the new test mirrors an already-passing test's assertion style verbatim — flagging the unverified build transparently rather than claiming a completed test run.
