### PR TITLE
docs(bounty_escrow): clarify get_escrow_count is a lifetime total

### DIFF
--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -2856,12 +2856,32 @@ impl BountyEscrowContract {
         stats
     }
 
-    /// Get total count of escrows
-    /// Get total count of escrows
+    /// Returns the **lifetime total** number of bounties ever locked into
+    /// this contract — `EscrowIndex` is append-only and never pruned, so
+    /// this count never decreases and includes every `Released`/`Refunded`
+    /// bounty from the contract's entire history, not just currently-active
+    /// ones. For a live/active count use
+    /// [`Self::count_bounties_by_status`]`(EscrowStatus::Locked)` or
+    /// [`Self::get_aggregate_stats`] instead.
+    ///
+    /// See also [`Self::get_total_bounties_created`], an identically-behaved
+    /// alias with a name that doesn't invite the "currently active" reading.
     ///
     /// # Authorization
     /// None — callable by anyone (read-only query).
     pub fn get_escrow_count(env: Env) -> u32 {
+        Self::get_total_bounties_created(env)
+    }
+
+    /// Lifetime total number of bounties ever locked into this contract.
+    /// Identical behavior to [`Self::get_escrow_count`] (kept for backward
+    /// compatibility) under a name that doesn't invite confusion with a
+    /// live/active count. See [`Self::get_escrow_count`]'s doc comment for
+    /// the full semantics and the correct live-count alternatives.
+    ///
+    /// # Authorization
+    /// None — callable by anyone (read-only query).
+    pub fn get_total_bounties_created(env: Env) -> u32 {
         let index: Vec<u64> = env
             .storage()
             .persistent()

--- a/bounty_escrow/contracts/escrow/src/test_analytics_monitoring.rs
+++ b/bounty_escrow/contracts/escrow/src/test_analytics_monitoring.rs
@@ -273,6 +273,38 @@ fn test_escrow_count_increments_on_each_lock() {
     assert_eq!(escrow.get_escrow_count(), 3);
 }
 
+// Regression guard for issue #476: get_escrow_count's name invites reading it
+// as a live/active count, when it's actually the lifetime total (never
+// decreases, includes settled bounties). get_total_bounties_created is an
+// identically-behaved alias with an unambiguous name; this asserts the two
+// never diverge, release/refund included.
+#[test]
+fn test_get_total_bounties_created_matches_get_escrow_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let contributor = Address::generate(&env);
+    let (token, token_admin) = create_token_contract(&env, &admin);
+    let escrow = create_escrow_contract(&env);
+    escrow.init(&admin, &token.address);
+    token_admin.mint(&depositor, &1_000_000);
+
+    let deadline = env.ledger().timestamp() + 1000;
+
+    assert_eq!(escrow.get_total_bounties_created(), escrow.get_escrow_count());
+
+    escrow.lock_funds(&depositor, &70, &100, &deadline);
+    escrow.lock_funds(&depositor, &71, &100, &deadline);
+    assert_eq!(escrow.get_total_bounties_created(), escrow.get_escrow_count());
+    assert_eq!(escrow.get_total_bounties_created(), 2);
+
+    // Settling a bounty must not decrease either count -- both are lifetime totals.
+    escrow.release_funds(&70, &contributor);
+    assert_eq!(escrow.get_total_bounties_created(), escrow.get_escrow_count());
+    assert_eq!(escrow.get_total_bounties_created(), 2);
+}
+
 #[test]
 fn test_escrow_count_does_not_decrement_after_release() {
     let env = Env::default();

--- a/docs/QUERY_QUICK_REFERENCE.md
+++ b/docs/QUERY_QUICK_REFERENCE.md
@@ -171,7 +171,7 @@ loop {
 // Bounty Escrow Dashboard
 let stats = contract.get_aggregate_stats(env.clone());
 let user_escrows = contract.query_escrows_by_depositor(env.clone(), user_addr, 0, 10);
-let total_count = contract.get_escrow_count(env);
+let total_count = contract.get_escrow_count(env); // lifetime total, not a live/active count
 
 // Program Escrow Dashboard
 let stats = contract.get_program_aggregate_stats(env.clone());


### PR DESCRIPTION
Closes #476

## Summary
`get_escrow_count`'s name and doc comment ("Get total count of escrows") invited reading it as a live/active count. It's actually the **lifetime total** — `EscrowIndex` is append-only and never pruned, so this never decreases and includes every settled `Released`/`Refunded` bounty from the contract's entire history, sitting right next to `count_bounties_by_status(EscrowStatus::Locked)` (which *does* report a live count).

- Rewrote the doc comment to state this explicitly, cross-referencing `count_bounties_by_status`/`get_aggregate_stats` for a live count.
- Added `get_total_bounties_created` as an identically-behaved alias under an unambiguous name; `get_escrow_count` now delegates to it (kept, not removed, for backward compatibility — no breaking rename).
- Clarified the one remaining ambiguous reference in `docs/QUERY_QUICK_REFERENCE.md`'s dashboard-stats example (the `EscrowQueryFilter` examples in that same file were already fixed by #486 / PR #564, not touched again here).

## Tests
Added `test_get_total_bounties_created_matches_get_escrow_count` in `bounty_escrow/contracts/escrow/src/test_analytics_monitoring.rs`, asserting the two never diverge across lock and release — settlement must not decrease either count, since both are lifetime totals.

## Verification
This repo's Cargo build is slow to compile from a cold cache in this environment (multiple concurrent builds contending for the shared `target/` dir lock), so I was not able to get a `cargo test` run to complete in time. The behavioral change is a pure delegation (`get_escrow_count` now calls the identical logic via a new function name) with no logic change, and the new test follows the exact pattern of the existing, presumably-passing `test_escrow_count_increments_on_each_lock` in the same file — flagging the unverified build transparently rather than claiming a completed test run.
