### PR TITLE
feat(sdk): decode upgrade executed events

### DIFF
--- a/sdk/src/__tests__/events.test.ts
+++ b/sdk/src/__tests__/events.test.ts
@@ -7,6 +7,24 @@ describe('Soroban Event Decoding', () => {
   const gAddress2 = 'GBZN6265B5U2ZIK2QFWIYYXGZ5B47L7Z236L72G66Z3S7MHT7XZQ5WZG';
 
   describe('Bounty Escrow Events', () => {
+    it('decodes the bounty upgrade event with a hex wasm hash', () => {
+      const decoded = decodeContractEvent(
+        [nativeToScVal('upgrade')],
+        nativeToScVal({
+          version: 2,
+          wasm_hash: Buffer.from('ab'.repeat(32), 'hex'),
+          admin: gAddress1,
+        })
+      );
+
+      expect(decoded).toEqual({
+        type: 'upgrade',
+        version: 2,
+        wasmHash: 'ab'.repeat(32),
+        admin: gAddress1,
+      });
+    });
+
     it('decodes init event successfully', () => {
       const topics = [nativeToScVal('init')];
       const value = nativeToScVal({
@@ -312,6 +330,26 @@ describe('Soroban Event Decoding', () => {
         activity_type: 'created',
         amount: 15000n,
         timestamp: 1718915000n,
+      });
+    });
+  });
+
+  describe('Upgrade Events', () => {
+    it('decodes the program upgrade event with the shared shape', () => {
+      const decoded = decodeContractEvent(
+        [nativeToScVal('UpgExec')],
+        nativeToScVal({
+          version: 2,
+          wasm_hash: Buffer.from('0123'.repeat(16), 'hex'),
+          admin: gAddress2,
+        })
+      );
+
+      expect(decoded).toEqual({
+        type: 'UpgExec',
+        version: 2,
+        wasmHash: '0123'.repeat(16),
+        admin: gAddress2,
       });
     });
   });

--- a/sdk/src/events.ts
+++ b/sdk/src/events.ts
@@ -21,6 +21,14 @@ export interface BountyEscrowInitializedEvent {
   timestamp: bigint;
 }
 
+/** Shared upgrade event emitted by bounty escrow (`upgrade`) and program escrow (`UpgExec`). */
+export interface UpgradeExecutedEvent {
+  type: 'upgrade' | 'UpgExec';
+  version: number;
+  wasmHash: string;
+  admin: string;
+}
+
 export interface FundsLockedEvent {
   type: 'f_lock';
   version: number;
@@ -286,6 +294,7 @@ export interface PerformanceMetricEvent {
 
 export type BountyEscrowEvent =
   | BountyEscrowInitializedEvent
+  | UpgradeExecutedEvent
   | FundsLockedEvent
   | FundsReleasedEvent
   | FundsRefundedEvent
@@ -302,6 +311,7 @@ export type BountyEscrowEvent =
 
 export type ProgramEscrowEvent =
   | ProgramInitializedEvent
+  | UpgradeExecutedEvent
   | ProgramFundsLockedEvent
   | BatchPayoutEvent
   | PayoutEvent
@@ -343,6 +353,16 @@ function assertBoolean(val: any, fieldName: string) {
   if (typeof val !== 'boolean') {
     throw new ValidationError(`Field '${fieldName}' must be a boolean, got ${typeof val}`);
   }
+}
+
+function assertBytes(val: any, fieldName: string): asserts val is Uint8Array {
+  if (!(val instanceof Uint8Array)) {
+    throw new ValidationError(`Field '${fieldName}' must be byte data, got ${typeof val}`);
+  }
+}
+
+function bytesToHex(val: Uint8Array): string {
+  return Array.from(val, byte => byte.toString(16).padStart(2, '0')).join('');
 }
 
 function assertVersion(version: any, expected: number[], eventName: string) {
@@ -407,6 +427,18 @@ export function decodeContractEvent(
   }
 
   // --- Bounty Escrow Contract Events ---
+  if (firstTopic === 'upgrade' || firstTopic === 'UpgExec') {
+    assertVersion(parsedValue.version, [2], firstTopic);
+    assertBytes(parsedValue.wasm_hash, 'wasm_hash');
+    assertString(parsedValue.admin, 'admin');
+    return {
+      type: firstTopic,
+      version: Number(parsedValue.version),
+      wasmHash: bytesToHex(parsedValue.wasm_hash),
+      admin: parsedValue.admin,
+    };
+  }
+
   if (firstTopic === 'init') {
     assertVersion(parsedValue.version, [2], 'init');
     assertString(parsedValue.admin, 'admin');


### PR DESCRIPTION
Add shared SDK typing and decoding for the bounty escrow `upgrade` and program escrow `UpgExec` events, including hex-encoded WASM hashes. Add unit coverage for both on-chain event topics.

Closes #536