### PR TITLE
docs: refresh admin test coverage summary

### DIFF
--- a/docs/ADMIN_TESTS_SUMMARY.md
+++ b/docs/ADMIN_TESTS_SUMMARY.md
@@ -3,88 +3,29 @@
 ## Overview
 Added comprehensive tests for admin rotation and configuration update functionality across all three contracts as specified in the requirements.
 
-## Tests Added
+## Coverage Added
 
-### 1. Program Escrow (`contracts/program-escrow/src/lib.rs`)
+The current test suite covers the same behaviors across these durable test
+modules rather than relying on a fixed list of function names:
 
-#### New Public Function
-- `getadmin()` - Returns the current admin address
+- `program-escrow/src/rbac_tests.rs` covers admin-only rate-limit and fund-cap
+  configuration updates, including unauthorized callers.
+- `bounty_escrow/contracts/escrow/src/test_admin_authz.rs` covers admin-gated
+  fee and multisig configuration updates and rejection of non-admin callers.
+- `grainlify-core/src/governance.rs` and its governance test modules cover
+  initialization, upgrade-mode authorization, and persistence across updates.
 
-#### Tests Added
-1. **`test_admin_rotation`**
-   - Verifies that admin can be set and rotated
-   - Confirms the new admin address is persisted
+Run the relevant package tests to discover the current test names:
 
-2. **`test_new_admin_can_update_config`**
-   - Tests that after admin rotation, the new admin can update rate limit configuration
-   - Validates configuration changes are applied correctly
-
-3. **`test_non_admin_cannot_update_config`**
-   - Ensures non-admin users are rejected when attempting to update configuration
-   - Expects panic with "Admin not set" error
-
-### 2. Bounty Escrow (`contracts/bounty_escrow/contracts/escrow/src/test_bounty_escrow.rs`)
-
-#### Tests Added
-1. **`test_admin_can_update_fee_config`**
-   - Verifies admin can update fee configuration (lock_fee_rate, release_fee_rate, fee_enabled)
-   - Confirms configuration changes persist
-
-2. **`test_non_admin_cannot_update_fee_config`**
-   - Ensures non-admin users cannot update fee configuration
-   - Expects panic with "Error(Contract, #2)" (NotInitialized error)
-
-3. **`test_admin_can_update_multisig_config`**
-   - Tests admin can update multisig configuration (threshold_amount, signers, required_signatures)
-   - Validates configuration is correctly stored
-
-4. **`test_non_admin_cannot_update_multisig_config`**
-   - Ensures non-admin users cannot update multisig configuration
-   - Expects panic with "Error(Contract, #2)" (NotInitialized error)
-
-### 3. Grainlify Core (`contracts/grainlify-core/src/lib.rs`)
-
-#### Tests Added
-1. **`test_admin_initialization`**
-   - Verifies admin can be initialized
-   - Confirms initial version is set correctly (version 2)
-
-2. **`test_cannot_reinitialize_admin`**
-   - Ensures admin cannot be changed after initialization (immutable admin pattern)
-   - Expects panic with "Already initialized" error
-
-3. **`test_admin_persists_across_version_updates`**
-   - Tests that admin authorization persists across multiple version updates
-   - Validates version changes are applied correctly
-
-## Test Results
-
-### Program Escrow
+```bash
+cargo test -p program-escrow
+cargo test -p bounty-escrow
+cargo test -p grainlify-core
 ```
-test test::test_admin_rotation ... ok
-test test::test_new_admin_can_update_config ... ok
-test test::test_non_admin_cannot_update_config - should panic ... ok
-```
-**Status: ✅ All 3 tests passing**
 
-### Bounty Escrow
-```
-test test_bounty_escrow::test_admin_can_update_fee_config ... ok
-test test_bounty_escrow::test_admin_can_update_multisig_config ... ok
-test test_bounty_escrow::test_non_admin_cannot_update_fee_config - should panic ... ok
-test test_bounty_escrow::test_non_admin_cannot_update_multisig_config - should panic ... ok
-```
-**Status: ✅ All 4 tests passing**
-
-### Grainlify Core
-```
-test test::test_admin_initialization ... ok
-test test::test_cannot_reinitialize_admin - should panic ... ok
-test test::test_admin_persists_across_version_updates ... ok
-```
-**Status: ✅ All 3 tests passing**
-
-## Total Tests Added: 10
+This document intentionally avoids duplicating individual test names, which
+can change during ordinary test-suite refactors without changing the covered
+security behaviors.
 
 ## Key Features Tested
 


### PR DESCRIPTION
Replace the stale list of removed test function names with durable references to the current admin-authorization test modules and package commands.

Validation: documentation diff check passed.

Closes #551