### PR TITLE
fix(disputes): reject unknown schedule disputes

### DIFF
--- a/program-escrow/src/lib.rs
+++ b/program-escrow/src/lib.rs
@@ -1343,6 +1343,8 @@ impl ProgramEscrowContract {
     ///
     /// Direct payouts and release schedules for this recipient are blocked,
     /// while unrelated recipients remain payable unless a global dispute is open.
+    /// This is intentionally allowed before a recipient has a scheduled release
+    /// so a pending payout can be challenged preemptively.
     pub fn open_recipient_dispute(env: Env, recipient: Address, reason: String) {
         Self::open_dispute_at(
             &env,
@@ -1357,7 +1359,11 @@ impl ProgramEscrowContract {
     ///
     /// Only the selected release schedule is blocked unless a global or
     /// recipient-scoped dispute also applies.
+    ///
+    /// # Panics
+    /// * If the release schedule does not exist
     pub fn open_schedule_dispute(env: Env, schedule_id: u64, reason: String) {
+        Self::get_program_release_schedule(env.clone(), schedule_id);
         Self::open_dispute_at(
             &env,
             DataKey::ScheduleDispute(schedule_id),

--- a/program-escrow/src/test_dispute_resolution.rs
+++ b/program-escrow/src/test_dispute_resolution.rs
@@ -518,6 +518,17 @@ fn test_schedule_dispute_skips_only_target_schedule_release() {
     assert_eq!(data.payout_history.len(), 1);
 }
 
+/// A schedule dispute must reject an ID that is not present in the program.
+#[test]
+#[should_panic(expected = "Schedule not found")]
+fn test_schedule_dispute_rejects_unknown_schedule() {
+    let env = Env::default();
+    let (client, _admin, _cid) = setup(&env, 100_000);
+    let reason = String::from_str(&env, "Unknown schedule challenged");
+
+    client.open_schedule_dispute(&999, &reason);
+}
+
 // ─── Test 17: resolve schedule dispute re-enables release ────────────────────
 
 /// Resolving an open schedule-scoped dispute re-enables release/payment for that schedule.


### PR DESCRIPTION
Validate that a schedule exists before opening a schedule-scoped dispute, while documenting the intentional preemptive behavior for recipient disputes. Add a regression test for an unknown schedule ID.

Closes #544