### PR TITLE
fix: cap get_high_value_bounties limit with MAX_QUERY_LIMIT (closes #530)

### DIFF
--- a/bounty_escrow/contracts/escrow/src/lib.rs
+++ b/bounty_escrow/contracts/escrow/src/lib.rs
@@ -3900,11 +3900,13 @@ impl BountyEscrowContract {
     ///
     /// # Arguments
     /// * `min_amount` - Minimum remaining amount to consider "high-value"
-    /// * `limit` - Maximum number of results
+    /// * `limit` - Maximum number of results (capped at [`MAX_QUERY_LIMIT`])
     ///
     /// # Authorization
     /// None — callable by anyone (read-only query).
     pub fn get_high_value_bounties(env: Env, min_amount: i128, limit: u32) -> Vec<u64> {
+        let limit = limit.min(MAX_QUERY_LIMIT);
+
         let index: Vec<u64> = env
             .storage()
             .persistent()


### PR DESCRIPTION
## Description

`get_high_value_bounties` was the only remaining read-side pagination function that lacked the `MAX_QUERY_LIMIT` cap introduced in PR #514. Passing `limit = u32::MAX` (or any value above 100) would walk the entire `EscrowIndex` and return an unbounded-size result vector — the exact DoS-via-unbounded-read pattern that PR #514's regression test was designed to prevent.

## Changes

- Added `let limit = limit.min(MAX_QUERY_LIMIT);` to `get_high_value_bounties` (line ~3908)
- Updated doc comment to document the cap behavior

## Testing

CI will run existing Soroban contract tests including the analytics monitoring test suite (`test_analytics_monitoring.rs`) which already covers `get_high_value_bounties`.

Closes #530